### PR TITLE
BatchRequestStep enhancements

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,11 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <VersionPrefix>1.19.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Improved ServiceException/error information to include OData error response, raw response body, and client-request-id.
-      - Resolves #27. Enhances GraphClientFactory compatibility by enabling GraphServiceClient creation by passing in a custom HttpClient
+      - BatchRequestStep enhancements: added overloads to add BatchRequestStep using BaseRequest and HttpRequestMessage
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -78,8 +78,46 @@ namespace Microsoft.Graph
         /// <returns>True or false based on addition or not addition of the provided <see cref="BatchRequestStep"/>. </returns>
         public bool AddBatchRequestStep(BatchRequestStep batchRequestStep)
         {
-            if (batchRequestStep == null || BatchRequestSteps.ContainsKey(batchRequestStep.RequestId))
+            if (batchRequestStep == null
+                || BatchRequestSteps.ContainsKey(batchRequestStep.RequestId)
+                || BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests //we should not add any more steps
+                )
+            {
                 return false;
+            }
+
+            (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
+            return true;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="HttpRequestMessage"/> to batch request content.
+        /// </summary>
+        /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
+        /// <returns>True or false based on addition or not addition of the provided <see cref="HttpRequestMessage"/>. </returns>
+        public bool AddBatchRequestStep(HttpRequestMessage httpRequestMessage)
+        {
+            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)//we should not add any more steps
+                return false;
+
+            string requestId = Guid.NewGuid().ToString();
+            BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, httpRequestMessage);
+            (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
+            return true;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="IBaseRequest"/> to batch request content
+        /// </summary>
+        /// <param name="request">A <see cref="BaseRequest"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
+        /// <returns>True or false based on addition or not addition of the provided <see cref="BaseRequest"/>. </returns>
+        public bool AddBatchRequestStep(IBaseRequest request)
+        {
+            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)//we should not add any more steps
+                return false;
+
+            string requestId = Guid.NewGuid().ToString();
+            BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, request.GetHttpRequestMessage());
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
             return true;
         }
@@ -227,7 +265,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Determines whether the HTTP content has a valid length in bytes.
         /// </summary>
-        /// <param name="length">The length in bytes of the HHTP content.</param>
+        /// <param name="length">The length in bytes of the HTTP content.</param>
         /// <returns></returns>
         protected override bool TryComputeLength(out long length)
         {

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -94,32 +94,36 @@ namespace Microsoft.Graph
         /// Adds a <see cref="HttpRequestMessage"/> to batch request content.
         /// </summary>
         /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
-        /// <returns>True or false based on addition or not addition of the provided <see cref="HttpRequestMessage"/>. </returns>
-        public bool AddBatchRequestStep(HttpRequestMessage httpRequestMessage)
+        public void AddBatchRequestStep(HttpRequestMessage httpRequestMessage)
         {
-            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)//we should not add any more steps
-                return false;
+            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
+                throw new ClientException(new Error
+                {
+                    Code = ErrorConstants.Codes.MaximumValueExceeded,
+                    Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests)
+                });
 
             string requestId = Guid.NewGuid().ToString();
             BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, httpRequestMessage);
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
-            return true;
         }
 
         /// <summary>
         /// Adds a <see cref="IBaseRequest"/> to batch request content
         /// </summary>
         /// <param name="request">A <see cref="BaseRequest"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
-        /// <returns>True or false based on addition or not addition of the provided <see cref="BaseRequest"/>. </returns>
-        public bool AddBatchRequestStep(IBaseRequest request)
+        public void AddBatchRequestStep(IBaseRequest request)
         {
-            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)//we should not add any more steps
-                return false;
+            if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
+                throw new ClientException(new Error
+                {
+                    Code = ErrorConstants.Codes.MaximumValueExceeded,
+                    Message = string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests)
+                });
 
             string requestId = Guid.NewGuid().ToString();
             BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, request.GetHttpRequestMessage());
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
-            return true;
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -177,10 +177,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             // Act
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-            bool isSuccess = batchRequestContent.AddBatchRequestStep(httpRequestMessage);
+            batchRequestContent.AddBatchRequestStep(httpRequestMessage);
 
             // Assert we added successfully and contents are as expected
