### PR TITLE
DeltaResponseHandler adds a delta response payload manifest to CollectionPage.AdditionalData

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -152,5 +152,20 @@ namespace Microsoft.Graph
             }
             return baseRequest;
         }
+
+        /// <summary>
+        /// Replaces the default response handler with a custom response handler for this request.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
+        /// <param name="responseHandler">The <see cref="IResponseHandler"/> for the request.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">If responseHandler is null.</exception>
+        public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : IBaseRequest
+        {
+            baseRequest.ResponseHandler = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
+
+            return baseRequest;
+        }
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Graph
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> for the request.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">If responseHandler is null.</exception>
-        public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : IBaseRequest
+        public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : BaseRequest
         {
             baseRequest.ResponseHandler = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
 

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -23,6 +23,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Fix for modifying the Timeout property of a passed HttpClient
+      - Add DeltaResponseHandler to discover null changes for delta query.
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class BaseRequest : IBaseRequest
     {
-        private ResponseHandler responseHandler;
+        private IResponseHandler responseHandler;
 
         /// <summary>
         /// Constructs a new <see cref="BaseRequest"/>.
@@ -60,6 +60,11 @@ namespace Microsoft.Graph
             // This can be changed can be changed by the user by calling WithPerRequestAuthProvider extension method.
             this.WithDefaultAuthProvider();
         }
+
+        /// <summary>
+        /// Gets or sets the response handler for the request.
+        /// </summary>
+        public IResponseHandler ResponseHandler { get { return responseHandler; } set { responseHandler = value; } }
 
         /// <summary>
         /// Gets or sets the content type for the request.

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -142,9 +142,9 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets all changes on the object.
         /// </summary>
-        /// <param name="changedObject">The responseItem re</param>
-        /// <param name="changes"></param>
-        /// <param name="parentName"></param>
+        /// <param name="changedObject">The responseItem to inspect for changes.</param>
+        /// <param name="changes">The list of properties returned in the response.</param>
+        /// <param name="parentName">The parent object of this changed object.</param>
         /// <returns></returns>
         private async Task GetObjectProperties(JObject changedObject, JArray changes, string parentName = "")
         {

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -4,24 +4,31 @@
 
 namespace Microsoft.Graph
 {
+    using Newtonsoft.Json;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Provides method(s) to deserialize raw HTTP responses into strong types.
+    /// PREVIEW 
+    /// A response handler that exposes the list of changes returned in a response.
+    /// This supports scenarios where the service expresses changes to 'null'. The
+    /// deserializer can't express changes to null so you can now discover if a property
+    /// has been set to null. This is intended for use with a Delta query scenario.
     /// </summary>
-    public class ResponseHandler : IResponseHandler
+    public class DeltaResponseHandler : IResponseHandler
     {
         private readonly ISerializer serializer;
         /// <summary>
         /// Constructs a new <see cref="ResponseHandler"/>.
         /// </summary>
         /// <param name="serializer"></param>
-        public ResponseHandler(ISerializer serializer)
+        
+        public DeltaResponseHandler()
         {
-            this.serializer = serializer;
+            this.serializer = new Serializer();
         }
 
         /// <summary>
@@ -30,15 +37,46 @@ namespace Microsoft.Graph
         /// <typeparam name="T">The type to return</typeparam>
         /// <param name="response">The HttpResponseMessage to handle</param>
         /// <returns></returns>
-        public async Task<T> HandleResponse<T>(HttpResponseMessage response)
+        public async Task<T> HandleResponse<T>(HttpResponseMessage response) 
         {
             if (response.Content != null)
             {
                 var responseString = await GetResponseString(response);
+
                 return serializer.DeserializeObject<T>(responseString);
             }
 
             return default(T);
+        }
+
+        /// <summary>
+        /// Get the change properties.
+        /// </summary>
+        /// <param name="responseString">The response from the service.</param>
+        /// <returns>A list of changes.</returns>
+        private List<string> GetChangedProperties(string responseString)
+        {
+            var changedPropertiesList = new List<string>();
+
+            using (JsonTextReader reader = new JsonTextReader(new StringReader(responseString)))
+            {
+                // Forward the reader to the list of changes.
+                while (reader.TokenType != JsonToken.StartArray) // This is a weak assumption. 
+                {
+                    reader.Read();
+                }
+                
+                // Read all of the changed properties in the page and
+                // add them to the changed property list.
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonToken.PropertyName)
+                    {
+                        changedPropertiesList.Add(reader.Path);
+                    }
+                }
+            }
+            return changedPropertiesList;
         }
 
         /// <summary>
@@ -52,9 +90,14 @@ namespace Microsoft.Graph
 
             var content = await hrm.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            //Only add headers if we are going to return a response body
+            //Only add headers and the changed list if we are going to return a response body
             if (content.Length > 0)
             {
+                // Get the list of changes in the delta response. 
+                List<string> changedProperties = GetChangedProperties(content);
+                var changes = serializer.SerializeObject(changedProperties);
+
+                // Add headers
                 var responseHeaders = hrm.Headers;
                 var statusCode = hrm.StatusCode;
 
@@ -63,11 +106,11 @@ namespace Microsoft.Graph
 
                 responseContent = content.Substring(0, content.Length - 1) + ", ";
                 responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
-                responseContent += "\"statusCode\": \"" + statusCode + "\"}";
+                responseContent += "\"statusCode\": \"" + statusCode + "\", ";
+                responseContent += "\"changes\": " + changes + "}";
             }
 
             return responseContent;
         }
-
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Graph
     public interface IBaseRequest
     {
         /// <summary>
-        /// Gets or sets the response handler for the request.
-        /// </summary>
-        IResponseHandler ResponseHandler { get; set; }
-
-        /// <summary>
         /// Gets or sets the content type for the request.
         /// </summary>
         string ContentType { get; set; }

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Graph
     public interface IBaseRequest
     {
         /// <summary>
+        /// Gets or sets the response handler for the request.
+        /// </summary>
+        IResponseHandler ResponseHandler { get; set; }
+
+        /// <summary>
         /// Gets or sets the content type for the request.
         /// </summary>
         string ContentType { get; set; }

--- a/src/Microsoft.Graph.Core/Requests/IResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/IResponseHandler.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// The interface required for all response handlers.
+    /// </summary>
+    public interface IResponseHandler
+    {
+        /// <summary>
+        /// Process raw HTTP response into the requested domain type.
+        /// </summary>
+        /// <typeparam name="T">The type to return</typeparam>
+        /// <param name="response">The HttpResponseMessage to handle.</param>
+        /// <returns></returns>
+        Task<T> HandleResponse<T>(HttpResponseMessage response);
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -411,5 +411,20 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+
+        [Fact]
+        public void BaseRequest_Should_Set_ResponseHandler()
+        {
+            // Arrange
+            var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient);
+
+            // Act
+            baseRequest.WithResponseHandler<BaseRequest>(new DeltaResponseHandler());
+
+            // Assert
+            Assert.NotNull(baseRequest.ResponseHandler);
+            Assert.IsType<DeltaResponseHandler>(baseRequest.ResponseHandler);
+        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using System.Threading.Tasks;
     using Xunit;
     using Microsoft.Graph;
+    using System.Linq;
 
     public class ResponseHandlerTests
     {
@@ -65,28 +66,38 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
             var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JObject>(hrm);
             string attendeeName = (string)deltaJObjectResponse.SelectToken("value[0].attendees[0].emailAddress.name");
-            //string attendeeName = (string)deltaJObjectResponse.SelectToken("value[0].changes.emailAddress.name");
+            string attendeeNameInChangelist = (deltaJObjectResponse["value"][0]["changes"] as JArray)[9].ToString();
+            var collectionPage = deltaServiceLibResponse.Value as CollectionPage<Event>;
+            var collectionPageHasChanges = collectionPage[0].AdditionalData.TryGetValue("changes", out object obj);
 
             // IEventDeltaCollectionPage is what the service library provides.
             // Can't test against the service library model, since it has a reference to the signed
             // public version of this library. see issue #57 for more info.
             // https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/57
-            // Service library testing will need to happen in the service library repo.
+            // Service library testing will need to happen in the service library repo once this is published on NuGet.
 
             // Assert
             Assert.True(deltaServiceLibResponse.Value is IEventDeltaCollectionPage); // We create a valid ICollectionPage.
             Assert.Equal("George", attendeeName); // We maintain the expected response body when we change it.
-            // TODO: Assert that we capture emailAddress.Name in the change list.
+            Assert.Equal("attendees[0].emailaddress.name", attendeeNameInChangelist); // We expect that this property is in changelist.
+            Assert.True(collectionPageHasChanges); // We expect that the CollectionPage is populated with the changes.
         }
 
+        /// <summary>
+        /// Occurs in the response when we call with the deltalink and there are no items to sync.
+        /// </summary>
+        /// <returns></returns>
         [Fact]
         public async Task HandleEventDeltaResponseWithEmptyCollectionPage()
         {
             // Arrange
             var deltaResponseHandler = new DeltaResponseHandler();
+            var odataContext = @"https://graph.microsoft.com/v1.0/$metadata#Collection(event)";
+            var odataDeltalink = @"https://graph.microsoft.com/v1.0/me/mailfolders/inbox/messages/delta?$deltatoken=LztZwWjo5IivWBhyxw5rACKxf7mPm0oW6JZZ7fvKxYPS_67JnEYmfQQMPccy6FRun0DWJF5775dvuXxlZnMYhBubC1v4SBVT9ZjO8f7acZI.uCdGKSBS4YxPEbn_Q5zxLSq91WhpGoz9ZKeNZHMWgSA";
+
 
             // Empty result
-            var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[]}";
+            var testString = "{\"@odata.context\":\"" + odataContext + "\",\"@odata.deltaLink\":\"" + odataDeltalink + "\",\"value\":[]}";
 
             var hrm = new HttpResponseMessage()
             {
@@ -96,15 +107,46 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var deltaResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
-            bool hasChanges = deltaResponse.AdditionalData.TryGetValue("changes", out object changes);
+            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JObject>(hrm);
+            var hasItems = deltaJObjectResponse["value"].HasValues;
+            var odataContextFromJObject = deltaJObjectResponse["@odata.context"].ToString();
+            var odataDeltalinkFromJObject = deltaJObjectResponse["@odata.deltaLink"].ToString();
 
-            var serializer = new Serializer();
-            List<string> changeList = serializer.DeserializeObject<List<string>>(changes.ToString());
-
-            // Assert
-            Assert.True(hasChanges);
-            Assert.Empty(changeList);
+            Assert.False(hasItems); // We don't expect items in an empty collection page
+            Assert.Equal(odataContext, odataContextFromJObject); // We expect that the odata.context isn't transformed.
+            Assert.Equal(odataDeltalink, odataDeltalinkFromJObject); // We expect that the odata.deltalink isn't transformed.
         }
+        // TODO: need a test case to check for setting to null!!!!!
+
+        [Fact]
+        public async Task HandleEventDeltaResponseWithNullValues()
+        {
+            // Arrange
+            var deltaResponseHandler = new DeltaResponseHandler();
+
+            // TestString represents a page of results with a nextLink. There are two changed events.
+            // The events have key:value properties, key:object properties, and key:array properties.
+            // To view and format this test string, replace all \" with ", and use a JSON formatter
+            // to make it pretty.
+            var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"EZ9r3czxY0m2jz8c45czkwAAFXcvIw==\",\"subject\":null,\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T19:30:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-10T21:30:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[{\"emailAddress\":{\"name\":\"George\",\"address\":\"george@contoso.onmicrosoft.com\"}},{\"emailAddress\":{\"name\":\"Jane\",\"address\":\"jane@contoso.onmicrosoft.com\"}}],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxTAAA=\"},{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"WEZ9r3czxY0m2jz8c45czkwAAFXcvJA==\",\"subject\":\"Prepare food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T22:00:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-11T00:00:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxUAAA=\"}]}";
+
+            var hrm = new HttpResponseMessage()
+            {
+                Content = new StringContent(testString,
+                                            Encoding.UTF8,
+                                            "application/json")
+            };
+
+            // Act
+            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
+            var eventsDeltaCollectionPage = deltaServiceLibResponse.Value as CollectionPage<Event>;
+            eventsDeltaCollectionPage[0].AdditionalData.TryGetValue("changes", out object changes);
+            var changeArray = changes as JArray;
+            //changeArray.Children();
+
+            // TODO finish this test
+
+        }
+
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -5,10 +5,13 @@
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 {
     using Newtonsoft.Json.Linq;
+    using System.Collections.Generic;
     using System.Net.Http;
     using System.Text;
     using System.Threading.Tasks;
     using Xunit;
+    using Microsoft.Graph;
+    
     public class ResponseHandlerTests
     {
         [Fact]
@@ -37,6 +40,81 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal("OK", user.AdditionalData["statusCode"]);
             var headers = (JObject)(user.AdditionalData["responseHeaders"]);
             Assert.Equal("value", (string)headers["test"][0]);
+        }
+
+        [Fact]
+        public async Task HandleEventDeltaResponseWithoutAttendees()
+        {
+            // Arrange
+            var deltaResponseHandler = new DeltaResponseHandler();
+
+            // No attendee
+            var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"EZ9r3czxY0m2jz8c45czkwAAFXcvIw==\",\"subject\":\"Get food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T19:30:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-10T21:30:00.0000000\",\"timeZone\":\"UTC\"},\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"},\"customProp\":\"customValue\"},\"id\":\"AAMkADVxTAAA=\"},{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"WEZ9r3czxY0m2jz8c45czkwAAFXcvJA==\",\"subject\":\"Prepare food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T22:00:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-11T00:00:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxUAAA=\"}]}";
+
+            var hrm = new HttpResponseMessage()
+            {
+                Content = new StringContent(testString, 
+                                            Encoding.UTF8, 
+                                            "application/json")
+            };
+
+            // Act
+            var deltaResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
+            bool hasChanges = deltaResponse.AdditionalData.TryGetValue("changes", out object changes);
+
+            // Can't test against the actual model, see issue #57 for more info.
+            var serializer = new Serializer();
+            List<string> changeList = serializer.DeserializeObject<List<string>>(changes.ToString());
+            
+            // Assert
+            Assert.True(hasChanges);
+            Assert.Equal("value[0]['@odata.type']", changeList[0]);
+            Assert.Equal("value[0]['@odata.etag']", changeList[1]);
+            Assert.Equal("value[0].subject", changeList[2]);
+            Assert.Equal("value[0].body", changeList[3]);
+            Assert.Equal("value[0].body.contentType", changeList[4]);
+            Assert.Equal("value[0].body.content", changeList[5]);
+            Assert.Equal("value[0].start", changeList[6]);
+            Assert.Equal("value[0].start.dateTime", changeList[7]);
+            Assert.Equal("value[0].start.timeZone", changeList[8]);
+            Assert.Equal("value[0].end", changeList[9]);
+            Assert.Equal("value[0].end.dateTime", changeList[10]);
+            Assert.Equal("value[0].end.timeZone", changeList[11]);
+            Assert.Equal("value[0].organizer", changeList[12]);
+            Assert.Equal("value[0].organizer.emailAddress", changeList[13]);
+            Assert.Equal("value[0].organizer.emailAddress.name", changeList[14]);
+            Assert.Equal("value[0].organizer.emailAddress.address", changeList[15]);
+            Assert.Equal("value[0].organizer.customProp", changeList[16]);
+            Assert.Equal("value[0].id", changeList[17]);
+            Assert.Equal("value[1]['@odata.type']", changeList[18]);
+        }
+
+        [Fact]
+        public async Task HandleEventDeltaResponseWithEmptyCollectionPage()
+        {
+            // Arrange
+            var deltaResponseHandler = new DeltaResponseHandler();
+
+            // Empty result
+            var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[]}";
+
+            var hrm = new HttpResponseMessage()
+            {
+                Content = new StringContent(testString,
+                                            Encoding.UTF8,
+                                            "application/json")
+            };
+
+            // Act
+            var deltaResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
+            bool hasChanges = deltaResponse.AdditionalData.TryGetValue("changes", out object changes);
+
+            var serializer = new Serializer();
+            List<string> changeList = serializer.DeserializeObject<List<string>>(changes.ToString());
+
+            // Assert
+            Assert.True(hasChanges);
+            Assert.Empty(changeList);
         }
     }
 }


### PR DESCRIPTION
[Delta query](https://docs.microsoft.com/en-us/graph/delta-query-users?view=graph-rest-1.0) provides a way to track changes.  You begin to track changes with a request like this:

`GET https://graph.microsoft.com/v1.0/users/delta?$select=displayName,givenName,surname`

`var userDeltaCollectionPage = await graphClient.Users.Delta().Request().Select("displayName,givenName,surname").GetAsync();`

Currently, a developer has to inspect the selected properties on each object in the page. The inspection requires first that they check that the selected properties are not null before getting the changed value. If the selected property is a primitive, then they can capture that value. If the selected property is an object, they must also inspect all of its property with a null check before capturing the values.  This may mean unnecessarily checking many properties that have not changed. This PR should reduce the amount of null checking that has to occur when a delta query payload is received by providing a manifest of changes. This is especially useful when a property has been set to null as previously, there was no way to determine whether a property has been set to null, or was not set and so it defaulted to null. 

The change manifest is set on each item in the CollectionPage. It is found in the AdditionalData dictionary with a a key called `changes`.  This functionality is accessed via:

**Microsoft.Graph.Core**

```csharp
var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<JObject>(httpresponsemessage);
var changesOnTheFirstItem = deltaJObjectResponse["value"][0]["changes"] as JArray;

// This is not an important scenario as the developer can query whether a value is set null using JMESPath or using Newtonsoft.
```

**Microsoft.Graph**

This enables developers to discover values set to null when using the service library. 

```csharp
var eventsDeltaCollectionPage = await graphClient.Me.CalendarView
                                               .Delta()
                                               .Request()
                                               .WithResponseHandler(new DeltaResponseHandler())
                                               .Select("subject")
                                               .GetAsync();

// Accesses the changes on each page item.
eventsDeltaCollectionPage[0].AdditionalData.TryGetValue("changes", out object changes);
var changeList = (changes as JArray).ToObject<List<string>>();

// Updating a non-schematized property on a model such as instance annotations, open types,
// and schema extensions. Can also be used to discover deleted items.
if (changeList.Exists(x => x.Equals("@removed.reason")))
{
    eventsDeltaCollectionPage[0].AdditionalData.TryGetValue("@removed", out object odataEtag);
    Console.Writeline("This item was removed.")
    // TODO: myModel.Delete();
}

// Core scenario - update schematized property regardless of it is set to null.
// This property has been set to null in the response. We can be confident that
// whatever the value set is correct, regardless whether it is null.
if (changeList.Exists(x => x.Equals("subject")))
{
    myModel.Subject = eventsDeltaCollectionPage[0].Subject;
}

// Update the value on a complex type property's value. Developer can't just replace the body
// as that could result in overwriting other unchanged property. Essentially, they need to inspect
// every leaf node in the selected property set.
if (changeList.Exists(x => x.Equals("body.content"))) // 
{
    if (myModel.Body == null)
    {
        myModel.Body = new ItemBody();
    }

    myModel.Body.Content = eventsDeltaCollectionPage[0].Body.Content;
}

// Update complex type property's value when the value is a collection of objects.
// We don't know whether this is an update or add without querying the client model.
// We will need to check each object in the model.
var attendeesChangelist = changeList.FindAll(x => x.Contains("attendees"));
if (attendeesChangelist.Count > 0)
{
    // This is where if we provided the delta response as a JSON object, 
    // we could let the developer use JMESPath to query the changes.
    if (changeList.Exists(x => x.Equals("attendees[0].emailAddress.name")))
    {
        if (myModel.Attendees == null) // Attendees are being added for the first time.
        {
            var attendees = new List<Attendee>();
            attendees.AddRange(eventsDeltaCollectionPage[0].Attendees);
            myModel.Attendees = attendees;
        }
        else // Attendees list is being updated.
        {
            // We need to inspect each object, and determine which objects and properties 
            // need to be initialized and/or updated.
        }
    }
}

```

The raw JSON on the object after adding the change list looks like:

```json
{
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(event)",
    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4",
    "value": [
        {
            "@odata.type": "#microsoft.graph.event",
            "@odata.etag": "EZ9r3czxY0m2jz8c45czkwAAFXcvIw==",
            "subject": null,
            "id": "AAMkADVxTAAA=",
            "changes" : ["@odata.type", "@odata.etag", "subject", "id"]
        }
    ]
}
 ```


This also now allows developers to add their own response handler to any request builder. This enables new ways to process the contents of a request builder based response. 

Generally, a change results in the returning the entire item with the original property set. 

> The delta feed shows the latest state for each item, not each change. If an item were renamed twice, it would only show up once, with its latest name.

https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http

- [x] Put changes on the object, not the page collection. Will need to JObject, not JsonTextReader
- [x] Should work with only core and also with service libraries.
- [x] support open properties in the change list.