### PR TITLE
Update from dotnet pack to msbuild pack

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -164,12 +164,12 @@ steps:
      ]
     SessionTimeout: 20
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack (no build, create NuGet)'
+- task: MSBuild@1
+  displayName: 'Create NuGet package for preview release'
   inputs:
-    command: pack
-    packagesToPack: '**\Microsoft.Graph.Core.csproj'
-    nobuild: true
+    solution: '**/Microsoft.Graph.Core.csproj'
+    configuration: 'release'
+    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)''
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -156,12 +156,12 @@ steps:
      ]
     SessionTimeout: 20
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack (no build, create NuGet)'
+- task: MSBuild@1
+  displayName: 'Create NuGet package for production release'
   inputs:
-    command: pack
-    packagesToPack: '**\Microsoft.Graph.Core.csproj'
-    nobuild: true
+    solution: '**/Microsoft.Graph.Core.csproj'
+    configuration: 'release'
+    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)''
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'


### PR DESCRIPTION
Xamarin update requires us to use msbuild pack to create a NuGet
package.

On branch mm/supportXamarinPack
Changes to be committed:
    modified:   pipelines/previewBuild.yml
    modified:   pipelines/productionBuild.yml