### PR TITLE
Updating Retry Handler to use time limit instead of count limit

### DIFF
--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -20,8 +20,6 @@ namespace Microsoft.Graph
 
             internal static string TooManyRedirects = "tooManyRedirects";
 
-            internal static string TooManyRetries = "tooManyRetries";
-
             internal static string MaximumValueExceeded = "MaximumValueExceeded";
 
             internal static string InvalidArgument = "invalidArgument";
@@ -46,8 +44,6 @@ namespace Microsoft.Graph
             internal static string RequestUrlMissing = "Request URL is required to send a request.";
 
             internal static string TooManyRedirectsFormatString = "More than {0} redirects encountered while sending the request.";
-
-            internal static string TooManyRetriesFormatString = "More than {0} retries encountered while sending the request.";
 
             internal static string UnableToCreateInstanceOfTypeFormatString = "Unable to create an instance of type {0}.";
 

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Graph
             internal static string MaximumValueExceeded = "MaximumValueExceeded";
 
             internal static string InvalidArgument = "invalidArgument";
+
+            internal static string MaximumRetryTimeReached = "maximumRetryTimeReached";
         }
 
         internal static class Messages
@@ -64,6 +66,8 @@ namespace Microsoft.Graph
             internal static string InvalidDependsOnRequestId = "Corresponding batch request id not found for the specified dependsOn relation.";
 
             public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
+
+            internal static string MaximumRetryTimeReached = "Maximum time for request retries reached.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Graph
 
             internal static string InvalidArgument = "invalidArgument";
 
-            internal static string MaximumRetryTimeReached = "maximumRetryTimeReached";
+            internal static string MaximumRetriesTimeLimitReached = "maximumRetriesTimeLimitReached";
         }
 
         internal static class Messages
@@ -67,7 +67,7 @@ namespace Microsoft.Graph
 
             public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
 
-            internal static string MaximumRetryTimeReached = "Maximum time for request retries reached.";
+            internal static string MaximumRetriesTimeLimitReached = "Maximum time of {0} for request retries reached.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Graph
             internal static string MaximumValueExceeded = "MaximumValueExceeded";
 
             internal static string InvalidArgument = "invalidArgument";
-
-            internal static string MaximumRetriesTimeLimitReached = "maximumRetriesTimeLimitReached";
         }
 
         internal static class Messages
@@ -66,8 +64,6 @@ namespace Microsoft.Graph
             internal static string InvalidDependsOnRequestId = "Corresponding batch request id not found for the specified dependsOn relation.";
 
             public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
-
-            internal static string MaximumRetriesTimeLimitReached = "Maximum time of {0} for request retries reached.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Graph
 
             internal static string TooManyRedirects = "tooManyRedirects";
 
+            internal static string TooManyRetries = "tooManyRetries";
+
             internal static string MaximumValueExceeded = "MaximumValueExceeded";
 
             internal static string InvalidArgument = "invalidArgument";
@@ -44,6 +46,8 @@ namespace Microsoft.Graph
             internal static string RequestUrlMissing = "Request URL is required to send a request.";
 
             internal static string TooManyRedirectsFormatString = "More than {0} redirects encountered while sending the request.";
+
+            internal static string TooManyRetriesFormatString = "More than {0} retries encountered while sending the request.";
 
             internal static string UnableToCreateInstanceOfTypeFormatString = "Unable to create an instance of type {0}.";
 

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -114,18 +114,18 @@ namespace Microsoft.Graph
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
-        /// <param name="maxRetryTime">The maxRetryTime for the request.</param>
+        /// <param name="retriesTimeLimit">The retriestimelimit for the request.</param>
         /// <returns></returns>
