### PR TITLE
TokenCredential Support

### DIFF
--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -54,6 +54,8 @@ steps:
     arguments: '-packageName "$(PACKAGE_NAME)" -projectPath "$(PROJECT_PATH)"'
   enabled: true
 
+- task: NuGetToolInstaller@1
+
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:

--- a/src/Microsoft.Graph.Core/AuthConstants.cs
+++ b/src/Microsoft.Graph.Core/AuthConstants.cs
@@ -1,0 +1,18 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    internal static class AuthConstants
+    {
+        internal const string DefaultScopeUrl = "https://graph.microsoft.com/.default";
+
+        internal static class Tenants
+        {
+            public const string Common = "common";
+            public const string Organizations = "organizations";
+            public const string Consumers = "consumers";
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Authentication/MsalAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Authentication/MsalAuthenticationProviderOption.cs
@@ -1,0 +1,22 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Identity.Client;
+    using System.Security;
+
+    /// <summary>
+    /// Options class used to configure the authentication providers.
+    /// </summary>
+    internal class MsalAuthenticationProviderOption : IAuthenticationProviderOption
+    {
+
+        /// <summary>
+        /// Scopes to use when authenticating.
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+    }
+}

--- a/src/Microsoft.Graph.Core/Authentication/TokenCredentialAuthProvider.cs
+++ b/src/Microsoft.Graph.Core/Authentication/TokenCredentialAuthProvider.cs
@@ -1,0 +1,49 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Azure.Core;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Linq;
+
+    /// <summary>
+    /// An AuthProvider to handle instances of <see cref="TokenCredential"/> from Azure.Core and Azure.Identity
+    /// </summary>
+    public class TokenCredentialAuthProvider : IAuthenticationProvider
+    {
+        private readonly TokenCredential _credential;
+
+        private readonly IEnumerable<string> _scopes;
+
+        /// <summary>
+        /// An AuthProvider to handle instances of <see cref="TokenCredential"/> from Azure.Core and Azure.Identity
+        /// </summary>
+        /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authentication</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
+        public TokenCredentialAuthProvider(TokenCredential tokenCredential, IEnumerable<string> scopes = null)
+        {
+            _credential = tokenCredential;
+            _scopes = scopes ?? new List<string> { AuthConstants.DefaultScopeUrl };
+        }
+
+        /// <summary>
+        /// Adds an authentication header to the incoming request by checking using the <see cref="TokenCredential"/> provided
+        /// during the creation of this class
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> to authenticate</param>
+        /// <returns></returns>
+        public async Task AuthenticateRequestAsync(HttpRequestMessage request)
+        {
+            //First try to read the scopes off the requestContext.
+            MsalAuthenticationProviderOption msalAuthProviderOption = request.GetMsalAuthProviderOption();
+            AccessToken token = await _credential.GetTokenAsync(new TokenRequestContext(msalAuthProviderOption.Scopes ?? _scopes.ToArray()), CancellationToken.None).ConfigureAwait(false);
+            request.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, token.Token);
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Authentication/TokenCredentialAuthProvider.cs
+++ b/src/Microsoft.Graph.Core/Authentication/TokenCredentialAuthProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Graph
     using System.Net.Http.Headers;
     using System.Threading;
     using System.Linq;
+    using System;
 
     /// <summary>
     /// An AuthProvider to handle instances of <see cref="TokenCredential"/> from Azure.Core and Azure.Identity
@@ -26,9 +27,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authentication</param>
         /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
+        /// <exception cref="ArgumentException"> When a null <see cref="TokenCredential"/> is passed</exception>
         public TokenCredentialAuthProvider(TokenCredential tokenCredential, IEnumerable<string> scopes = null)
         {
-            _credential = tokenCredential;
+            _credential = tokenCredential ?? throw new ArgumentException(
+                              string.Format(ErrorConstants.Messages.NullParameter, nameof(tokenCredential)),
+                              nameof(tokenCredential));
             _scopes = scopes ?? new List<string> { AuthConstants.DefaultScopeUrl };
         }
 

--- a/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
+++ b/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
@@ -1,0 +1,155 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Azure.Core;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using Microsoft.Identity.Client;
+    using System;
+
+    /// <summary>
+    /// A <see cref="TokenCredential"/> implementation using MSAL.Net to acquire token by integrated windows authentication.
+    /// </summary>
+    public class IntegratedWindowsTokenCredential : TokenCredential
+    {
+
+        private static readonly List<string> WellKnownTenants = new List<string>
+        {   AuthConstants.Tenants.Common,
+            AuthConstants.Tenants.Consumers,
+            AuthConstants.Tenants.Organizations
+        };
+
+        private readonly IPublicClientApplication _clientApplication;
+
+        /// <summary>
+        /// Creates a new IntegratedWindowsTokenCredential which will authenticate users with the specified application.
+        /// </summary>
+        /// <param name="publicClientApplication">A <see cref="IPublicClientApplication"/> to pass to <see cref="IntegratedWindowsTokenCredential"/> for authentication.</param>
+        public IntegratedWindowsTokenCredential(IPublicClientApplication publicClientApplication)
+        {
+            _clientApplication = publicClientApplication ?? throw new AuthenticationException(
+                new Error
+                {
+                    Code = ErrorConstants.Codes.InvalidRequest,
+                    Message = string.Format(ErrorConstants.Messages.NullValue, nameof(publicClientApplication))
+                });
+        }
+
+        /// <summary>
+        /// Gets an <see cref="AccessToken"/> using the provided <see cref="TokenRequestContext"/> in a synchronous fashion
+        /// </summary>
+        /// <param name="requestContext">The <see cref="TokenRequestContext"/> for the request</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request</param>
+        /// <returns>An <see cref="AccessToken"/> to make requests with</returns>
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return GetTokenAsync(requestContext,cancellationToken).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Gets an <see cref="AccessToken"/> using the provided <see cref="TokenRequestContext"/> in an asynchronous fashion
+        /// </summary>
+        /// <param name="requestContext">The <see cref="TokenRequestContext"/> for the request</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request</param>
+        /// <returns>An <see cref="AccessToken"/> to make requests with</returns>
+        public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            AuthenticationResult result;
+            try
+            {
+                // Try to get the account from the cache
+                IEnumerable<IAccount> accounts = await _clientApplication.GetAccountsAsync();
+                IAccount account = accounts.FirstOrDefault();
+
+                // Try to get the token silently
+                AcquireTokenSilentParameterBuilder tokenSilentBuilder =
+                    _clientApplication.AcquireTokenSilent(requestContext.Scopes, account);
+
+                if (!ContainsWellKnownTenantName(_clientApplication.Authority))
+                    tokenSilentBuilder.WithAuthority(_clientApplication.Authority);
+
+                result = await tokenSilentBuilder.ExecuteAsync(cancellationToken);
+            }
+            catch (MsalException)
+            {
+                // We can't get the token silently so get a new one
+                result = await GetNewAccessTokenAsync(requestContext);
+            }
+
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        /// <summary>
+        /// Gets an new <see cref="AccessToken"/> after checking the cache has failed
+        /// </summary>
+        /// <param name="requestContext">The <see cref="TokenRequestContext"/> for the request</param>
+        /// <returns></returns>
+        private async Task<AuthenticationResult> GetNewAccessTokenAsync(TokenRequestContext requestContext)
+        {
+            AuthenticationResult authenticationResult = null;
+            int retryCount = 0;
+            do
+            {
+                try
+                {
+                    authenticationResult = await _clientApplication.AcquireTokenByIntegratedWindowsAuth(requestContext.Scopes)
+                                .ExecuteAsync();
+                }
+                catch (MsalServiceException serviceException)
+                {
+                    // Service not available so wait 
+                    if (serviceException.ErrorCode == ErrorConstants.Codes.TemporarilyUnavailable)
+                    {
+                        TimeSpan delay = this.GetRetryAfter(serviceException);
+                        retryCount++;
+                        // pause execution
+                        await Task.Delay(delay);
+                    }
+                    else
+                    {
+                        throw new AuthenticationException(
+                            new Error
+                            {
+                                Code = ErrorConstants.Codes.GeneralException,
+                                Message = ErrorConstants.Messages.UnexpectedMsalException
+                            },
+                            serviceException);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    throw new AuthenticationException(
+                            new Error
+                            {
+                                Code = ErrorConstants.Codes.GeneralException,
+                                Message = ErrorConstants.Messages.UnexpectedException
+                            },
+                            exception);
+                }
+
+            } while (retryCount < 3);
+
+            return authenticationResult;
+        }
+
+        /// <summary>
+        /// Determines if an authority url has a `well known` tenant name (common, consumers, organizations) in its tenant segment.
+        /// </summary>
+        /// <param name="currentAuthority">The authority url to check.</param>
+        /// <returns>True is pre-defined tenant names are present, and false if not. </returns>
+        private bool ContainsWellKnownTenantName(string currentAuthority)
+        {
+            if (!Uri.IsWellFormedUriString(currentAuthority, UriKind.Absolute))
+                throw new ArgumentException("Invalid authority URI set.");
+
+            Uri authorityUri = new Uri(currentAuthority);
+
+            return WellKnownTenants.Contains(authorityUri.Segments[1].Replace(@"/", string.Empty));
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Exceptions/AuthenticationException.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/AuthenticationException.cs
@@ -1,0 +1,29 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    /// <summary>
+    /// Graph authentication exception
+    /// </summary>
+    public class AuthenticationException : Exception
+    {
+        /// <summary>
+        /// Creates a new authentication exception.
+        /// </summary>
+        /// <param name="error">The error that triggered the exception.</param>
+        /// <param name="innerException">The possible inner exception.</param>
+        public AuthenticationException(Error error, Exception innerException = null)
+            : base(error?.ToString(), innerException)
+        {
+            this.Error = error;
+        }
+
+        /// <summary>
+        /// The error from the authentication exception.
+        /// </summary>
+        public Error Error { get; private set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Exceptions/AuthenticationException.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/AuthenticationException.cs
@@ -5,8 +5,9 @@
 namespace Microsoft.Graph
 {
     using System;
+
     /// <summary>
-    /// Graph authentication exception
+    /// Generic exception class to report unknown exceptions during authentication
     /// </summary>
     public class AuthenticationException : Exception
     {

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Graph
             internal static string MaximumValueExceeded = "MaximumValueExceeded";
 
             internal static string InvalidArgument = "invalidArgument";
+
+            internal const string TemporarilyUnavailable = "temporarily_unavailable";
         }
 
         internal static class Messages
@@ -66,6 +68,14 @@ namespace Microsoft.Graph
             internal static string ExpiredUploadSession = "Upload session expired. Upload cannot resume";
 
             internal static string NoResponseForUpload = "No Response Received for upload.";
+
+            internal static string NullValue = "{0} cannot be null.";
+
+            internal static string UnexpectedMsalException = "Unexpected exception returned from MSAL.";
+            
+            internal static string UnexpectedException = "Unexpected exception occured while authenticating the request.";
+
+            internal static string MissingRetryAfterHeader = "Missing retry after header.";
 
             public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
         }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -167,5 +167,41 @@ namespace Microsoft.Graph
 
             return baseRequest;
         }
+
+        /// <summary>
+        /// Sets Microsoft Graph's scopes that will be used by <see cref="IAuthenticationProvider"/> to authenticate this request
+        /// and can be used to perform incremental scope consent.
+        /// This only works with the default authentication handler and default set of Microsoft graph authentication providers.
+        /// If you use a custom authentication handler or authentication provider, you have to handle it's retrieval in your implementation.
+        /// </summary>
+        /// <param name="baseRequest">The <see cref="IBaseRequest"/>.</param>
+        /// <param name="scopes">Microsoft graph scopes used to authenticate this request.</param>
+        public static T WithScopes<T>(this T baseRequest, string[] scopes) where T : IBaseRequest
+        {
+            string authHandlerOptionKey = typeof(AuthenticationHandlerOption).ToString();
+            AuthenticationHandlerOption authHandlerOptions; 
+
+            // make sure that the options exist in the middleware otherwise create is
+            if (baseRequest.MiddlewareOptions.ContainsKey(authHandlerOptionKey))
+            {
+                authHandlerOptions = baseRequest.MiddlewareOptions[authHandlerOptionKey] as AuthenticationHandlerOption;
+            }
+            else
+            {
+                baseRequest.MiddlewareOptions.Add(authHandlerOptionKey, new AuthenticationHandlerOption());
+                authHandlerOptions = baseRequest.MiddlewareOptions[authHandlerOptionKey] as AuthenticationHandlerOption;
+            }
+
+            // get the auth handler options or create a new instance if absent
+            MsalAuthenticationProviderOption msalAuthProviderOption = authHandlerOptions.AuthenticationProviderOption as MsalAuthenticationProviderOption ?? new MsalAuthenticationProviderOption();
+
+            msalAuthProviderOption.Scopes = scopes;
+
+            // update the base request object as appropriate
+            authHandlerOptions.AuthenticationProviderOption = msalAuthProviderOption;
+            baseRequest.MiddlewareOptions[authHandlerOptionKey] = authHandlerOptions;
+
+            return baseRequest;
+        }
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Graph
             string authHandlerOptionKey = typeof(AuthenticationHandlerOption).ToString();
             AuthenticationHandlerOption authHandlerOptions; 
 
-            // make sure that the options exist in the middleware otherwise create is
+            // make sure that the options exist in the middleware otherwise create it
             if (baseRequest.MiddlewareOptions.ContainsKey(authHandlerOptionKey))
             {
                 authHandlerOptions = baseRequest.MiddlewareOptions[authHandlerOptionKey] as AuthenticationHandlerOption;

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -122,5 +122,17 @@ namespace Microsoft.Graph
             return (T)option;
         }
 
+        /// <summary>
+        /// Gets a <see cref="MsalAuthenticationProviderOption"/> from <see cref="HttpRequestMessage"/>
+        /// </summary>
+        /// <param name="httpRequestMessage">The <see cref="HttpRequestMessage"/> representation of the request.</param>
+        /// <returns>A middleware option of type <see cref="MsalAuthenticationProviderOption"/></returns>
+        internal static MsalAuthenticationProviderOption GetMsalAuthProviderOption(this HttpRequestMessage httpRequestMessage)
+        {
+            AuthenticationHandlerOption authHandlerOption = httpRequestMessage.GetMiddlewareOption<AuthenticationHandlerOption>();
+
+            return authHandlerOption?.AuthenticationProviderOption as MsalAuthenticationProviderOption ?? new MsalAuthenticationProviderOption();
+        }
+
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/TokenCredentialExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/TokenCredentialExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Graph
             }
 
             if (delay == null)
-                throw new MsalServiceException(serviceException.ErrorCode, ErrorConstants.Messages.MissingRetryAfterHeader);
+                throw new MsalServiceException(serviceException.ErrorCode, ErrorConstants.Messages.MissingRetryAfterHeader, serviceException);
 
             return delay.Value;
         }

--- a/src/Microsoft.Graph.Core/Extensions/TokenCredentialExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/TokenCredentialExtensions.cs
@@ -1,0 +1,40 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Identity.Client;
+    using System;
+    using System.Net.Http.Headers;
+    using Azure.Core;
+
+    internal static class TokenCredentialExtensions
+    {
+        /// <summary>
+        /// Gets retry after timespan from <see cref="RetryConditionHeaderValue"/>.
+        /// </summary>
+        /// <param name="tokenCredential">n <see cref="TokenCredential"/> object.</param>
+        /// <param name="serviceException">A <see cref="MsalServiceException"/> with RetryAfter header</param>
+        internal static TimeSpan GetRetryAfter(this TokenCredential tokenCredential, MsalServiceException serviceException)
+        {
+            RetryConditionHeaderValue retryAfter = serviceException.Headers?.RetryAfter;
+            TimeSpan? delay = null;
+
+            if (retryAfter != null && retryAfter.Delta.HasValue)
+            {
+                delay = retryAfter.Delta;
+            }
+            else if (retryAfter != null && retryAfter.Date.HasValue)
+            {
+                delay = retryAfter.Date.Value.Offset;
+            }
+
+            if (delay == null)
+                throw new MsalServiceException(serviceException.ErrorCode, ErrorConstants.Messages.MissingRetryAfterHeader);
+
+            return delay.Value;
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Graph Core Client Library implements core functionality used by Microsoft Graph client libraries.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.1;net45;Xamarin.iOS10;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
     <PackageId>Microsoft.Graph.Core</PackageId>
@@ -13,7 +13,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/microsoftgraph/msgraph-sdk-dotnet</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -22,79 +22,69 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Test feature 2.0 CD
-      
+      - Adds support for TokenCredential from Azure.Core
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS1014'">
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v1.014</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);iOS</DefineConstants>
     <DebugType>full</DebugType>
     <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <DebugType>full</DebugType>
     <DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
-	<LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets</LanguageTargets>
+    <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.1\Microsoft.Graph.Core.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Microsoft.Graph.Core.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.1|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard1.1\Microsoft.Graph.Core.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\Microsoft.Graph.Core.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
-    <DocumentationFile>bin\Release\net45\Microsoft.Graph.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
+    <DocumentationFile>bin\Release\net461\Microsoft.Graph.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
-    <DocumentationFile>bin\Debug\net45\Microsoft.Graph.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
+    <DocumentationFile>bin\Debug\net461\Microsoft.Graph.xml</DocumentationFile>
   </PropertyGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Net.Http" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Security.Claims" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS1014' ">
+    <Reference Include="Xamarin.iOS" />
     <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
-	<PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
-	<PackageReference Include="System.ValueTuple" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
-	<Reference Include="Xamarin.iOS" />
-	<Reference Include="System" />
-	<Reference Include="System.Core" />
-	<Reference Include="System.Xml" />
-	<Reference Include="Microsoft.CSharp" />
-	<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-	<PackageReference Include="System.Net.Http" Version="4.3.3" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
-	<Reference Include="Mono.Android" />
-	<Reference Include="System" />
-	<Reference Include="System.Core" />
-	<Reference Include="System.Xml" />
-	<Reference Include="Microsoft.CSharp" />
-	<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-	<PackageReference Include="System.Net.Http" Version="4.3.3" />
-	<PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
+    <Reference Include="Mono.Android" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-	<None Include="..\..\LICENSE.txt">
-	  <Pack>True</Pack>
-	  <PackagePath></PackagePath>
-	</None>
+  <None Include="..\..\LICENSE.txt">
+    <Pack>True</Pack>
+    <PackagePath></PackagePath>
+  </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
+    <PackageReference Include="Azure.Core" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -4,7 +4,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;MonoAndroid80;Xamarin.iOS10</TargetFrameworks>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
     <PackageId>Microsoft.Graph.Core</PackageId>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -26,16 +26,16 @@
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS1014'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
     <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v1.014</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <DefineConstants>$(DefineConstants);iOS</DefineConstants>
     <DebugType>full</DebugType>
     <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <DebugType>full</DebugType>
     <DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
@@ -61,7 +61,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS1014' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Graph
     using System;
     using System.Net.Http;
     using Microsoft.Graph.Core.Requests;
+    using System.Collections.Generic;
+    using Azure.Core;
 
     /// <summary>
     /// A default <see cref="IBaseClient"/> implementation.
@@ -28,6 +30,25 @@ namespace Microsoft.Graph
         {
             this.BaseUrl = baseUrl;
             this.AuthenticationProvider = authenticationProvider;
+            this.HttpProvider = httpProvider ?? new HttpProvider(new Serializer());
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="BaseClient"/>.
+        /// </summary>
+        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
+        /// <param name="tokenCredential">The <see cref="TokenCredential"/> for authenticating request messages.</param>
+        /// <param name="scopes">List of scopes for the authentication context.</param>
+        /// <param name="httpProvider">The <see cref="IHttpProvider"/> for sending requests.</param>
+        public BaseClient(
+            string baseUrl,
+            TokenCredential tokenCredential,
+            IEnumerable<string> scopes = null,
+            IHttpProvider httpProvider = null
+            )
+        {
+            this.BaseUrl = baseUrl;
+            this.AuthenticationProvider = new TokenCredentialAuthProvider(tokenCredential, scopes );
             this.HttpProvider = httpProvider ?? new HttpProvider(new Serializer());
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Authentication
+{
+    using Azure.Core;
+    using Microsoft.Identity.Client;
+    using Xunit;
+    using System.Collections.Generic;
+
+    public class IntegrateWindowsTokenCredentialTests
+    {
+        [Fact]
+        public void ShouldConstructAuthProviderWithPublicClientApp()
+        {
+            string clientId = "00000000-0000-0000-0000-000000000000";
+            string authority = "https://login.microsoftonline.com/organizations/";
+            IEnumerable<string> scopes = new List<string> { "User.ReadBasic.All" };
+
+            IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
+                .Create(clientId)
+                .WithAuthority(authority)
+                .Build();
+
+            IntegratedWindowsTokenCredential integratedWindowsTokenCredential = new IntegratedWindowsTokenCredential(publicClientApplication);
+
+            Assert.IsAssignableFrom<TokenCredential>(integratedWindowsTokenCredential);
+        }
+
+        [Fact]
+        public void ConstructorShouldThrowExceptionWithNullPublicClientApp()
+        {
+            IEnumerable<string> scopes = new List<string> { "User.ReadBasic.All" };
+
+            AuthenticationException ex = Assert.Throws<AuthenticationException>(() => new IntegratedWindowsTokenCredential(null));
+
+            Assert.Equal(ex.Error.Code, ErrorConstants.Codes.InvalidRequest);
+            Assert.Equal(ex.Error.Message, string.Format(ErrorConstants.Messages.NullValue, "publicClientApplication"));
+        }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/TokenCredentialAuthProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/TokenCredentialAuthProviderTests.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Authentication
+{
+    using System.Threading.Tasks;
+    using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
+    using System.Net.Http;
+    using Xunit;
+
+    public class TokenCredentialAuthProviderTests
+    {
+        private readonly MockTokenCredential _mockTokenCredential;
+
+        public TokenCredentialAuthProviderTests()
+        { 
+            _mockTokenCredential = new MockTokenCredential();
+        }
+
+        [Fact]
+        public async Task TokenCredentialAuthProviderReadsScopesFromContext()
+        {
+            // Arrange
+            HttpRequestMessage htpHttpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://localhost");
+            TokenCredentialAuthProvider tokenCredentialAuthProvider = new TokenCredentialAuthProvider(_mockTokenCredential.Object);
+
+            // Act
+            Assert.Null(htpHttpRequestMessage.Headers.Authorization);
+            await tokenCredentialAuthProvider.AuthenticateRequestAsync(htpHttpRequestMessage);
+
+            // Assert
+            Assert.NotNull(htpHttpRequestMessage.Headers.Authorization);
+            Assert.Equal("Bearer", htpHttpRequestMessage.Headers.Authorization.Scheme);
+            Assert.Equal("mockToken", htpHttpRequestMessage.Headers.Authorization.Parameter);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
+namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
 {
     using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
     using System;
@@ -124,6 +124,25 @@
                 Assert.NotEqual(perRequestAutHeader, returnedResponseMessage.RequestMessage.Headers.Authorization.Parameter);
                 Assert.Equal(defaultAuthHeader, returnedResponseMessage.RequestMessage.Headers.Authorization.Parameter);
             }
+        }
+
+        [Fact]
+        public void WithScopes_ShouldUseScopesProvided()
+        {
+            //Arrange
+            var scopes = new string[] { "User.Read", "Mail.Send"};
+            var baseRequest = new BaseRequest(requestUrl, baseClient);
+            
+            // Act
+            baseRequest.WithScopes(scopes);
+
+            // Assert
+            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+            var messageScopes = baseRequest.GetHttpRequestMessage().GetMiddlewareOption<AuthenticationHandlerOption>()
+                .AuthenticationProviderOption.Scopes;
+            Assert.Equal(2, messageScopes.Length);
+            Assert.Equal(scopes[0], messageScopes[0]);
+            Assert.Equal(scopes[1], messageScopes[1]);
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;Xamarin.iOS10;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;Xamarin.iOS1014;MonoAndroid80</TargetFrameworks>
     <AssemblyName>Microsoft.Graph.DotnetCore.Core.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Core.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
 	<DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
 	<!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS1014'">
 	<TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
 	<TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
 	<DefineConstants>$(DefineConstants);iOS</DefineConstants>
@@ -25,9 +26,9 @@
 	<LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
 	<TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-	<TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+	<TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
 	<AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
 	<DebugType>full</DebugType>
 	<DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
@@ -38,38 +39,36 @@
 	<PackageReference Include="System.Reflection.Emit" Version="4.3.0">
 	  <ExcludeAssets>all</ExcludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 	<PackageReference Include="Moq" Version="4.10.1" />
 	<PackageReference Include="xunit" Version="2.4.1" />
 	<PackageReference Include="Microsoft.Graph" Version="1.*" />
 	<ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS1014' ">
 	<Reference Include="Microsoft.CSharp" />
 	<Reference Include="Xamarin.iOS" />
 	<Reference Include="System" />
 	<Reference Include="System.Core" />
 	<Reference Include="System.Xml" />
 	<Reference Include="System.Runtime.Serialization" />
-	<PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
 	<Reference Include="Microsoft.CSharp" />
 	<Reference Include="Mono.Android" />
 	<Reference Include="System" />
 	<Reference Include="System.Core" />
 	<Reference Include="System.Xml" />
 	<Reference Include="System.Runtime.Serialization" />
-	<PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;Xamarin.iOS1014;MonoAndroid80</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
     <AssemblyName>Microsoft.Graph.DotnetCore.Core.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Core.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
 	<!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS1014'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
 	<TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
 	<TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
 	<DefineConstants>$(DefineConstants);iOS</DefineConstants>
@@ -53,7 +53,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS1014' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
 	<Reference Include="Microsoft.CSharp" />
 	<Reference Include="Xamarin.iOS" />
 	<Reference Include="System" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockTokenCredential.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockTokenCredential.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
+{
+    using Moq;
+    using Azure.Core;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class MockTokenCredential : Mock<TokenCredential>
+    {
+        public MockTokenCredential()
+            : base(MockBehavior.Strict)
+        {
+            this.SetupAllProperties();
+
+            this.Setup( tokenCredential => tokenCredential.GetTokenAsync( It.IsAny<TokenRequestContext>(),CancellationToken.None ))
+                .Returns( new ValueTask<AccessToken>(new AccessToken("mockToken", DateTimeOffset.UtcNow.AddMinutes(10))));
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
@@ -9,10 +9,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     public class BaseClientTests
     {
         private MockAuthenticationProvider authenticationProvider;
+        private MockTokenCredential tokenCredential;
 
         public BaseClientTests()
         {
             this.authenticationProvider = new MockAuthenticationProvider();
+            this.tokenCredential = new MockTokenCredential();
         }
 
         [Fact]
@@ -41,6 +43,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             ServiceException exception = Assert.Throws<ServiceException>(() => new BaseClient(null, this.authenticationProvider.Object));
             Assert.Equal(ErrorConstants.Codes.InvalidRequest, exception.Error.Code);
             Assert.Equal(ErrorConstants.Messages.BaseUrlMissing, exception.Error.Message);
+        }
+
+        [Fact]
+        public void BaseClient_InitializeWithTokenCredential()
+        {
+            var expectedBaseUrl = "https://localhost";
+
+            var baseClient = new BaseClient(expectedBaseUrl, this.tokenCredential.Object);
+
+            Assert.Equal(expectedBaseUrl, baseClient.BaseUrl);
+            Assert.IsType<TokenCredentialAuthProvider>(baseClient.AuthenticationProvider);
+
         }
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request
1. Adds support for TokenCredentials from Azure.Identity by adding TokenCredential Auth provider.

Therefore one can make use a TokenCredential from Azure.Identity to make calls like the example below which uses the InteractiveBrowserCredential.

```cs
string clientId = "clientId";
string[] scopes = new[] { "User.Read", "Mail.ReadWrite" };

InteractiveBrowserCredential myBrowserCredential = new InteractiveBrowserCredential(clientId);
TokenCredentialAuthProvider tokenCredentialAuthProvider = new TokenCredentialAuthProvider(myBrowserCredential, scopes);

//Try to get something from the Graph!!
HttpClient httpClient = GraphClientFactory.Create(tokenCredentialAuthProvider);
HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/");
HttpResponseMessage response = await httpClient.SendAsync(requestMessage);
```

2. Adds baseclient constructor to take in tokencredential to the baseclient
This is done so as to enable a future case in the service library that would looks as below
```cs
string[] scopes = new[] { "User.Read", "Mail.ReadWrite" };
InteractiveBrowserCredential myBrowserCredential = new InteractiveBrowserCredential(clientId);

//Try to get something from the Graph!!
GraphServiceClient graphClient = new GraphServiceClient(myBrowserCredential);

var user = await graphClient.Me.Request().WithScopes(scopes).GetAsync();
```
3. Updates runtimes to .net standard 2.0
4. Adds an IntergratedWindowsTokenCredential not provided by Azure.Identity

This can be used with the core library as follows
```cs
string clientId = "clientId";
string authority = "https://login.microsoftonline.com/organizations/";
string[] scopes = new[] { "User.Read", "Mail.ReadWrite" };

IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
    .Create(clientId)
    .Build();

IntegratedWindowsTokenCredential integratedWindowsTokenCredential = new IntegratedWindowsTokenCredential(publicClientApplication);
TokenCredentialAuthProvider tokenCredentialAuthProvider = new TokenCredentialAuthProvider(integratedWindowsTokenCredential, scopes);

//Try to get something from the Graph!!
HttpClient httpClient = GraphClientFactory.Create(tokenCredentialAuthProvider);

HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me");
```
5. Tests have been added to validate the various changes made above.