### PR TITLE
Batch Request Enhancements

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Graph Core Client Library implements core functionality used by Microsoft Graph client libraries.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -26,6 +26,7 @@
       - BatchRequestStep enhancements: added overloads to add BatchRequestStep using BaseRequest and HttpRequestMessage.
       - Adds ChaosHandler for testing.
       - HTTP pipeline updates overwrite existing inner handlers.
+      - BatchRequestContent enhancements to enable deserialization to a given type
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -94,7 +94,8 @@ namespace Microsoft.Graph
         /// Adds a <see cref="HttpRequestMessage"/> to batch request content.
         /// </summary>
         /// <param name="httpRequestMessage">A <see cref="HttpRequestMessage"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
-        public void AddBatchRequestStep(HttpRequestMessage httpRequestMessage)
+        /// <returns>The requestId of the newly created <see cref="BatchRequestStep"/></returns>
+        public string AddBatchRequestStep(HttpRequestMessage httpRequestMessage)
         {
             if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
                 throw new ClientException(new Error
@@ -106,13 +107,15 @@ namespace Microsoft.Graph
             string requestId = Guid.NewGuid().ToString();
             BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, httpRequestMessage);
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
+            return requestId;
         }
 
         /// <summary>
         /// Adds a <see cref="IBaseRequest"/> to batch request content
         /// </summary>
         /// <param name="request">A <see cref="BaseRequest"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
-        public void AddBatchRequestStep(IBaseRequest request)
+        /// <returns>The requestId of the  newly created <see cref="BatchRequestStep"/></returns>
+        public string AddBatchRequestStep(IBaseRequest request)
         {
             if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
                 throw new ClientException(new Error
@@ -124,6 +127,7 @@ namespace Microsoft.Graph
             string requestId = Guid.NewGuid().ToString();
             BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, request.GetHttpRequestMessage());
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Add(batchRequestStep.RequestId, batchRequestStep);
+            return requestId;
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -177,9 +177,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             // Act
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-            batchRequestContent.AddBatchRequestStep(httpRequestMessage);
+            string batchRequestStepId = batchRequestContent.AddBatchRequestStep(httpRequestMessage);
 
             // Assert we added successfully and contents are as expected
+            Assert.NotNull(batchRequestStepId);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.AbsoluteUri, httpRequestMessage.RequestUri.AbsoluteUri);
@@ -195,7 +196,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             for (var i = 0; i < CoreConstants.BatchRequest.MaxNumberOfRequests; i++)
             {
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-                batchRequestContent.AddBatchRequestStep(httpRequestMessage);
+                string batchRequestStepId = batchRequestContent.AddBatchRequestStep(httpRequestMessage);
+                Assert.NotNull(batchRequestStepId);
                 Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(i+1));//Assert we can add steps up to the max
             }
 
@@ -219,9 +221,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
 
             // Act
-            batchRequestContent.AddBatchRequestStep(baseRequest);
+            string batchRequestStepId = batchRequestContent.AddBatchRequestStep(baseRequest);
 
             // Assert we added successfully and contents are as expected
+            Assert.NotNull(batchRequestStepId);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.OriginalString, baseRequest.RequestUrl);
@@ -238,7 +241,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             for (var i = 0; i < CoreConstants.BatchRequest.MaxNumberOfRequests; i++)
             {
                 BaseRequest baseRequest = new BaseRequest(REQUEST_URL, client);
-                batchRequestContent.AddBatchRequestStep(baseRequest);
+                string batchRequestStepId = batchRequestContent.AddBatchRequestStep(baseRequest);
+                Assert.NotNull(batchRequestStepId);
                 Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(i + 1));//Assert we can add steps up to the max
             }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -120,6 +120,69 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
             Assert.True(response.Headers.CacheControl.NoCache);