-        public static T WithRetriesTimeLimit<T>(this T baseRequest, int maxRetryTime) where T : IBaseRequest
+        public static T WithRetriesTimeLimit<T>(this T baseRequest, int retriesTimeLimit) where T : IBaseRequest
         {
             string retryOptionKey = typeof(RetryHandlerOption).ToString();
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
-                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetriesTimeLimit = maxRetryTime;
+                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetriesTimeLimit = retriesTimeLimit;
             }
             else
             {
-                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { RetriesTimeLimit = maxRetryTime });
+                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { RetriesTimeLimit = retriesTimeLimit });
             }
             return baseRequest;
         }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -103,6 +103,29 @@ namespace Microsoft.Graph
             else
             {
                 baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { MaxRetry = maxRetry });
+            }
+            return baseRequest;
+        }
+
+        /// <summary>
+        /// Sets the maximum time for request retries to the default Retry Middleware Handler for this request.
+        /// This only works with the default Retry Middleware Handler.
+        /// If you use a custom Retry Middleware Handler, you have to handle it's retrieval in your implementation.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
+        /// <param name="maxRetryTime">The maxRetryTime for the request.</param>
+        /// <returns></returns>
+        public static T WithMaxRetryTime<T>(this T baseRequest, int maxRetryTime) where T : IBaseRequest
+        {
+            string retryOptionKey = typeof(RetryHandlerOption).ToString();
+            if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
+            {
+                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).MaxRetryTime = maxRetryTime;
+            }
+            else
+            {
+                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { MaxRetryTime = maxRetryTime });
             }
             return baseRequest;
         }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Graph
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
-        /// <param name="retriesTimeLimit">The retriestimelimit for the request.</param>
+        /// <param name="retriesTimeLimit">The retriestimelimit for the request in seconds.</param>
         /// <returns></returns>
-        public static T WithRetriesTimeLimit<T>(this T baseRequest, int retriesTimeLimit) where T : IBaseRequest
+        public static T WithMaxRetry<T>(this T baseRequest, TimeSpan retriesTimeLimit) where T : IBaseRequest
         {
             string retryOptionKey = typeof(RetryHandlerOption).ToString();
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -121,11 +121,11 @@ namespace Microsoft.Graph
             string retryOptionKey = typeof(RetryHandlerOption).ToString();
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
-                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).MaxRetryTime = maxRetryTime;
+                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetryTimeLimit = maxRetryTime;
             }
             else
             {
-                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { MaxRetryTime = maxRetryTime });
+                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { RetryTimeLimit = maxRetryTime });
             }
             return baseRequest;
         }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -121,11 +121,11 @@ namespace Microsoft.Graph
             string retryOptionKey = typeof(RetryHandlerOption).ToString();
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
-                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetryTimeLimit = maxRetryTime;
+                (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetriesTimeLimit = maxRetryTime;
             }
             else
             {
-                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { RetryTimeLimit = maxRetryTime });
+                baseRequest.MiddlewareOptions.Add(retryOptionKey, new RetryHandlerOption { RetriesTimeLimit = maxRetryTime });
             }
             return baseRequest;
         }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Graph
         /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
         /// <param name="maxRetryTime">The maxRetryTime for the request.</param>
         /// <returns></returns>
-        public static T WithMaxRetryTime<T>(this T baseRequest, int maxRetryTime) where T : IBaseRequest
+        public static T WithRetriesTimeLimit<T>(this T baseRequest, int maxRetryTime) where T : IBaseRequest
         {
             string retryOptionKey = typeof(RetryHandlerOption).ToString();
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,7 +19,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.16.0</VersionPrefix>
+    <VersionPrefix>1.17.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Fix #481. Use native HTTP client handlers for Xamarin.iOS and Xamarin.Android.

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph
         internal const int DEFAULT_MAX_RETRY = 3;
         internal const int MAX_MAX_RETRY = 10;
         internal const int MAX_DELAY = 180;
-        internal const int RETRY_TIME_LIMIT = 180;
+        internal const int RETRIES_TIME_LIMIT = 180;
 
         /// <summary>
         /// Constructs a new <see cref="RetryHandlerOption"/>
@@ -73,25 +73,25 @@ namespace Microsoft.Graph
             }
         }
 
