### PR TITLE
Add batch request builder to baseclient

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,11 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <VersionPrefix>1.19.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Improved ServiceException/error information to include OData error response, raw response body, and client-request-id.
-      - Resolves #27. Enhances GraphClientFactory compatibility by enabling GraphServiceClient creation by passing in a custom HttpClient
+      - Adds request builders for the batch endpoint to the client
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Graph
 {
     using System;
     using System.Net.Http;
+    using Microsoft.Graph.Core.Requests;
 
     /// <summary>
     /// A default <see cref="IBaseClient"/> implementation.
@@ -79,5 +80,16 @@ namespace Microsoft.Graph
         /// Gets or Sets the <see cref="IAuthenticationProvider"/> for authenticating a single HTTP requests. 
         /// </summary>
         public Func<IAuthenticationProvider> PerRequestAuthProvider { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IBatchRequestBuilder"/> for building batch Requests
+        /// </summary>
+        public IBatchRequestBuilder Batch
+        {
+            get
+            {
+                return new BatchRequestBuilder(this.BaseUrl + "/$batch", this);
+            }
+        }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Requests
+{
+    using Newtonsoft.Json.Linq;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The type BatchRequest
+    /// </summary>
+    public class BatchRequest: BaseRequest, IBatchRequest
+    {
+        /// <summary>
+        /// Constructs a new BatchRequest.
+        /// </summary>
+        /// <param name="requestUrl">The URL for the built request.</param>
+        /// <param name="client">The <see cref="IBaseClient"/> for handling requests.</param>
+        /// <param name="options">Query and header option name value pairs for the request.</param>
+        public BatchRequest(
+            string requestUrl, 
+            IBaseClient client, 
+            IEnumerable<Option> options = null) 
+            : base(requestUrl, client, options)
+        {
+        }
+
+        /// <summary>
+        /// Sends out the <see cref="BatchRequestContent"/> using the POST method
+        /// </summary>
+        /// <param name="batchRequestContent">The <see cref="BatchRequestContent"/> for the request</param>
+        /// <returns></returns>
+        public Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent)
+        {
+            return this.PostAsync(batchRequestContent, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends out the <see cref="BatchRequestContent"/> using the POST method
+        /// </summary>
+        /// <param name="batchRequestContent">The <see cref="BatchRequestContent"/> for the request</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        public async Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            JObject serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false);
+            HttpResponseMessage httpResponseMessage = await this.SendRequestAsync(serializableContent, cancellationToken).ConfigureAwait(false);
+            return new BatchResponseContent(httpResponseMessage);
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
@@ -1,0 +1,45 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Requests
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The type BatchRequestBuilder
+    /// </summary>
+    public class BatchRequestBuilder: BaseRequestBuilder, IBatchRequestBuilder
+    {
+        /// <summary>
+        /// Constructs a new BatchRequestBuilder.
+        /// </summary>
+        /// <param name="requestUrl">The URL for the built request.</param>
+        /// <param name="client">The <see cref="IBaseClient"/> for handling requests.</param>
+        public BatchRequestBuilder(
+            string requestUrl, 
+            IBaseClient client) 
+            : base(requestUrl, client)
+        {
+        }
+
+        /// <summary>
+        /// Builds the request.
+        /// </summary>
+        /// <returns>The built request.</returns>
+        public IBatchRequest Request()
+        {
+            return this.Request(null);
+        }
+
+        /// <summary>
+        /// Builds the request.
+        /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
+        /// <returns>The built request.</returns>
+        public IBatchRequest Request(IEnumerable<Option> options)
+        {
+            return new BatchRequest(this.RequestUrl,this.Client,options);
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph
 {
     using System;
+    using Microsoft.Graph.Core.Requests;
 
     /// <summary>
     /// Interface for the base client.
@@ -30,5 +31,10 @@ namespace Microsoft.Graph
         /// Gets or Sets the <see cref="IAuthenticationProvider"/> for authenticating a single HTTP requests. 
         /// </summary>
         Func<IAuthenticationProvider> PerRequestAuthProvider { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="IBatchRequestBuilder"/> for building batch Requests
+        /// </summary>
+        IBatchRequestBuilder Batch { get; }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/IBatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBatchRequest.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Requests
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The interface IBatchRequest.
+    /// </summary>
+    public interface IBatchRequest : IBaseRequest
+    {
+        /// <summary>
+        /// Sends out the <see cref="BatchRequestContent"/> using the POST method
+        /// </summary>
+        /// <param name="batchRequestContent">The <see cref="BatchRequestContent"/> for the request</param>
+        /// <returns></returns>
+        Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent);
+
+        /// <summary>
+        /// Sends out the <see cref="BatchRequestContent"/> using the POST method
+        /// </summary>
+        /// <param name="batchRequestContent">The <see cref="BatchRequestContent"/> for the request</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/IBatchRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBatchRequestBuilder.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Requests
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The interface IBatchRequestBuilder
+    /// </summary>
+    public interface IBatchRequestBuilder : IBaseRequestBuilder
+    {
+        /// <summary>
+        /// Builds the request.
+        /// </summary>
+        /// <returns>The built request.</returns>
+        new IBatchRequest Request();
+
+        /// <summary>
+        /// Builds the request.
+        /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
+        /// <returns>The built request.</returns>
+        new IBatchRequest Request(IEnumerable<Option> options);
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
+{
+    using Moq;
+    using Xunit;
+    using Microsoft.Graph.Core.Requests;
+
+    public class BatchRequestBuilderTests
+    {
+        [Fact]
+        public void BatchRequestBuilder()
+        {
+            // Arrange
+            var requestUrl = "https://localhost";
+            var client = new Mock<IBaseClient>().Object;
+
+            // Act
+            var batchRequestBuilder = new BatchRequestBuilder(requestUrl, client);
+
+            // Assert
+            Assert.Equal(requestUrl, batchRequestBuilder.RequestUrl);
+            Assert.Equal(client, batchRequestBuilder.Client);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestTests.cs
@@ -1,0 +1,115 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Graph.Core.Requests;
+    using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
+    using Xunit;
+
+    public class BatchRequestTests: RequestTestBase
+    {
+        [Fact]
+        public void BatchRequest()
+        {
+            // Arrange
+            var requestUrl = "https://localhost";
+
+            // Act
+            var batchRequest = new BatchRequest(requestUrl, this.baseClient);
+
+            // Assert
+            Assert.Empty(batchRequest.QueryOptions);
+        }
+
+        [Fact]
+        public void BatchRequestWithOptions()
+        {
+            // Arrange
+            var requestUrl = "https://localhost";
+            var queryOption = new QueryOption("name", "value");
+            List<Option> optionsList = new List<Option> {queryOption};
+
+            // Act
+            var batchRequest = new BatchRequest(requestUrl,this.baseClient,optionsList);
+
+            // Assert
+            Assert.NotEmpty(batchRequest.QueryOptions);
+            Assert.Equal(batchRequest.QueryOptions.First().Name, queryOption.Name);
+            Assert.Equal(batchRequest.QueryOptions.First().Value, queryOption.Value);
+        }
+
+
+        [Fact]
+        public async Task PostAsyncReturnsBatchResponseContent()
+        {
+            using (HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK))
+            using (TestHttpMessageHandler testHttpMessageHandler = new TestHttpMessageHandler())
+            {
+                /* Arrange */
+                // 1. create a mock response
+                string requestUrl = "https://localhost/";
+                string responseJSON = "{\"responses\":"
+                                      + "[{"
+                                      + "\"id\": \"1\","
+                                      + "\"status\":200,"
+                                      + "\"headers\":{\"Cache-Control\":\"no-cache\",\"OData-Version\":\"4.0\",\"Content-Type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\"},"
+                                      + "\"body\":{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\",\"displayName\":\"MOD Administrator\",\"jobTitle\":null,\"id\":\"9f4fe8ea-7e6e-486e-b8f4-VkHdanfIomf\"}"
+                                      + "},"
+                                      + "{"
+                                      + "\"id\": \"2\","
+                                      + "\"status\":409,"
+                                      + "\"headers\" : {\"Cache-Control\":\"no-cache\"},"
+                                      + "\"body\":{\"error\": {\"code\": \"20117\",\"message\": \"An item with this name already exists in this location.\",\"innerError\":{\"request-id\": \"nothing1b13-45cd-new-92be873c5781\",\"date\": \"2019-03-22T23:17:50\"}}}"
+                                      + "}]}";
+                HttpContent content = new StringContent(responseJSON);
+                responseMessage.Content = content;
+
+                // 2. Map the response
+                testHttpMessageHandler.AddResponseMapping(requestUrl, responseMessage);
+                
+                // 3. Create a batch request object to be tested
+                MockCustomHttpProvider customHttpProvider = new MockCustomHttpProvider(testHttpMessageHandler);
+                BaseClient client = new BaseClient(requestUrl, authenticationProvider.Object, customHttpProvider);
+                BatchRequest batchRequest = new BatchRequest(requestUrl, client);
+
+                // 4. Create batch request content to be sent out
+                // 4.1 Create HttpRequestMessages for the content
+                HttpRequestMessage httpRequestMessage1 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/");
+                HttpRequestMessage httpRequestMessage2 = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/onenote/notebooks");
+
+                // 4.2 Create batch request steps with request ids.
+                BatchRequestStep requestStep1 = new BatchRequestStep("1", httpRequestMessage1);
+                BatchRequestStep requestStep2 = new BatchRequestStep("2", httpRequestMessage2, new List<string> { "1" });
+
+                // 4.3 Add batch request steps to BatchRequestContent.
+                BatchRequestContent batchRequestContent = new BatchRequestContent(requestStep1,requestStep2);
+
+                /* Act */
+                BatchResponseContent returnedResponse = await batchRequest.PostAsync(batchRequestContent);
+                HttpResponseMessage firstResponse = await returnedResponse.GetResponseByIdAsync("1");
+                HttpResponseMessage secondResponse = await returnedResponse.GetResponseByIdAsync("2");
+
+                /* Assert */
+                // validate the first response
+                Assert.NotNull(firstResponse);
+                Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+                Assert.True(firstResponse.Headers.CacheControl.NoCache);
+                Assert.NotNull(firstResponse.Content);
+
+                // validate the second response
+                Assert.NotNull(secondResponse);
+                Assert.Equal(HttpStatusCode.Conflict, secondResponse.StatusCode);
+                Assert.True(secondResponse.Headers.CacheControl.NoCache);
+                Assert.NotNull(secondResponse.Content);
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #46 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this PR

Adds request builder for the batch endpoint to base client so that the following scenario is possible. Where we use the graphServiceClient to send out the batchRequest content like this: 

```cs
// Add batch request steps to BatchRequestContent.
BatchRequestContent batchRequestContent = new BatchRequestContent(batchRequestStep1, batchRequestStep2);

/* Use the Request builders :) */
BatchResponseContent returnedResponse = await graphServiceClient.Batch.Request().PostAsync(batchRequestContent);

/* Read the responses :) */
HttpResponseMessage firstResponse = await returnedResponse.GetResponseByIdAsync("1");
            HttpResponseMessage secondResponse = await returnedResponse.GetResponseByIdAsync("2");
```

Rather than calling `PostAsync` of a httpclient like this:
```cs
// Send batch request with BatchRequestContent.
HttpResponseMessage response = await httpClient.PostAsync("https://graph.microsoft.com/v1.0/$batch", batchRequestContent);

// Handle http responses using BatchResponseContent.
BatchResponseContent batchResponseContent = new BatchResponseContent(response);
```