### PR TITLE
Use common serializer in Batch requests and responses

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -27,6 +27,7 @@
       - Adds ChaosHandler for testing.
       - HTTP pipeline updates overwrite existing inner handlers.
       - BatchRequestContent enhancements to enable deserialization to a given type
+      - Updates to fix and use common serializer for batch content
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Serialization/Serializer.cs
+++ b/src/Microsoft.Graph.Core/Serialization/Serializer.cs
@@ -59,8 +59,7 @@ namespace Microsoft.Graph
                 true /* leaveOpen */))
             using (var textReader = new JsonTextReader(streamReader))
             {
-                var jsonSerializer = new JsonSerializer();
-
+                var jsonSerializer = JsonSerializer.Create(this.jsonSerializerSettings);
                 return jsonSerializer.Deserialize<T>(textReader);
             }
         }


### PR DESCRIPTION
This PR fixes microsoftgraph/msgraph-sdk-dotnet#587 and fixes microsoftgraph/msgraph-sdk-dotnet#291

### Changes proposed in this pull request
- Updates method overload `DeserializeObject<T>(Stream stream)` in Serializer to use common serializer settings
- Uses common serializer for intermediate de/serialization in BatchRequestContent and BatchResponseContent to fix inconsistent responses as seen in this [issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/587)
- Adds tests to validate date values are consistent before/after serialization for BatchRequestContent and BatchResponseContent