-        private int _retryTimeLimit = RETRY_TIME_LIMIT;
+        private int _retriesTimeLimit = RETRIES_TIME_LIMIT;
         /// <summary>
         /// The maximum time allowed for request retries. This defaults to 180
         /// </summary>
-        public int RetryTimeLimit
+        public int RetriesTimeLimit
         {
             get
             {
-                return _retryTimeLimit;
+                return _retriesTimeLimit;
             }
             set
             {
-                if(value > RETRY_TIME_LIMIT)
+                if(value > RETRIES_TIME_LIMIT)
                 {
                     throw new ServiceException(
                         new Error
                         {
                             Code = ErrorConstants.Codes.MaximumValueExceeded,
-                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", RETRY_TIME_LIMIT)
+                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", RETRIES_TIME_LIMIT)
                         });
                 }
             }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Graph
         internal const int DEFAULT_MAX_RETRY = 3;
         internal const int MAX_MAX_RETRY = 10;
         internal const int MAX_DELAY = 180;
-        internal const int RETRIES_TIME_LIMIT = 180;
 
         /// <summary>
         /// Constructs a new <see cref="RetryHandlerOption"/>
@@ -76,7 +75,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// The maximum time allowed for request retries. This defaults to 180
         /// </summary>
-        public int RetriesTimeLimit { get; set; } = RETRIES_TIME_LIMIT;
+        public TimeSpan RetriesTimeLimit { get; set; } = TimeSpan.FromSeconds(180);
 
         /// <summary>
         /// A delegate that's called to determine whether a request should be retried or not.

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph
         internal const int DEFAULT_MAX_RETRY = 3;
         internal const int MAX_MAX_RETRY = 10;
         internal const int MAX_DELAY = 180;
-        internal const int MAX_RETRY_TIME = 180;
+        internal const int RETRY_TIME_LIMIT = 180;
 
         /// <summary>
         /// Constructs a new <see cref="RetryHandlerOption"/>
@@ -73,25 +73,25 @@ namespace Microsoft.Graph
             }
         }
 
-        private int _maxRetryTime = MAX_RETRY_TIME;
+        private int _retryTimeLimit = RETRY_TIME_LIMIT;
         /// <summary>
         /// The maximum time allowed for request retries. This defaults to 180
         /// </summary>
-        public int MaxRetryTime
+        public int RetryTimeLimit
         {
             get
             {
-                return _maxRetryTime;
+                return _retryTimeLimit;
             }
             set
             {
-                if(value > MAX_RETRY_TIME)
+                if(value > RETRY_TIME_LIMIT)
                 {
                     throw new ServiceException(
                         new Error
                         {
                             Code = ErrorConstants.Codes.MaximumValueExceeded,
-                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", MAX_RETRY_TIME)
+                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", RETRY_TIME_LIMIT)
                         });
                 }
             }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -73,29 +73,10 @@ namespace Microsoft.Graph
             }
         }
 
-        private int _retriesTimeLimit = RETRIES_TIME_LIMIT;
         /// <summary>
         /// The maximum time allowed for request retries. This defaults to 180
         /// </summary>
-        public int RetriesTimeLimit
-        {
-            get
-            {
-                return _retriesTimeLimit;
-            }
-            set
-            {
-                if(value > RETRIES_TIME_LIMIT)
-                {
-                    throw new ServiceException(
-                        new Error
-                        {
-                            Code = ErrorConstants.Codes.MaximumValueExceeded,
-                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", RETRIES_TIME_LIMIT)
-                        });
-                }
-            }
-        }
+        public int RetriesTimeLimit { get; set; } = RETRIES_TIME_LIMIT;
 
         /// <summary>
         /// A delegate that's called to determine whether a request should be retried or not.

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -73,9 +73,9 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// The maximum time allowed for request retries. This defaults to 180 seconds
+        /// The maximum time allowed for request retries.
         /// </summary>
