### PR TITLE
Added ChaosHandler

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/SerializerExtentions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/SerializerExtentions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    public static class SerializerExtentions
+    {
+        public static HttpContent SerializeAsJsonContent(this ISerializer serializer, object source )
+        {
+            var stringContent = serializer.SerializeObject(source);
+            return new StringContent(stringContent, Encoding.UTF8, "application/json");
+        }
+        
+    }
+}

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -23,7 +23,9 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Adds request builders for the batch endpoint to the client
-      - BatchRequestStep enhancements: added overloads to add BatchRequestStep using BaseRequest and HttpRequestMessage
+      - BatchRequestStep enhancements: added overloads to add BatchRequestStep using BaseRequest and HttpRequestMessage.
+      - Adds ChaosHandler for testing.
+      - HTTP pipeline updates overwrite existing inner handlers.
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Graph Core Client Library implements core functionality used by Microsoft Graph client libraries.</Description>
-    <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard1.1;net45;Xamarin.iOS10;MonoAndroid70</TargetFrameworks>
@@ -93,5 +93,8 @@
 	  <Pack>True</Pack>
 	  <PackagePath></PackagePath>
 	</None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
@@ -96,18 +96,23 @@ namespace Microsoft.Graph
 
         public static HttpResponseMessage Create429TooManyRequestsResponse(TimeSpan retry)
         {
+            var serializer = new Serializer();
             var throttleResponse = new HttpResponseMessage()
             {
-                StatusCode = (HttpStatusCode)429
+                StatusCode = (HttpStatusCode)429,
+                Content = serializer.SerializeAsJsonContent(new { error = new Error() { Code = "activityLimitReached", Message= "Client application has been throttled and should not attempt to repeat the request until an amount of time has elapsed." } })
             };
             throttleResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
             return throttleResponse;
         }