-            Assert.True(isSuccess);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.AbsoluteUri, httpRequestMessage.RequestUri.AbsoluteUri);
@@ -196,16 +195,16 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             for (var i = 0; i < CoreConstants.BatchRequest.MaxNumberOfRequests; i++)
             {
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-                bool isSuccess = batchRequestContent.AddBatchRequestStep(httpRequestMessage);
-                Assert.True(isSuccess);//Assert we can add steps up to the max
+                batchRequestContent.AddBatchRequestStep(httpRequestMessage);
+                Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(i+1));//Assert we can add steps up to the max
             }
 
             // Act
             HttpRequestMessage extraHttpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-            bool result = batchRequestContent.AddBatchRequestStep(extraHttpRequestMessage);
             
             // Assert
-            Assert.False(result);//Assert we did not add any more steps
+            var exception = Assert.Throws<ClientException>(() => batchRequestContent.AddBatchRequestStep(extraHttpRequestMessage));//Assert we throw exception on excess add
+            Assert.Equal(ErrorConstants.Codes.MaximumValueExceeded, exception.Error.Code);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(CoreConstants.BatchRequest.MaxNumberOfRequests));
         }
@@ -220,10 +219,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
 
             // Act
-            bool isSuccess = batchRequestContent.AddBatchRequestStep(baseRequest);
+            batchRequestContent.AddBatchRequestStep(baseRequest);
 
             // Assert we added successfully and contents are as expected
-            Assert.True(isSuccess);// 
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.OriginalString, baseRequest.RequestUrl);
@@ -240,16 +238,16 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             for (var i = 0; i < CoreConstants.BatchRequest.MaxNumberOfRequests; i++)
             {
                 BaseRequest baseRequest = new BaseRequest(REQUEST_URL, client);
-                bool isSuccess = batchRequestContent.AddBatchRequestStep(baseRequest);
-                Assert.True(isSuccess);//Assert we can add steps up to the max
+                batchRequestContent.AddBatchRequestStep(baseRequest);
+                Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(i + 1));//Assert we can add steps up to the max
             }
 
             // Act
             BaseRequest extraBaseRequest = new BaseRequest(REQUEST_URL, client);
-            bool result = batchRequestContent.AddBatchRequestStep(extraBaseRequest);
-
+            var exception = Assert.Throws<ClientException>(() => batchRequestContent.AddBatchRequestStep(extraBaseRequest));
+            
             // Assert
-            Assert.False(result);//Assert we did not add any more steps
+            Assert.Equal(ErrorConstants.Codes.MaximumValueExceeded, exception.Error.Code);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(CoreConstants.BatchRequest.MaxNumberOfRequests));
         }


### PR DESCRIPTION
This PR closes #45

### Changes proposed in this pull request

1. Adds overload to add steps using HttpRequestMessage to support a scenario like
```cs
HttpRequestMessage httpRequestMessage1 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/");
HttpRequestMessage httpRequestMessage2 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/calendars");

// Add batch request steps to BatchRequestContent.
BatchRequestContent batchRequestContent = new BatchRequestContent();
batchRequestContent.AddBatchRequestStep(httpRequestMessage1);
batchRequestContent.AddBatchRequestStep(httpRequestMessage2);

// Send batch request with BatchRequestContent. 
HttpResponseMessage response = await httpClient.PostAsync("https://graph.microsoft.com/v1.0/$batch", batchRequestContent);
```
2. Adds overload to add steps using IBaseRequest to support a scenario like
```cs
IUserRequest request1 = graphServiceClient.Me.Request();
IUserCalendarsCollectionRequest request2 = graphServiceClient.Me.Calendars.Request();

// Add batch request steps to BatchRequestContent.
BatchRequestContent batchRequestContent = new BatchRequestContent();
batchRequestContent.AddBatchRequestStep(request1);
batchRequestContent.AddBatchRequestStep(request2);

// Send batch request with BatchRequestContent. 
HttpResponseMessage response = await httpClient.PostAsync("https://graph.microsoft.com/v1.0/$batch", batchRequestContent);
```
3. Adds tests to validate the behavior and to ensure BatchRequestSteps do not exceed max value set for the batch endpoint