-        public TimeSpan RetriesTimeLimit { get; set; } = TimeSpan.FromSeconds(180);
+        public TimeSpan RetriesTimeLimit { get; set; } = TimeSpan.Zero;
 
         /// <summary>
         /// A delegate that's called to determine whether a request should be retried or not.

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Graph
         internal const int DEFAULT_MAX_RETRY = 3;
         internal const int MAX_MAX_RETRY = 10;
         internal const int MAX_DELAY = 180;
+        internal const int MAX_RETRY_TIME = 180;
 
         /// <summary>
         /// Constructs a new <see cref="RetryHandlerOption"/>
@@ -69,6 +70,30 @@ namespace Microsoft.Graph
                         });
                 }
                 _maxRetry = value;
+            }
+        }
+
+        private int _maxRetryTime = MAX_RETRY_TIME;
+        /// <summary>
+        /// The maximum time allowed for request retries. This defaults to 180
+        /// </summary>
+        public int MaxRetryTime
+        {
+            get
+            {
+                return _maxRetryTime;
+            }
+            set
+            {
+                if(value > MAX_RETRY_TIME)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.MaximumValueExceeded,
+                            Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "MaxRetryTime", MAX_RETRY_TIME)
+                        });
+                }
             }
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// The maximum time allowed for request retries. This defaults to 180
+        /// The maximum time allowed for request retries. This defaults to 180 seconds
         /// </summary>
         public TimeSpan RetriesTimeLimit { get; set; } = TimeSpan.FromSeconds(180);
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Graph
         private async Task<HttpResponseMessage> SendRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
             int retryCount = 0;
-            double cumulativeDelay = 0.0;
+            TimeSpan cumulativeDelay = TimeSpan.Zero;
             
             while (cumulativeDelay < RetryOption.RetriesTimeLimit)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.Graph
                 Task delay = Delay(response, retryCount, RetryOption.Delay, out double delayInSeconds, ref cumulativeDelay, cancellationToken);
 
                 // Check whether delay(s) exceed the client-specified maximum retries value 
-                if (delayInSeconds > RetryOption.RetriesTimeLimit || cumulativeDelay > RetryOption.RetriesTimeLimit)
+                if (TimeSpan.FromSeconds(delayInSeconds) > RetryOption.RetriesTimeLimit || cumulativeDelay > RetryOption.RetriesTimeLimit)
                 {
                     return response; 
                 }
@@ -145,7 +145,7 @@ namespace Microsoft.Graph
         /// <param name="cumulativeDelay"></param>
         /// <param name="cancellationToken">The cancellationToken for the Http request</param>
         /// <returns>The <see cref="Task"/> for delay operation.</returns>
-        public Task Delay(HttpResponseMessage response, int retry_count, int delay, out double delayInSeconds, ref double cumulativeDelay, CancellationToken cancellationToken)
+        public Task Delay(HttpResponseMessage response, int retry_count, int delay, out double delayInSeconds, ref TimeSpan cumulativeDelay, CancellationToken cancellationToken)
         {
             HttpHeaders headers = response.Headers;
             delayInSeconds = RetryOption.Delay;
@@ -163,7 +163,7 @@ namespace Microsoft.Graph
                 delayInSeconds = m_pow * RetryOption.Delay;
             }
                     
-            cumulativeDelay += delayInSeconds;
+            cumulativeDelay += TimeSpan.FromSeconds(delayInSeconds);
 
             TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MAX_DELAY));
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Graph
         /// <param name="delayInSeconds"></param>
         /// <param name="cancellationToken">The cancellationToken for the Http request</param>
         /// <returns>The <see cref="Task"/> for delay operation.</returns>