+
         public static HttpResponseMessage Create503Response(TimeSpan retry)
         {
+            var serializer = new Serializer();
             var serverUnavailableResponse = new HttpResponseMessage()
             {
-                StatusCode = HttpStatusCode.ServiceUnavailable
+                StatusCode = HttpStatusCode.ServiceUnavailable,
+                Content = serializer.SerializeAsJsonContent(new { error = new Error() { Code = "serviceNotAvailable", Message= "The service is temporarily unavailable for maintenance or is overloaded. You may repeat the request after a delay, the length of which may be specified in a Retry-After header." } })
             };
             serverUnavailableResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
             return serverUnavailableResponse;
@@ -115,27 +120,33 @@ namespace Microsoft.Graph
 
         public static HttpResponseMessage Create502BadGatewayResponse()
         {
+            var serializer = new Serializer();
             var badGatewayResponse = new HttpResponseMessage()
             {
-                StatusCode = HttpStatusCode.BadGateway
+                StatusCode = HttpStatusCode.BadGateway,
+                Content = serializer.SerializeAsJsonContent(new { error = new Error() { Code = "502" } })
             };
             return badGatewayResponse;
         }
 
         public static HttpResponseMessage Create500InternalServerErrorResponse()
         {
+            var serializer = new Serializer();
             var internalServerError = new HttpResponseMessage()
             {
-                StatusCode = HttpStatusCode.InternalServerError
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = serializer.SerializeAsJsonContent(new { error = new Error() { Code = "generalException", Message= "There was an internal server error while processing the request." } })
             };
             return internalServerError;
         }
 
         public static HttpResponseMessage Create504GatewayTimeoutResponse(TimeSpan retry)
         {
+            var serializer = new Serializer();
             var gatewayTimeoutResponse = new HttpResponseMessage()
             {
-                StatusCode = HttpStatusCode.GatewayTimeout
+                StatusCode = HttpStatusCode.GatewayTimeout,
+                Content = serializer.SerializeAsJsonContent(new { error = new Error() { Code = "504", Message = "The server, while acting as a proxy, did not receive a timely response from the upstream server it needed to access in attempting to complete the request. May occur together with 503." } })
             };
             gatewayTimeoutResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
             return gatewayTimeoutResponse;

--- a/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
@@ -1,0 +1,145 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class ChaosHandler : DelegatingHandler
+    {
+        private DiagnosticSource _logger = new DiagnosticListener("Microsoft.Graph.ChaosHandler");
+
+        private Random _random;
+        private ChaosHandlerOption _globalChaosHandlerOptions;
+        private List<HttpResponseMessage> _KnownGraphFailures;
+
+        /// <summary>
+        /// Create a ChaosHandler.  
+        /// </summary>
+        /// <param name="chaosHandlerOptions">Optional parameter to change default behavior of handler.</param>
+        public ChaosHandler(ChaosHandlerOption chaosHandlerOptions = null)
+        {
+            _globalChaosHandlerOptions = chaosHandlerOptions ?? new ChaosHandlerOption();
+            _random = new Random(DateTime.Now.Millisecond);
+            LoadKnownGraphFailures(_globalChaosHandlerOptions.KnownChaos);
+        } 
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Select global or per request options
+            var chaosHandlerOptions = GetPerRequestOptions(request) ??_globalChaosHandlerOptions;  
+
+            HttpResponseMessage response = null;
+            // Planned Chaos or Random?
+            if (chaosHandlerOptions.PlannedChaosFactory != null)
+            {
+                response = chaosHandlerOptions.PlannedChaosFactory(request);
+                if (response != null) 
+                { 
+                    response.RequestMessage = request;
+                    if (_logger.IsEnabled("PlannedChaosResponse"))
+                        _logger.Write("PlannedChaosResponse", response);
+                }
+            } 
+            else 
+            {
+                if (_random.Next(100) < chaosHandlerOptions.ChaosPercentLevel)
+                {
+                    response = CreateChaosResponse(chaosHandlerOptions.KnownChaos ?? _KnownGraphFailures);
+                    response.RequestMessage = request;
+                    if (_logger.IsEnabled("ChaosResponse"))
+                        _logger.Write("ChaosResponse", response);
+                }
+            }
+
+            if (response == null)
+            {
+                response = await base.SendAsync(request, cancellationToken);
+            }
+            return response;
+        }
+
+        private ChaosHandlerOption GetPerRequestOptions(HttpRequestMessage request)
+        {
+            request.Properties.TryGetValue("ChaosRequestOptions", out var optionsObject);
+            return (ChaosHandlerOption)optionsObject;
+        }
+
+        private HttpResponseMessage CreateChaosResponse(List<HttpResponseMessage> knownFailures)
+        {
+            var responseIndex = _random.Next(knownFailures.Count);
+            return knownFailures[responseIndex];
+        }
+
+        private void LoadKnownGraphFailures(List<HttpResponseMessage> knownFailures)
+        {
+            if (knownFailures != null && knownFailures.Count > 0)
+            {
+                _KnownGraphFailures = knownFailures;
+            } 
+            else
+            {
+                _KnownGraphFailures = new List<HttpResponseMessage>();
+                _KnownGraphFailures.Add(Create429TooManyRequestsResponse(new TimeSpan(0, 0, 3)));
+                _KnownGraphFailures.Add(Create503Response(new TimeSpan(0, 0, 3)));
+                _KnownGraphFailures.Add(Create504GatewayTimeoutResponse(new TimeSpan(0, 0, 3)));
+            }
+        }
+
+        public static HttpResponseMessage Create429TooManyRequestsResponse(TimeSpan retry)
+        {
+            var throttleResponse = new HttpResponseMessage()
+            {
+                StatusCode = (HttpStatusCode)429
+            };
+            throttleResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return throttleResponse;
+        }
+        public static HttpResponseMessage Create503Response(TimeSpan retry)
+        {
+            var serverUnavailableResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable
+            };
+            serverUnavailableResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return serverUnavailableResponse;
+        }
+
+        public static HttpResponseMessage Create502BadGatewayResponse()
+        {
+            var badGatewayResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadGateway
+            };
+            return badGatewayResponse;
+        }
+
+        public static HttpResponseMessage Create500InternalServerErrorResponse()
+        {
+            var internalServerError = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.InternalServerError
+            };
+            return internalServerError;
+        }
+
+        public static HttpResponseMessage Create504GatewayTimeoutResponse(TimeSpan retry)
+        {
+            var gatewayTimeoutResponse = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.GatewayTimeout
+            };
+            gatewayTimeoutResponse.Headers.RetryAfter = new RetryConditionHeaderValue(retry);
+            return gatewayTimeoutResponse;
+        }
+
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ChaosHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ChaosHandlerOption.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Graph;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+
+    public class ChaosHandlerOption : IMiddlewareOption
+    {
+        /// <summary>
+        /// Percentage of responses that will have KnownChaos responses injected, assuming no PlannedChaosFactory is provided
+        /// </summary>
+        public int ChaosPercentLevel { get; set; } = 10;
+        /// <summary>
+        /// List of failure responses that potentially could be returned when 
+        /// </summary>
+        public List<HttpResponseMessage> KnownChaos { get; set; } = null;
+        /// <summary>
+        /// Function to return chaos response based on current request.  This is used to reproduce detected failure modes.
+        /// </summary>
+        public Func<HttpRequestMessage, HttpResponseMessage> PlannedChaosFactory { get; set; } = null;
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ChaosHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ChaosHandlerOption.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Graph
 {
-    using Microsoft.Graph;
     using System;
     using System.Collections.Generic;
     using System.Net.Http;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
@@ -2,8 +2,6 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-using System.Net.Http;
-
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
 {
     using System;
@@ -17,14 +15,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
 
     public class ChaosHandlerTests
     {
-        // Planned Chaos
-
-
-        // Random Chaos
         [Fact]
         public async Task RandomChaosShouldReturnRandomFailures()
         {
-
             // Arrange
             var handler = new ChaosHandler()
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
                 return null;
              };
 
-            // Create ChaosHandler with PlannedChaosFactory to 
             var handler = new ChaosHandler(new ChaosHandlerOption()
             {
                 PlannedChaosFactory = plannedChaos

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/ChaosHandlerTests.cs
@@ -1,0 +1,160 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Net.Http;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ChaosHandlerTests
+    {
+        // Planned Chaos
+
+
+        // Random Chaos
+        [Fact]
+        public async Task RandomChaosShouldReturnRandomFailures()
+        {
+
+            // Arrange
+            var handler = new ChaosHandler()
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            var request = new HttpRequestMessage();
+
+            // Act
+            Dictionary<HttpStatusCode, object> responses = new Dictionary<HttpStatusCode, object>();
+            HttpResponseMessage response;
+
+            // Make calls until all known failures have been triggered
+            while (responses.Count < 3)
+            {
+                response = await invoker.SendAsync(request, new CancellationToken());
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    responses[response.StatusCode] = null;
+                }
+            }
+
+            // Assert
+            Assert.True(responses.ContainsKey((HttpStatusCode)429));
+            Assert.True(responses.ContainsKey((HttpStatusCode)503));
+            Assert.True(responses.ContainsKey((HttpStatusCode)504));
+        }
+
+        [Fact]
+        public async Task RandomChaosWithCustomKnownFailuresShouldReturnAllFailuresRandomly()
+        {
+
+            // Arrange
+            var handler = new ChaosHandler(new ChaosHandlerOption()
+            {
+                KnownChaos = new List<HttpResponseMessage>()
+                {
+                    ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0,0,5)),
+                    ChaosHandler.Create500InternalServerErrorResponse(),
+                    ChaosHandler.Create503Response(new TimeSpan(0,0,5)),
+                    ChaosHandler.Create502BadGatewayResponse()
+                }
+            })
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            var request = new HttpRequestMessage();
+
+            // Act
+            Dictionary<HttpStatusCode, object> responses = new Dictionary<HttpStatusCode, object>();
+            HttpResponseMessage response;
+
+            // Make calls until all known failures have been triggered
+            while (responses.Count < 4)
+            {
+                response = await invoker.SendAsync(request, new CancellationToken());
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    responses[response.StatusCode] = null;
+                }
+            }
+
+            // Assert
+            Assert.True(responses.ContainsKey((HttpStatusCode)429));
+            Assert.True(responses.ContainsKey((HttpStatusCode)500));
+            Assert.True(responses.ContainsKey((HttpStatusCode)502));
+            Assert.True(responses.ContainsKey((HttpStatusCode)503));
+        }
+
+        [Fact]
+        public async Task PlannedChaosShouldReturnChaosWhenPlanned()
+        {
+            // Arrange
+
+            Func<HttpRequestMessage, HttpResponseMessage> plannedChaos = (req) =>
+             {
+                 if (req.RequestUri.OriginalString.Contains("/fail"))
+                 {
+                     return ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0, 0, 5));
+                 }
+
+                return null;
+             };
+
+            // Create ChaosHandler with PlannedChaosFactory to 
+            var handler = new ChaosHandler(new ChaosHandlerOption()
+            {
+                PlannedChaosFactory = plannedChaos
+            })
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+
+            var invoker = new HttpMessageInvoker(handler);
+            
+
+            // Act
+
+            var request1 = new HttpRequestMessage() { 
+                RequestUri = new Uri("http://example.org/success")
+            };
+            var response1 = await invoker.SendAsync(request1, new CancellationToken());
+
+            var request2 = new HttpRequestMessage()
+            {
+                RequestUri = new Uri("http://example.org/fail")
+            };
+            var response2 = await invoker.SendAsync(request2, new CancellationToken());
+
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+            Assert.Equal((HttpStatusCode)429, response2.StatusCode);
+        }
+
+    }
+
+    internal class FakeSuccessHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                RequestMessage = request
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
Added ChaosHandler middleware for simulating server failures

