### PR TITLE
null auth provider support

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Graph
         /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
         public SimpleHttpProvider(HttpClient httpClient, ISerializer serializer = null)
         {
-            this.httpClient = httpClient;
+            // Null authProvider addresses https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/605.
+            // We're reenabling this functionality that allowed setting a null authprovider.
+            this.httpClient = httpClient ?? GraphClientFactory.Create(authenticationProvider: null);
             Serializer = serializer ?? new Serializer();
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -71,13 +71,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public async Task InitSuccessfullyWithoutHttpClient()
         {
-            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
-            {
-                // Create a provider using a null client
-                SimpleHttpProvider testSimpleHttpProvider = new SimpleHttpProvider(null, this.serializer.Object);
-                // Assert that using the client throws no errors on initialization
-                Assert.NotNull(testSimpleHttpProvider.httpClient);
-            }
+            // Create a provider using a null client
+            SimpleHttpProvider testSimpleHttpProvider = new SimpleHttpProvider(null, this.serializer.Object);
+            // Assert that the httpclient is set (from the factory)
+            Assert.NotNull(testSimpleHttpProvider.httpClient);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -69,6 +69,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public async Task InitSuccessfullyWithoutHttpClient()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            {
+                // Create a provider using a null client
+                SimpleHttpProvider testSimpleHttpProvider = new SimpleHttpProvider(null, this.serializer.Object);
+                // Assert that using the client throws no errors on initialization
+                Assert.NotNull(testSimpleHttpProvider.httpClient);
+            }
+        }
+
+        [Fact]
         public async Task InitSuccessfullyWithUsedHttpClient()
         {
             // Create a httpClient


### PR DESCRIPTION
Fixes #70 , Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/605.

Allows a null httpClient to be set in the GraphServiceClient; unbreaks customers who don't use the authProvider and sets token on the request headers instead of using the authProviders.