### PR TITLE
Update previewBuild.yml for Azure Pipelines

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
     - dev
+    - feature/2.0
   paths:
     include:
       - src/*


### PR DESCRIPTION
I believe this is why we aren't seeing feature/2.0 preview builds kicking off.

Add feature/2.0 branch path spec.

@andrueastman