-        public Task Delay(HttpResponseMessage response, int retry_count, int delay, out double delayInSeconds, CancellationToken cancellationToken)
+        internal Task Delay(HttpResponseMessage response, int retry_count, int delay, out double delayInSeconds, CancellationToken cancellationToken)
         {
             HttpHeaders headers = response.Headers;
             delayInSeconds = delay;

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -58,21 +58,32 @@ namespace Microsoft.Graph
 
             var response = await base.SendAsync(httpRequest, cancellationToken);
 
-            if(ShouldRetry(response) && httpRequest.IsBuffered() && RetryOption.RetriesTimeLimit > 0 && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
+            // Call to the time-based retry task
+            // Check whether retries are permitted and that user provided a non-negative, non-zero value for the RetriesTimeLimit
+            if (ShouldRetry(response) && httpRequest.IsBuffered() && 
+                RetryOption.RetriesTimeLimit > TimeSpan.Zero && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
             {
-                response = await SendRetryAsync(response, cancellationToken);
+                response = await SendTimeBasedRetryAsync(response, cancellationToken);
+            }
+
+            // Call to the count-based retry task
+            // Check whether retries are permitted and that the MaxRetry value is a non-negative, non-zero value
+            if (ShouldRetry(response) && httpRequest.IsBuffered() &&
+                RetryOption.MaxRetry > 0 && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
+            {
+                response = await SendCountBasedRetryAsync(response, cancellationToken);
             }
 
             return response;
         }
 
         /// <summary>
-        /// Retry sending the HTTP request 
+        /// Retry sending the HTTP request using a time-based retry handler
         /// </summary>
         /// <param name="response">The <see cref="HttpResponseMessage"/> which is returned and includes the HTTP request needs to be retried.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the retry.</param>
         /// <returns></returns>
-        private async Task<HttpResponseMessage> SendRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> SendTimeBasedRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
             int retryCount = 0;
             TimeSpan cumulativeDelay = TimeSpan.Zero;
@@ -122,6 +133,53 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
+        /// Retry sending the HTTP request using a count-based retry handler
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/> which is returned and includes the HTTP request needs to be retried.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the retry.</param>
+        /// <returns></returns>
+        private async Task<HttpResponseMessage> SendCountBasedRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            int retryCount = 0;
+            while (retryCount < RetryOption.MaxRetry)
+            {
+                // Drain response content to free responses.
+                if (response.Content != null)
+                {
+                    await response.Content.ReadAsByteArrayAsync();
+                }
+
+                // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
+                Task delay = Delay(response, retryCount, RetryOption.Delay, cancellationToken);
+
+                // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                var request = await response.RequestMessage.CloneAsync();
+
+                // Increase retryCount and then update Retry-Attempt in request header
+                retryCount++;
+                AddOrUpdateRetryAttempt(request, retryCount);
+
+                // Delay time
+                await delay;
+
+                // Call base.SendAsync to send the request
+                response = await base.SendAsync(request, cancellationToken);
+
+                if (!ShouldRetry(response) || !request.IsBuffered() || !RetryOption.ShouldRetry(RetryOption.Delay, retryCount, response))
+                {
+                    return response;
+                }
+            }
+            throw new ServiceException(
+                         new Error
+                         {
+                             Code = ErrorConstants.Codes.TooManyRetries,
+                             Message = string.Format(ErrorConstants.Messages.TooManyRetriesFormatString, retryCount)
+                         });
+
+        }
+
+        /// <summary>
         /// Update Retry-Attempt header in the HTTP request
         /// </summary>
         /// <param name="request">The <see cref="HttpRequestMessage"/>needs to be sent.</param>
@@ -136,13 +194,13 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Delay task operation based on Retry-After header in the response or exponential backoff
+        /// Delay task operation for timed-retries based on Retry-After header in the response or exponential backoff
         /// </summary>
         /// <param name="response">The <see cref="HttpResponseMessage"/>returned.</param>
         /// <param name="retry_count">The retry counts</param>
         /// <param name="delay">Delay value in seconds.</param>
         /// <param name="delayInSeconds"></param>
-        /// <param name="cumulativeDelay"></param>
+        /// <param name="cumulativeDelay">The cumulative retry time </param>
         /// <param name="cancellationToken">The cancellationToken for the Http request</param>
         /// <returns>The <see cref="Task"/> for delay operation.</returns>
         public Task Delay(HttpResponseMessage response, int retry_count, int delay, out double delayInSeconds, ref TimeSpan cumulativeDelay, CancellationToken cancellationToken)
@@ -164,6 +222,38 @@ namespace Microsoft.Graph
             }
                     
             cumulativeDelay += TimeSpan.FromSeconds(delayInSeconds);
+
+            TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MAX_DELAY));
+
+            return Task.Delay(delayTimeSpan, cancellationToken);
+
+        }
+
+        /// <summary>
+        /// Delay task operation for count-retries based on Retry-After header in the response or exponential backoff
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/>returned.</param>
+        /// <param name="retry_count">The retry counts</param>
+        /// <param name="delay">Delay value in seconds.</param>
+        /// <param name="cancellationToken">The cancellationToken for the Http request</param>
+        /// <returns>The <see cref="Task"/> for delay operation.</returns>
+        public Task Delay(HttpResponseMessage response, int retry_count, int delay, CancellationToken cancellationToken)
+        {
+            HttpHeaders headers = response.Headers;
+            double delayInSeconds = RetryOption.Delay;
+            if (headers.TryGetValues(RETRY_AFTER, out IEnumerable<string> values))
+            {
+                string retry_after = values.First();
+                if (Int32.TryParse(retry_after, out int delay_seconds))
+                {
+                    delayInSeconds = delay_seconds;
+                }
+            }
+            else
+            {
+                m_pow = Math.Pow(2, retry_count);
+                delayInSeconds = m_pow * RetryOption.Delay;
+            }
 
             TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MAX_DELAY));
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -95,8 +95,8 @@ namespace Microsoft.Graph
                     // Get the cumulative delay time
                     cumulativeDelay += TimeSpan.FromSeconds(delayInSeconds);
 