+        }
+
+
+        [Fact]
+        public async Task BatchResponseContent_GetResponseByIdAsyncWithDeseirializer()
+        {
+            // Arrange
+            string responseJSON = "{\"responses\":"
+                + "[{"
+                    + "\"id\": \"1\","
+                    + "\"status\":200,"
+                    + "\"headers\":{\"Cache-Control\":\"no-cache\",\"OData-Version\":\"4.0\",\"Content-Type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\"},"
+                    + "\"body\":{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\",\"displayName\":\"MOD Administrator\",\"jobTitle\":null,\"id\":\"9f4fe8ea-7e6e-486e-b8f4-VkHdanfIomf\"}"
+                + "},"
+                + "{"
+                    + "\"id\": \"2\","
+                    + "\"status\":200,"
+                    + "\"headers\":{\"Cache-Control\":\"no-store, no-cache\",\"OData-Version\":\"4.0\",\"Content-Type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\"},"
+                    + "\"body\":{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#drives/$entity\",\"createdDateTime\":\"2019-01-12T09:05:38Z\",\"description\":\"\",\"id\":\"b!random-VkHdanfIomf\",\"lastModifiedDateTime\":\"2019-03-06T06:59:04Z\",\"name\":\"OneDrive\",\"webUrl\":\"https://m365x751487-my.sharepoint.com/personal/admin_m365x751487_onmicrosoft_com/Documents\",\"driveType\":\"business\",\"createdBy\":{\"user\":{\"displayName\":\"System Account\"}},\"lastModifiedBy\":{\"user\":{\"displayName\":\"System Account\"}},\"owner\":{\"user\":{\"email\":\"admin@M365x751487.OnMicrosoft.com\",\"id\":\"6b4fa8ea-7e6e-486e-a8f4-d00a5b23488c\",\"displayName\":\"MOD Administrator\"}},\"quota\":{\"deleted\":0,\"remaining\":1099509670098,\"state\":\"normal\",\"total\":1099511627776,\"used\":30324}}"
+                + "},"
+                + "{"
+                    + "\"id\": \"3\","
+                    + "\"status\":201,"
+                    + "\"headers\":{\"Location\":\"https://graph.microsoft.com/v1.0/users/9f4fe8ea-7e6e-486e-a8f4-nothing-here/onenote/notebooks/1-zyz-a1c1-441a-8b41-9378jjdd2\",\"Preference-Applied\":\"odata.include-annotations=*\",\"Cache-Control\":\"no-cache\",\"OData-Version\":\"4.0\",\"Content-Type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\"},"
+                    + "\"body\":{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#users('9f4fe8ea-7e6e-486e-a8f4-nothing-here')/onenote/notebooks/$entity\",\"id\":\"1-9f4fe8ea-7e6e-486e-a8f4-nothing-here\",\"self\":\"https://graph.microsoft.com/v1.0/users/9f4fe8ea-7e6e-486e-a8f4-nothing-here/onenote/notebooks/1-9f4fe8ea-7e6e-486e-a8f4-nothing-here\",\"createdDateTime\":\"2019-03-06T08:08:09Z\",\"displayName\":\"My Notebook -442293399\",\"lastModifiedDateTime\":\"2019-03-06T08:08:09Z\"}"
+                + "},"
+                + "{"
+                    + "\"id\": \"4\","
+                    + "\"status\":409,"
+                    + "\"headers\" : {\"Cache-Control\":\"no-cache\"},"
+                    + "\"body\":{\"error\": {\"code\": \"20117\",\"message\": \"An item with this name already exists in this location.\",\"innerError\":{\"request-id\": \"nothing1b13-45cd-new-92be873c5781\",\"date\": \"2019-03-22T23:17:50\"}}}"
+                + "}" +
+                "]}";
+
+            HttpContent content = new StringContent(responseJSON);
+            HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            httpResponseMessage.Content = content;
+
+            BatchResponseContent batchResponseContent = new BatchResponseContent(httpResponseMessage);
+
+            // Act
+            User user = await batchResponseContent.GetResponseByIdAsync<User>("1");
+            // Assert we have a valid user
+            Assert.Equal("MOD Administrator", user.DisplayName);
+
+            // Act
+            Drive drive = await batchResponseContent.GetResponseByIdAsync<Drive>("2");
+            // Assert we have a valid drive object
+            Assert.Equal("b!random-VkHdanfIomf", drive.Id);
+            Assert.Equal("OneDrive", drive.Name);
+
+            // Act
+            Notebook notebook = await batchResponseContent.GetResponseByIdAsync<Notebook>("3");
+            // Assert we have a valid notebook object
+            Assert.Equal("1-9f4fe8ea-7e6e-486e-a8f4-nothing-here", notebook.Id);
+            Assert.Equal("My Notebook -442293399", notebook.DisplayName);
+
+            // Act
+            ServiceException serviceException = await Assert.ThrowsAsync<ServiceException>(() => batchResponseContent.GetResponseByIdAsync<DriveItem>("4"));
+            // Assert we detect the incorrect response and give usable Service Exception
+            Assert.Equal("20117", serviceException.Error.Code);
+            Assert.Equal(HttpStatusCode.Conflict, serviceException.StatusCode);//status 409
+            Assert.NotNull(serviceException.RawResponseBody);
         }
     }
 }


### PR DESCRIPTION
This PR closes #51 

### Changes proposed in this pull request

1. Return ids on creating a batchRequestStep without providing one i.e. making a call like 
```cs

string userRequestId = batchRequestContent.AddBatchRequestStep(userRequest);

```

2. Allow de-serializing of responseContent to known type on getting response from ID

```cs
User user = await returnedResponse.GetResponseByIdAsync<User>(userRequestId);
```

This therefore means a user can perform the following scenario and its variants

```cs
// Get request objects from graph
IUserRequest userRequest = graphClient.Me.Request();
IUserEventsCollectionRequest eventsRequest = graphClient.Me.Events.Request();

BatchRequestContent batchRequestContent = new BatchRequestContent();

// Add the batchRequest steps and get back the ids for the steps
var userRequestId = batchRequestContent.AddBatchRequestStep(userRequest);
var eventsRequestId = batchRequestContent.AddBatchRequestStep(eventsRequest);

// send out request
BatchResponseContent returnedResponse = await graphClient.Batch.Request().PostAsync(batchRequestContent);

// deserialize response based on known return type
User user = await returnedResponse.GetResponseByIdAsync<User>(userRequestId);
UserEventsCollectionResponse events = await returnedResponse.GetResponseByIdAsync<UserEventsCollectionResponse>(eventsRequestId);
```