### PR TITLE
Add SimpleHttpProvider for GraphClientFactory compatibility

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,7 +19,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.17.0</VersionPrefix>
+    <VersionPrefix>1.18.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Removed PageIterator. It is now available from the service library.

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,11 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <VersionPrefix>1.19.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Removed PageIterator. It is now available from the service library.
-      - Add support for time based retry limits.
+      - Resolves #27. Enhances GraphClientFactory compatibility by enabling GraphServiceClient creation by passing in a custom HttpClient
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -23,6 +23,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Removed PageIterator. It is now available from the service library.
+      - Add support for time based retry limits.
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph
 {
     using System;
+    using System.Net.Http;
 
     /// <summary>
     /// A default <see cref="IBaseClient"/> implementation.
@@ -27,6 +28,19 @@ namespace Microsoft.Graph
             this.BaseUrl = baseUrl;
             this.AuthenticationProvider = authenticationProvider;
             this.HttpProvider = httpProvider ?? new HttpProvider(new Serializer());
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="BaseClient"/>.
+        /// </summary>
+        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
+        /// <param name="httpClient">The custom <see cref="HttpClient"/> to be used for making requests</param>
+        public BaseClient(
+            string baseUrl,
+            HttpClient httpClient)
+        {
+            this.BaseUrl = baseUrl;
+            this.HttpProvider = new SimpleHttpProvider(httpClient);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -457,15 +457,26 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Determins whether or not <see cref="BaseRequest"/> should authenticate the request or let <see cref="AuthenticationHandler"/> authenticate the request.
+        /// Determines whether or not <see cref="BaseRequest"/> should authenticate the request or let <see cref="AuthenticationHandler"/> authenticate the request.
         /// </summary>
         /// <returns>
         /// TRUE: If a CUSTOM <see cref="IHttpProvider"/> or DEFAULT <see cref="HttpProvider"/> is used WITHOUT an <see cref="AuthenticationHandler"/>.
-        /// FALSE: If our DEFAULT <see cref="HttpProvider"/> is used WITH an <see cref="AuthenticationHandler"/>.
+        /// FALSE: If our DEFAULT <see cref="HttpProvider"/> or <see cref="SimpleHttpProvider"/> is used WITH an <see cref="AuthenticationHandler"/>.
         /// </returns>
         private bool ShouldAuthenticateRequest()
         {
-            return !(this.Client.HttpProvider is HttpProvider && (this.Client.HttpProvider as HttpProvider).httpClient.ContainsFeatureFlag(FeatureFlag.AuthHandler));
+            switch (this.Client.HttpProvider)
+            {
+                case HttpProvider provider when provider.httpClient.ContainsFeatureFlag(FeatureFlag.AuthHandler):
+                    return false; //no need to authenticate as we have an AuthHandler provided 
+
+                case SimpleHttpProvider simpleHttpProvider when simpleHttpProvider.httpClient.ContainsFeatureFlag(FeatureFlag.AuthHandler):
+                    return false; //no need to authenticate as we have an AuthHandler provided 
+
+                default:
+                    return true;
+
+            }
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -165,7 +165,10 @@ namespace Microsoft.Graph
             {
                 using (response)
                 {
-                    await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                    if (null != response.Content)
+                    {
+                        await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                    }
 
                     var errorResponse = await this.ConvertErrorResponseAsync(response).ConfigureAwait(false);
                     Error error = null;
@@ -210,7 +213,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -90,7 +90,10 @@ namespace Microsoft.Graph
             {
                 using (response)
                 {
-                    await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                    if (null != response.Content)
+                    {
+                        await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                    }
 
                     var errorResponse = await this.ConvertErrorResponseAsync(response).ConfigureAwait(false);
                     Error error;
@@ -131,7 +134,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Graph
             {
                 using (response)
                 {
+                    await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+
                     var errorResponse = await this.ConvertErrorResponseAsync(response).ConfigureAwait(false);
                     Error error;
 
@@ -121,10 +123,30 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    // Pass through the response headers and status code to the ServiceException.
-                    // System.Net.HttpStatusCode does not support RFC 6585, Additional HTTP Status Codes.
-                    // Throttling status code 429 is in RFC 6586. The status code 429 will be passed through.
-                    throw new ServiceException(error, response.Headers, response.StatusCode);
+                    if (string.IsNullOrEmpty(error.ClientRequestId))
+                    {
+                        if (response.Headers.TryGetValues(CoreConstants.Headers.ClientRequestId, out var clientRequestId))
+                        {
+                            error.ClientRequestId = clientRequestId.FirstOrDefault();
+                        }
+                    }
+
+                    if (response.Content.Headers.ContentType.MediaType == "application/json")
+                    {
+                        string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        throw new ServiceException(error,
+                            response.Headers,
+                            response.StatusCode,
+                            rawResponseBody);
+                    }
+                    else
+                    {
+                        // Pass through the response headers and status code to the ServiceException.
+                        // System.Net.HttpStatusCode does not support RFC 6585, Additional HTTP Status Codes.
+                        // Throttling status code 429 is in RFC 6586. The status code 429 will be passed through.
+                        throw new ServiceException(error, response.Headers, response.StatusCode);
+                    }
                 }
             }
 

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -1,0 +1,200 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// An <see cref="IHttpProvider"/> implementation using standard .NET libraries.
+    /// </summary>
+    public class SimpleHttpProvider : IHttpProvider
+    {
+        internal readonly HttpClient httpClient;
+
+        /// <summary>
+        /// Constructs a new <see cref="SimpleHttpProvider"/>.
+        /// </summary>
+        /// <param name="httpClient">Custom http client to be used for making requests</param>
+        /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
+        public SimpleHttpProvider(HttpClient httpClient, ISerializer serializer = null)
+        {
+            this.httpClient = httpClient;
+            Serializer = serializer ?? new Serializer();
+            OverallTimeout = new TimeSpan(0, 5, 0);
+        }
+
+        /// <summary>
+        /// Gets a serializer for serializing and deserializing JSON objects.
+        /// </summary>
+        public ISerializer Serializer { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the overall request timeout.
+        /// </summary>
+        public TimeSpan OverallTimeout
+        {
+            get => this.httpClient.Timeout;
+
+            set
+            {
+                try
+                {
+                    this.httpClient.Timeout = value;
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.NotAllowed,
+                            Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
+                        },
+                        exception);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends the request.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>
+        /// <returns>The <see cref="HttpResponseMessage"/>.</returns>
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            return this.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends the request.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>
+        /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The <see cref="HttpResponseMessage"/>.</returns>
+        public async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, 
+            HttpCompletionOption completionOption, 
+            CancellationToken cancellationToken)
+        {
+            var response = await this.SendRequestAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+
+            // check if the response is of a successful nature.
+            if (!response.IsSuccessStatusCode)
+            {
+                using (response)
+                {
+                    var errorResponse = await this.ConvertErrorResponseAsync(response).ConfigureAwait(false);
+                    Error error;
+
+                    if (errorResponse == null || errorResponse.Error == null)
+                    {
+                        if (response.StatusCode == HttpStatusCode.NotFound)
+                        {
+                            error = new Error { Code = ErrorConstants.Codes.ItemNotFound };
+                        }
+                        else
+                        {
+                            error = new Error
+                            {
+                                Code = ErrorConstants.Codes.GeneralException,
+                                Message = ErrorConstants.Messages.UnexpectedExceptionResponse,
+                            };
+                        }
+                    }
+                    else
+                    {
+                        error = errorResponse.Error;
+                    }
+
+                    if (string.IsNullOrEmpty(error.ThrowSite))
+                    {
+                        if (response.Headers.TryGetValues(CoreConstants.Headers.ThrowSiteHeaderName, out var throwSiteValues))
+                        {
+                            error.ThrowSite = throwSiteValues.FirstOrDefault();
+                        }
+                    }
+
+                    // Pass through the response headers and status code to the ServiceException.
+                    // System.Net.HttpStatusCode does not support RFC 6585, Additional HTTP Status Codes.
+                    // Throttling status code 429 is in RFC 6586. The status code 429 will be passed through.
+                    throw new ServiceException(error, response.Headers, response.StatusCode);
+                }
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        /// Disposes the HttpClient and HttpClientHandler instances.
+        /// </summary>
+        public void Dispose()
+        {
+            httpClient?.Dispose();
+        }
+
+        /// <summary>
+        /// Converts the <see cref="HttpRequestException"/> into an <see cref="ErrorResponse"/> object;
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponseMessage"/> to convert.</param>
+        /// <returns>The <see cref="ErrorResponse"/> object.</returns>
+        private async Task<ErrorResponse> ConvertErrorResponseAsync(HttpResponseMessage response)
+        {
+            try
+            {
+                using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                {
+                    return this.Serializer.DeserializeObject<ErrorResponse>(responseStream);
+                }
+            }
+            catch (Exception)
+            {
+                // If there's an exception deserializing the error response return null and throw a generic
+                // ServiceException later.
+                return null;
+            }
+        }
+
+        private async Task<HttpResponseMessage> SendRequestAsync(
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await this.httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException exception)
+            {
+                throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.Timeout,
+                        Message = ErrorConstants.Messages.RequestTimedOut,
+                    },
+                    exception);
+            }
+            catch (ServiceException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.GeneralException,
+                        Message = ErrorConstants.Messages.UnexpectedExceptionOnSend,
+                    },
+                    exception);
+            }
+        }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string requestUrl = string.Concat(this.baseUrl, "foo/bar");
             string clientRequestId = Guid.NewGuid().ToString();
 
-            var client = new BaseClient("http://localhost.foo", null);
+            var client = new BaseClient(baseUrl: "http://localhost.foo", authenticationProvider: null);
             var baseRequest = new BaseRequest(requestUrl, client) { Method = "PUT" };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -22,6 +22,35 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         private readonly TestHttpMessageHandler testHttpMessageHandler;
         private readonly MockAuthenticationProvider authProvider;
 
+        /*
+         {
+            "error": {
+                "code": "BadRequest",
+                "message": "Resource not found for the segment 'mer'.",
+                "innerError": {
+                    "request - id": "a9acfc00-2b19-44b5-a2c6-6c329b4337b3",
+                    "date": "2019-09-10T18:26:26",
+                    "code": "inner-error-code"
+                },
+                "target": "target-value",
+                "unexpected-property": "unexpected-property-value",
+                "details": [
+                    {
+                        "code": "details-code-value",
+                        "message": "details",
+                        "target": "details-target-value",
+                        "unexpected-details-property": "unexpected-details-property-value"
+                    },
+                    {
+                        "code": "details-code-value2"
+                    }
+                ]
+            }
+        }
+        */
+        // Use https://www.minifyjson.org/ if you need minify or beautify as part of an update.
+        private const string JsonErrorResponseBody = "{\"error\":{\"code\":\"BadRequest\",\"message\":\"Resource not found for the segment 'mer'.\",\"innerError\":{\"request - id\":\"a9acfc00-2b19-44b5-a2c6-6c329b4337b3\",\"date\":\"2019-09-10T18:26:26\",\"code\":\"inner-error-code\"},\"target\":\"target-value\",\"unexpected-property\":\"unexpected-property-value\",\"details\":[{\"code\":\"details-code-value\",\"message\":\"details\",\"target\":\"details-target-value\",\"unexpected-details-property\":\"unexpected-details-property-value\"},{\"code\":\"details-code-value2\"}]}}";
+
         public SimpleHttpProviderTests()
         {
             this.testHttpMessageHandler = new TestHttpMessageHandler();
@@ -257,5 +286,59 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             }
         }
 
+        [Fact]
+        public async Task SendAsync_CopyClientRequestIdHeader_AddClientRequestIdToError()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent("test"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+
+                const string clientRequestId = "3c9c5bc6-42d2-49ac-a99c-49c10513339a";
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.Headers.Add(CoreConstants.Headers.ClientRequestId, clientRequestId);
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+                Assert.NotNull(exception.Error);
+                Assert.Equal(clientRequestId, exception.Error.ClientRequestId);
+            }
+        }
+
+        /// <summary>
+        /// Testing that ErrorResponse can't be deserialized and causes the GeneralException 
+        /// code to be thrown in a ServiceException. We are testing whether we can
+        /// get the response body.
+        /// </summary>
+        [Fact]
+        public async Task SendAsync_AddRawResponseToErrorWithErrorResponseDeserializeException()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent(JsonErrorResponseBody))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.Content.Headers.ContentType.MediaType = "application/json";
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+
+                // Assert that we creating an GeneralException error.
+                Assert.Same(ErrorConstants.Codes.GeneralException, exception.Error.Code);
+                Assert.Same(ErrorConstants.Messages.UnexpectedExceptionResponse, exception.Error.Message);
+
+                // Assert that we get the expected response body.
+                Assert.Equal(JsonErrorResponseBody, exception.RawResponseBody);
+
+            }
+        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -1,0 +1,261 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
+{
+    using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
+    using Moq;
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    public class SimpleHttpProviderTests:IDisposable
+    {
+        private SimpleHttpProvider simpleHttpProvider;
+        private readonly MockSerializer serializer;
+        private readonly TestHttpMessageHandler testHttpMessageHandler;
+        private readonly MockAuthenticationProvider authProvider;
+
+        public SimpleHttpProviderTests()
+        {
+            this.testHttpMessageHandler = new TestHttpMessageHandler();
+            this.authProvider = new MockAuthenticationProvider();
+            this.serializer = new MockSerializer();
+
+            var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
+            var httpClient = GraphClientFactory.Create(handlers: defaultHandlers, finalHandler: testHttpMessageHandler);
+
+            this.simpleHttpProvider = new SimpleHttpProvider(httpClient, this.serializer.Object);
+        }
+
+        public void Dispose()
+        {
+            this.simpleHttpProvider.Dispose();
+        }
+
+        [Fact]
+        public async Task SendAsync()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+                var returnedResponseMessage = await this.simpleHttpProvider.SendAsync(httpRequestMessage);
+                Assert.True(returnedResponseMessage.RequestMessage.Headers.Contains(CoreConstants.Headers.FeatureFlag));
+                Assert.Equal(httpResponseMessage, returnedResponseMessage);
+            }
+        }
+
+
+        [Fact]
+        public async Task SendAsync_ThrowsClientGeneralException()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            {
+                this.simpleHttpProvider.Dispose();
+                var clientException = new Exception();
+
+                var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
+                var httpClient = GraphClientFactory.Create(handlers: defaultHandlers, finalHandler: new ExceptionHttpMessageHandler(clientException));
+                this.simpleHttpProvider = new SimpleHttpProvider(httpClient, this.serializer.Object);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(
+                    httpRequestMessage, HttpCompletionOption.ResponseContentRead, CancellationToken.None));
+
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.GeneralException));
+                Assert.Equal(ErrorConstants.Messages.UnexpectedExceptionOnSend, exception.Error.Message);
+                Assert.Equal(clientException, exception.InnerException);
+            }
+        }
+
+        [Fact]
+
+        public async Task SendAsync_ThrowsClientTimeoutException()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            {
+                this.simpleHttpProvider.Dispose();
+
+                var clientException = new TaskCanceledException();
+                var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
+                var httpClient = GraphClientFactory.Create(handlers: defaultHandlers, finalHandler: new ExceptionHttpMessageHandler(clientException));
+                this.simpleHttpProvider = new SimpleHttpProvider(httpClient, this.serializer.Object);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(
+                    httpRequestMessage, HttpCompletionOption.ResponseContentRead, CancellationToken.None));
+
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.Timeout));
+                Assert.Equal(ErrorConstants.Messages.RequestTimedOut, exception.Error.Message);
+                Assert.Equal(clientException, exception.InnerException);
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_ThrowsServiceExceptionOnInvalidRedirectResponse()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.GeneralException));
+                Assert.Equal(
+                    ErrorConstants.Messages.LocationHeaderNotSetOnRedirect,
+                    exception.Error.Message);
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_VerifiesHeadersOnRedirect()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var redirectResponseMessage = new HttpResponseMessage())
+            using (var finalResponseMessage = new HttpResponseMessage())
+            {
+                httpRequestMessage.Headers.Add("testHeader", "testValue");
+
+                redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
+                redirectResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), redirectResponseMessage);
+                this.testHttpMessageHandler.AddResponseMapping(redirectResponseMessage.Headers.Location.ToString(), finalResponseMessage);
+
+                var returnedResponseMessage = await this.simpleHttpProvider.SendAsync(httpRequestMessage);
+
+                Assert.Equal(6, finalResponseMessage.RequestMessage.Headers.Count());
+
+                foreach (var header in httpRequestMessage.Headers)
+                {
+                    var actualValues = finalResponseMessage.RequestMessage.Headers.GetValues(header.Key);
+
+                    var enumerable = actualValues as string[] ?? actualValues.ToArray();
+                    Assert.Equal(enumerable.Length, header.Value.Count());
+
+                    foreach (var headerValue in header.Value)
+                    {
+                        Assert.Contains(headerValue, enumerable);
+                    }
+                }
+
+                Assert.Equal(finalResponseMessage, returnedResponseMessage);
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_TThrowsServiceExceptionOnMaxRedirects()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var redirectResponseMessage = new HttpResponseMessage())
+            using (var tooManyRedirectsResponseMessage = new HttpResponseMessage())
+            {
+                redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
+                tooManyRedirectsResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                tooManyRedirectsResponseMessage.Headers.Location = new Uri("https://localhost");
+
+                redirectResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), redirectResponseMessage);
+                this.testHttpMessageHandler.AddResponseMapping(redirectResponseMessage.Headers.Location.ToString(), tooManyRedirectsResponseMessage);
+
+                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, "ticket");
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(
+                    httpRequestMessage,
+                    HttpCompletionOption.ResponseContentRead,
+                    CancellationToken.None));
+
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.TooManyRedirects));
+                Assert.Equal(
+                    string.Format(ErrorConstants.Messages.TooManyRedirectsFormatString, "5"),
+                    exception.Error.Message);
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_ThrowsServiceExceptionWithEmptyMessageOnHTTPNotFoundWithoutErrorBody()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://localhost"))
+            using (var stringContent = new StringContent("test"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.StatusCode = HttpStatusCode.NotFound;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+                this.serializer.Setup(
+                        mySerializer => mySerializer.DeserializeObject<ErrorResponse>(
+                            It.IsAny<Stream>()))
+                    .Returns((ErrorResponse)null);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+                Assert.True(exception.IsMatch(ErrorConstants.Codes.ItemNotFound));
+                Assert.True(string.IsNullOrEmpty(exception.Error.Message));
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_ThrowsServiceExceptionWithMessageOnHTTPNotFoundWithBody()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent("test"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.StatusCode = HttpStatusCode.InternalServerError;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+                var expectedError = new ErrorResponse
+                {
+                    Error = new Error
+                    {
+                        Code = ErrorConstants.Codes.ItemNotFound,
+                        Message = "Error message"
+                    }
+                };
+
+                this.serializer.Setup(mySerializer => mySerializer.DeserializeObject<ErrorResponse>(It.IsAny<Stream>())).Returns(expectedError);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+                Assert.Equal(expectedError.Error.Code, exception.Error.Code);
+                Assert.Equal(expectedError.Error.Message, exception.Error.Message);
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_ThrowsServiceExceptionWithThrowSiteHeader()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                const string throwSite = "throw site";
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.Headers.Add(CoreConstants.Headers.ThrowSiteHeaderName, throwSite);
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                this.serializer.Setup(
+                        mySerializer => mySerializer.DeserializeObject<ErrorResponse>(
+                            It.IsAny<Stream>()))
+                    .Returns(new ErrorResponse { Error = new Error() });
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+                Assert.NotNull(exception.Error);
+                Assert.Equal(throwSite, exception.Error.ThrowSite);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Adds a new IHttpProvider to enhance compatibility with GraphClientFactory by working towards adding support for the following scenario.
```
  HttpClient client = GraphClientFactory.Create(...);
  var graphServiceClient = new GraphServiceClient(client);

```
This means that one can easily use a custom httpClient with the request builders provided.
- Modifies checks in BaseRequests.cs to not authenticate the requests when the Provider is 
 either SimpleHttprovider or HttpProvider  and when authprovider is present.
- Adds tests


<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- resolves a task in #27  
- is the predecessor for https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/221