-                    // Check whether delay(s) exceed the client-specified retries time limit value 
-                    if (TimeSpan.FromSeconds(delayInSeconds) > RetryOption.RetriesTimeLimit || cumulativeDelay > RetryOption.RetriesTimeLimit)
+                    // Check whether delay will exceed the client-specified retries time limit value 
+                    if (cumulativeDelay > RetryOption.RetriesTimeLimit)
                     {
                         return response;
                     }
@@ -120,7 +120,7 @@ namespace Microsoft.Graph
                     return response;
                 }
             }
-            throw new ServiceException(
+            throw new ServiceException (
                          new Error
                          {
                              Code = ErrorConstants.Codes.TooManyRetries,

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Graph
 
             var response = await base.SendAsync(httpRequest, cancellationToken);
 
-            if(ShouldRetry(response) && httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
+            if(ShouldRetry(response) && httpRequest.IsBuffered() && RetryOption.RetriesTimeLimit > 0 && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
             {
                 response = await SendRetryAsync(response, cancellationToken);
             }
@@ -115,8 +115,8 @@ namespace Microsoft.Graph
             throw new ServiceException(
                          new Error
                          {
-                             Code = ErrorConstants.Codes.MaximumRetryTimeReached,
-                             Message = string.Format(ErrorConstants.Messages.MaximumRetryTimeReached, retryCount)
+                             Code = ErrorConstants.Codes.MaximumRetriesTimeLimitReached,
+                             Message = string.Format(ErrorConstants.Messages.MaximumRetriesTimeLimitReached, RetryOption.RetriesTimeLimit)
                          });
 
         }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Graph
         {
             int retryCount = 0;
             cumulativeDelay = 0.0;
-            while (cumulativeDelay < RetryOption.MaxRetryTime)
+            while (cumulativeDelay < RetryOption.RetryTimeLimit)
             {
                 // Drain response content to free responses.
                 if (response.Content != null)

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/Options/RetrytHandlerOptionTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/Options/RetrytHandlerOptionTests.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware.Options
 {
+    using System;
     using System.Net.Http;
     using Xunit;
 
@@ -16,6 +17,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware.Options
             Assert.Equal(RetryHandlerOption.DEFAULT_DELAY, retryOptions.Delay);
             Assert.Equal(RetryHandlerOption.DEFAULT_MAX_RETRY, retryOptions.MaxRetry);
             Assert.True(retryOptions.ShouldRetry(0, 0, null));
+            Assert.Equal(TimeSpan.Zero, retryOptions.RetriesTimeLimit);
         }
 
         [Fact]
@@ -52,7 +54,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware.Options
             Assert.Equal(ShouldRetry, retryOptions.ShouldRetry);
         }
 
-        private bool ShouldRetry(int delay, int attempts, HttpResponseMessage rwsponse)
+        private bool ShouldRetry(int delay, int attempts, HttpResponseMessage response)
         {
             return false;
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -206,8 +206,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             }
             catch (ServiceException exception)
             {
-                Assert.True(exception.IsMatch(ErrorConstants.Codes.TooManyRetries), "Unexpected error code returned.");
-                Assert.Equal(String.Format(ErrorConstants.Messages.TooManyRetriesFormatString, 10), exception.Error.Message);
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.MaximumRetriesTimeLimitReached), "Unexpected error code returned.");
+                Assert.Equal(String.Format(ErrorConstants.Messages.MaximumRetriesTimeLimitReached, 10), exception.Error.Message);
                 Assert.IsType<ServiceException>(exception);
                 IEnumerable<string> values;
                 Assert.True(httpRequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attemp Header");

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -276,9 +276,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message, int delay = RetryHandlerOption.MAX_DELAY)
         {
             Message = message;
+            double cumulativeDelay = 0.0;
             await Task.Run(async () =>
             {
-                await this.retryHandler.Delay(response, count, delay, new CancellationToken());
+                await this.retryHandler.Delay(response, count, delay, out double delayInSeconds, ref cumulativeDelay, new CancellationToken());
                 Message += " Work " + count.ToString();
             });
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -206,8 +206,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             }
             catch (ServiceException exception)
             {
-                Assert.True(exception.IsMatch(ErrorConstants.Codes.MaximumRetriesTimeLimitReached), "Unexpected error code returned.");
-                Assert.Equal(String.Format(ErrorConstants.Messages.MaximumRetriesTimeLimitReached, 10), exception.Error.Message);
                 Assert.IsType<ServiceException>(exception);
                 IEnumerable<string> values;
                 Assert.True(httpRequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attemp Header");
@@ -296,10 +294,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message, int delay = RetryHandlerOption.MAX_DELAY)
         {
             Message = message;
-            TimeSpan cumulativeDelay = TimeSpan.Zero;
             await Task.Run(async () =>
             {
-                await this.retryHandler.Delay(response, count, delay, out double delayInSeconds, ref cumulativeDelay, new CancellationToken());
+                await this.retryHandler.Delay(response, count, delay, out double delayInSeconds, new CancellationToken());
                 Message += " Work " + count.ToString();
             });
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var retryResponse = new HttpResponseMessage(statusCode);
             retryResponse.Headers.TryAddWithoutValidation(RETRY_AFTER, 20.ToString());
-            retryHandler.RetryOption.RetriesTimeLimit = 10;
+            retryHandler.RetryOption.RetriesTimeLimit = TimeSpan.FromSeconds(10);
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse);
 
@@ -296,7 +296,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message, int delay = RetryHandlerOption.MAX_DELAY)
         {
             Message = message;
-            double cumulativeDelay = 0.0;
+            TimeSpan cumulativeDelay = TimeSpan.Zero;
             await Task.Run(async () =>
             {
                 await this.retryHandler.Delay(response, count, delay, out double delayInSeconds, ref cumulativeDelay, new CancellationToken());


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/441

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Maximum request retries will be based against the maximum retries time limit specified by the client, or the default maximum retries time limit value.
- If the the delay is greater than the maximum retries time limit specified, then there will be no request retry and the response will be returned. 

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- Link to the Retry Handler design spec: https://github.com/microsoftgraph/msgraph-sdk-design/pull/18 