This example shows how to create a GraphServiceClient with the ChaosHandler in the pipeline
```csharp
            var handlers = GraphClientFactory.CreateDefaultHandlers(authProvider);
            handlers.Add(new ChaosHandler());

            // Create a customized HttpClient based on these handlers
            HttpClient client = GraphClientFactory.Create(handlers);

            // Create a GraphServiceClient based on the HttpClient
            var graphClient = new GraphServiceClient(client);
```

ChaosHandler can also be created with a customized set of known failures.
```csharp
var handler = new ChaosHandler(new ChaosHandlerOption()
            {
                KnownChaos = new List<HttpResponseMessage>()
                {
                    ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0,0,5)),
                    ChaosHandler.Create500InternalServerErrorResponse(),
                    ChaosHandler.Create503Response(new TimeSpan(0,0,5)),
                    ChaosHandler.Create502BadGatewayResponse()
                }
            });
```

Once a problem has been identified, it is possible to plan to have certain failures be returned for specific requests.

```csharp
           Func<HttpRequestMessage, HttpResponseMessage> plannedChaos = (req) =>
             {
                 if (req.RequestUri.OriginalString.Contains("/fail"))
                 {
                     return ChaosHandler.Create429TooManyRequestsResponse(new TimeSpan(0, 0, 5));
                 }
                return null;
             };

            var handler = new ChaosHandler(new ChaosHandlerOption()
            {
                PlannedChaosFactory = plannedChaos
            });
```