### PR TITLE
Prevent setting of timeout property in HttpClient

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -29,7 +29,7 @@
       - BatchRequestContent enhancements to enable deserialization to a given type
       - Updates to fix and use common serializer for batch content
       - Adds FileUploadTask to provide support for file/attachement upload
-      - Fix for modified Timeout property in a passed HttpClient
+      - Fix for modifying the Timeout property of a passed HttpClient
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,16 +19,9 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.19.0</VersionPrefix>
+    <VersionPrefix>1.20.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Adds request builders for the batch endpoint to the client
-      - BatchRequestStep enhancements: added overloads to add BatchRequestStep using BaseRequest and HttpRequestMessage.
-      - Adds ChaosHandler for testing.
-      - HTTP pipeline updates overwrite existing inner handlers.
-      - BatchRequestContent enhancements to enable deserialization to a given type
-      - Updates to fix and use common serializer for batch content
-      - Adds FileUploadTask to provide support for file/attachement upload
       - Fix for modifying the Timeout property of a passed HttpClient
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -29,6 +29,7 @@
       - BatchRequestContent enhancements to enable deserialization to a given type
       - Updates to fix and use common serializer for batch content
       - Adds FileUploadTask to provide support for file/attachement upload
+      - Fix for modified Timeout property in a passed HttpClient
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Graph
         {
             this.httpClient = httpClient;
             Serializer = serializer ?? new Serializer();
-            OverallTimeout = new TimeSpan(0, 5, 0);
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -69,6 +69,26 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public async Task InitSuccessfullyWithUsedHttpClient()
+        {
+            // Create a httpClient
+            var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
+            using (HttpClient httpClient = GraphClientFactory.Create(handlers: defaultHandlers, finalHandler: testHttpMessageHandler))
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+                // use the httpClient to send something out
+                await httpClient.SendAsync(httpRequestMessage);
+                // Create a provider using the same client
+                SimpleHttpProvider testSimpleHttpProvider = new SimpleHttpProvider(httpClient, this.serializer.Object);
+                // Assert that using the used client throws no errors on initialization
+                Assert.NotNull(testSimpleHttpProvider.Serializer);
+                Assert.Equal(httpClient.Timeout, simpleHttpProvider.OverallTimeout);
+            }
+        }
+
+        [Fact]
         public async Task SendAsync()
         {
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))


### PR DESCRIPTION
Fixes #67

### Changes proposed in this pull request
This PR undos the automatic setting of timeout property in the HttpClient that is passed in the constructor as the HttpClient could already have been used before to therefore cause an exception.

#### Steps to test the fix
```cs
var httpClient = new HttpClient();
// make any request with the client
var graphServiceClient = new GraphServiceClient(httpClient); // no exception should throw!
```
#### Expected behavour
No expection should be thrown on the last line of the example.