### PR TITLE
Retry handler to retry on HTTP status 504.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Microsoft Graph .NET Core Client Library
-
-[![Build status](https://ci.appveyor.com/api/projects/status/m8qncaosr2ry4ks6/branch/master?svg=true)](https://ci.appveyor.com/project/MIchaelMainer/msgraph-sdk-dotnet/branch/master)
-[![NuGet Version](https://buildstats.info/nuget/Microsoft.Graph)](https://www.nuget.org/packages/Microsoft.Graph/)
+[![Build Status](https://o365exchange.visualstudio.com/O365%20Sandbox/_apis/build/status/Microsoft%20Graph/.Net/msgraph-sdk-dotnet-build-and-packaging-core?branchName=dev)](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/latest?definitionId=1410&branchName=dev)
+[![NuGet Version](https://buildstats.info/nuget/Microsoft.Graph.Core)](https://www.nuget.org/packages/Microsoft.Graph.Core/)
 
 Integrate the [Microsoft Graph API](https://graph.microsoft.com) into your .NET
 project!

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -17,10 +17,8 @@ namespace Microsoft.Graph
     /// </summary>
     public class RetryHandler : DelegatingHandler
     {
-
         private const string RETRY_AFTER = "Retry-After";
         private const string RETRY_ATTEMPT = "Retry-Attempt";
-        private const int DELAY_MILLISECONDS = 10000;
         private double m_pow = 1;
 
         /// <summary>
@@ -168,12 +166,9 @@ namespace Microsoft.Graph
         /// <returns></returns>
         private bool ShouldRetry(HttpResponseMessage response)
         {
-            if ((response.StatusCode == HttpStatusCode.ServiceUnavailable ||
-                response.StatusCode == (HttpStatusCode)429))
-            {
-                return true;
-            }
-            return false;
+            return (response.StatusCode == HttpStatusCode.ServiceUnavailable ||
+                response.StatusCode == HttpStatusCode.GatewayTimeout ||
+                response.StatusCode == (HttpStatusCode)429);
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
         }
 
-        [Fact(Skip = "In order to support HttpProvider, we'll skip authentication if no provider is set. We will add enable this once we re-write a new HttpProvider.")]
+        [Fact(Skip = "In order to support HttpProvider, we'll skip authentication if no provider is set. We will enable this once we re-write HttpProvider.")]
         public async Task SendRequest_UnauthorizedWithNoAuthenticationProvider()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "https://example.com/bar");

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         private const string RETRY_AFTER = "Retry-After";
         private const string RETRY_ATTEMPT = "Retry-Attempt";
 
-
         public RetryHandlerTests()
         {
             this.testHttpMessageHandler = new MockRedirectHandler();
@@ -86,6 +85,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldRetryWithAddRetryAttemptHeader(HttpStatusCode statusCode)
@@ -112,6 +112,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldRetryWithBuffedContent(HttpStatusCode statusCode)
@@ -136,6 +137,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldNotRetryWithPostStreaming(HttpStatusCode statusCode)
@@ -163,6 +165,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldNotRetryWithPutStreaming(HttpStatusCode statusCode)
@@ -189,6 +192,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
       
         [Theory(Skip = "skip test")]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ExceedMaxRetryShouldReturn(HttpStatusCode statusCode)
@@ -218,6 +222,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldDelayBasedOnRetryAfterHeader(HttpStatusCode statusCode)
@@ -233,6 +238,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldDelayBasedOnExponentialBackOff(HttpStatusCode statusCode)
@@ -249,6 +255,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Theory]
+        [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData(429)] // 429
         public async Task ShouldRetrytBasedOnRetryAfter(HttpStatusCode statusCode)


### PR DESCRIPTION
Fixes #
- Retry on HTTP status 504 [#476](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/476)

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Update readme's status badge.
- Update RetryHandler tests to test 504 retries.
