### PR TITLE
Fix default upload size (5 instead of 4)

### DIFF
--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class LargeFileUploadTask<T>
     {
-        private const int DefaultMaxSliceSize = 4 * 1024 * 1024;
+        private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
         private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;


### PR DESCRIPTION
If LargeFileUploadTask is called without the maxSliceSize parameter the default will be picked. But the default was 4*1024*1024 and that is not a multiplier of 320! So a caller must specify the size, even if they want to stick to the defaults (that may be changed in the future).

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
-
-
-

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-
-
-