### PR TITLE
Batch Requests with System.Text.Json

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -84,7 +84,7 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.9.0" />
     <PackageReference Include="Azure.Core" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -86,5 +86,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.7.1" />
     <PackageReference Include="Azure.Core" Version="1.0.1" />
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Graph.Core.Requests
 {
-    using Newtonsoft.Json.Linq;
+    using System.IO;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -49,9 +49,11 @@ namespace Microsoft.Graph.Core.Requests
         {
             this.ContentType = "application/json";
             this.Method = "POST";
-            JObject serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false);
-            HttpResponseMessage httpResponseMessage = await this.SendRequestAsync(serializableContent, cancellationToken).ConfigureAwait(false);
-            return new BatchResponseContent(httpResponseMessage);
+            using (Stream serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false))
+            {
+                HttpResponseMessage httpResponseMessage = await this.SendRequestAsync(serializableContent, cancellationToken).ConfigureAwait(false);
+                return new BatchResponseContent(httpResponseMessage);
+            }
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Graph
             {
                 writer.WritePropertyName(CoreConstants.BatchRequest.Headers);
                 writer.WriteStartObject();
-                foreach (KeyValuePair<string, IEnumerable<string>> header in batchRequestStep.Request.Content.Headers)
+                foreach (var header in batchRequestStep.Request.Content.Headers)
                 {
                     writer.WriteString(header.Key, GetHeaderValuesAsString(header.Value));
                 }
@@ -248,8 +248,10 @@ namespace Microsoft.Graph
             if (batchRequestStep.Request != null && batchRequestStep.Request.Content != null)
             {
                 writer.WritePropertyName(CoreConstants.BatchRequest.Body);
-                JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request);
-                content.WriteTo(writer);
+                using (JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request))
+                {
+                    content.WriteTo(writer);
+                }
             }
             writer.WriteEndObject();//close root object.
         }

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -4,8 +4,6 @@
 
 namespace Microsoft.Graph
 {
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -14,6 +12,7 @@ namespace Microsoft.Graph
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
+    using System.Text.Json;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -176,17 +175,37 @@ namespace Microsoft.Graph
             return isRemoved;
         }
 
-        internal async Task<JObject> GetBatchRequestContentAsync()
+        /// <summary>
+        /// Get the content of the batchRequest in the form of a stream.
+        /// It is the responsibility of the caller to dispose of the stream returned.
+        /// </summary>
+        /// <returns>A stream object with the contents of the batch request</returns>
+        internal async Task<Stream> GetBatchRequestContentAsync()
         {
-            JObject batchRequest = new JObject();
-            JArray batchRequestItems = new JArray();
+            var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();//open the root object
+                writer.WritePropertyName(CoreConstants.BatchRequest.Requests);// requests property name
 
-            foreach (KeyValuePair<string, BatchRequestStep> batchRequestStep in BatchRequestSteps)
-                batchRequestItems.Add(await GetBatchRequestContentFromStepAsync(batchRequestStep.Value));
+                //write the elements of the requests array
+                writer.WriteStartArray();
+                foreach (KeyValuePair<string, BatchRequestStep> batchRequestStep in BatchRequestSteps)
+                {
+                    await WriteBatchRequestStepAsync(batchRequestStep.Value, writer);
+                }
+                writer.WriteEndArray();
 
-            batchRequest.Add(CoreConstants.BatchRequest.Requests, batchRequestItems);
+                
+                writer.WriteEndObject();//close the root object
+                writer.Flush();
+                stream.Flush();
 
-            return batchRequest;
+                //Reset the position since we want the caller to use this stream
+                stream.Position = 0;
+
+                return stream;
+            }
         }
 
         private bool ContainsCorrespondingRequestId(IList<string> dependsOn)
@@ -194,37 +213,55 @@ namespace Microsoft.Graph
         	return dependsOn.All(requestId => BatchRequestSteps.ContainsKey(requestId));
         }
 
-        private async Task<JObject> GetBatchRequestContentFromStepAsync(BatchRequestStep batchRequestStep)
+        private async Task WriteBatchRequestStepAsync(BatchRequestStep batchRequestStep, Utf8JsonWriter writer)
         {
-            JObject jRequestContent = new JObject
-            {
-                { CoreConstants.BatchRequest.Id, batchRequestStep.RequestId },
-                { CoreConstants.BatchRequest.Url, GetRelativeUrl(batchRequestStep.Request.RequestUri) },
-                { CoreConstants.BatchRequest.Method, batchRequestStep.Request.Method.Method }
-            };
-            if (batchRequestStep.DependsOn != null && batchRequestStep.DependsOn.Count() > 0)
-                jRequestContent.Add(CoreConstants.BatchRequest.DependsOn, new JArray(batchRequestStep.DependsOn));
+            writer.WriteStartObject();// open root object
+            writer.WriteString(CoreConstants.BatchRequest.Id, batchRequestStep.RequestId);//write the id property
+            writer.WriteString(CoreConstants.BatchRequest.Url, GetRelativeUrl(batchRequestStep.Request.RequestUri));//write the url property
+            writer.WriteString(CoreConstants.BatchRequest.Method, batchRequestStep.Request.Method.Method);// write the method property
 
-            if (batchRequestStep.Request.Content?.Headers != null && batchRequestStep.Request.Content.Headers.Count() > 0)
-                jRequestContent.Add(CoreConstants.BatchRequest.Headers, GetContentHeader(batchRequestStep.Request.Content.Headers));
-
-            if(batchRequestStep.Request != null && batchRequestStep.Request.Content != null)
+            // if the step depends on another step, write it
+            if (batchRequestStep.DependsOn != null && batchRequestStep.DependsOn.Any())
             {
-                jRequestContent.Add(CoreConstants.BatchRequest.Body, await GetRequestContentAsync(batchRequestStep.Request));
+                writer.WritePropertyName(CoreConstants.BatchRequest.DependsOn);
+                writer.WriteStartArray();
+                foreach (var value in batchRequestStep.DependsOn)
+                {
+                    writer.WriteStringValue(value);//write the id it depends on
+                }
+                writer.WriteEndArray();
             }
 
-            return jRequestContent;
+            // write any headers the step contains
+            if (batchRequestStep.Request.Content?.Headers != null && batchRequestStep.Request.Content.Headers.Any())
+            {
+                writer.WritePropertyName(CoreConstants.BatchRequest.Headers);
+                writer.WriteStartObject();
+                foreach (KeyValuePair<string, IEnumerable<string>> header in batchRequestStep.Request.Content.Headers)
+                {
+                    writer.WriteString(header.Key, GetHeaderValuesAsString(header.Value));
+                }
+                writer.WriteEndObject();
+            }
+
+            // write the content of the step if it has any
+            if (batchRequestStep.Request != null && batchRequestStep.Request.Content != null)
+            {
+                writer.WritePropertyName(CoreConstants.BatchRequest.Body);
+                JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request);
+                content.WriteTo(writer);
+            }
+            writer.WriteEndObject();//close root object.
         }
 
-        private async Task<JObject> GetRequestContentAsync(HttpRequestMessage request)
+        private async Task<JsonDocument> GetRequestContentAsync(HttpRequestMessage request)
         {
             try
             {
                 HttpRequestMessage clonedRequest = await request.CloneAsync();
-
                 using (Stream streamContent = await clonedRequest.Content.ReadAsStreamAsync())
                 {
-                    return Serializer.DeserializeObject<JObject>(streamContent);
+                    return JsonDocument.Parse(streamContent);
                 }
             }
             catch (Exception ex)
@@ -235,16 +272,6 @@ namespace Microsoft.Graph
                     Message = ErrorConstants.Messages.UnableToDeserializexContent
                 }, ex);
             }
-        }
-
-        private JObject GetContentHeader(HttpContentHeaders headers)
-        {
-            JObject jHeaders = new JObject();
-            foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
-            {
-                jHeaders.Add(header.Key, GetHeaderValuesAsString(header.Value));
-            }
-            return jHeaders;
         }
 
         private string GetHeaderValuesAsString(IEnumerable<string> headerValues)
@@ -278,11 +305,9 @@ namespace Microsoft.Graph
         /// <returns></returns>
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            using (StreamWriter streamWritter = new StreamWriter(stream, new UTF8Encoding(), 1024, true))
-            using (JsonTextWriter textWritter = new JsonTextWriter(streamWritter))
+            using (Stream batchContent = await GetBatchRequestContentAsync())
             {
-                JObject batchContent = await GetBatchRequestContentAsync();
-                batchContent.WriteTo(textWritter);
+                await batchContent.CopyToAsync(stream);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Authentication
 {
+    using System;
     using Azure.Core;
     using Microsoft.Identity.Client;
     using Xunit;
@@ -34,10 +35,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Authentication
         {
             IEnumerable<string> scopes = new List<string> { "User.ReadBasic.All" };
 
-            AuthenticationException ex = Assert.Throws<AuthenticationException>(() => new IntegratedWindowsTokenCredential(null));
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => new IntegratedWindowsTokenCredential(null));
 
-            Assert.Equal(ex.Error.Code, ErrorConstants.Codes.InvalidRequest);
-            Assert.Equal(ex.Error.Message, string.Format(ErrorConstants.Messages.NullValue, "publicClientApplication"));
+            Assert.Equal(ex.ParamName, "publicClientApplication");
         }
 
     }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -236,8 +236,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             string requestContent;
             // we do this to get a version of the json that is indented 
             using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
+            using (JsonDocument jsonDocument = JsonDocument.Parse(requestStream))
             {
-                JsonDocument jsonDocument = JsonDocument.Parse(requestStream);
                 requestContent = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
             }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -4,12 +4,12 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 {
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.IO;
+    using System.Text.Json;
     using Xunit;
 
     public class BatchRequestContentTests
@@ -176,11 +176,16 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             batchRequestContent.RemoveBatchRequestStepWithId("1");
 
-            JObject requestContent = await batchRequestContent.GetBatchRequestContentAsync();
-
-            string expectedJson = "{\"requests\":[{\"id\":\"2\",\"url\":\"/me\",\"method\":\"GET\"}]}";
-            JObject expectedContent = JsonConvert.DeserializeObject<JObject>(expectedJson);
-
+            string requestContent;
+            // We get the contents of the stream as string for comparison.
+            using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
+            using (StreamReader reader = new StreamReader(requestStream))
+            {
+                requestContent = reader.ReadToEnd();
+            }
+            
+            string expectedContent = "{\"requests\":[{\"id\":\"2\",\"url\":\"/me\",\"method\":\"GET\"}]}";
+            
             Assert.NotNull(requestContent);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(expectedContent, requestContent);
@@ -189,8 +194,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
         [Fact]
         public async System.Threading.Tasks.Task BatchRequestContent_GetBatchRequestContentFromStepAsyncDoesNotModifyDateTimes()
         {
+            // System.Text.Json is strict on json content by default. So make sure that there are no 
+            // trailing comma's and special characters
             var payloadString = "{\r\n" +
-                                "  \"subject\": \"Let's go for lunch\",\r\n" +
+                                "  \"subject\": \"Lets go for lunch\",\r\n" +
                                 "  \"body\": {\r\n    \"contentType\": \"HTML\",\r\n" +
                                 "    \"content\": \"Does mid month work for you?\"\r\n" +
                                 "  },\r\n" +
@@ -202,7 +209,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                 "      \"dateTime\": \"2019-03-15T14:00:00.0000\",\r\n" +
                                 "      \"timeZone\": \"Pacific Standard Time\"\r\n" +
                                 "  },\r\n  \"location\":{\r\n" +
-                                "      \"displayName\":\"Harry's Bar\"\r\n" +
+                                "      \"displayName\":\"Harrys Bar\"\r\n" +
                                 "  },\r\n" +
                                 "  \"attendees\": [\r\n" +
                                 "    {\r\n" +
@@ -226,8 +233,13 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             batchRequestContent.AddBatchRequestStep(batchRequestStep1);
             batchRequestContent.AddBatchRequestStep(batchRequestStep2);
 
-            JObject requestContent = await batchRequestContent.GetBatchRequestContentAsync();
-            string content = requestContent.ToString();
+            string requestContent;
+            // we do this to get a version of the json that is indented 
+            using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
+            {
+                JsonDocument jsonDocument = JsonDocument.Parse(requestStream);
+                requestContent = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
+            }
 
             string expectedJson = "{\r\n" +
                                   "  \"requests\": [\r\n" +
@@ -247,7 +259,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                   "        \"Content-Type\": \"text/plain; charset=utf-8\"\r\n" +
                                   "      },\r\n" +
                                   "      \"body\": {\r\n" +
-                                  "        \"subject\": \"Let's go for lunch\",\r\n" +
+                                  "        \"subject\": \"Lets go for lunch\",\r\n" +
                                   "        \"body\": {\r\n" +
                                   "          \"contentType\": \"HTML\",\r\n" +
                                   "          \"content\": \"Does mid month work for you?\"\r\n" +
@@ -261,7 +273,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                   "          \"timeZone\": \"Pacific Standard Time\"\r\n" +
                                   "        },\r\n" +
                                   "        \"location\": {\r\n" +
-                                  "          \"displayName\": \"Harry's Bar\"\r\n" +
+                                  "          \"displayName\": \"Harrys Bar\"\r\n" +
                                   "        },\r\n" +
                                   "        \"attendees\": [\r\n" +
                                   "          {\r\n" +
@@ -279,7 +291,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             Assert.NotNull(requestContent);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(2));
-            Assert.Equal(expectedJson, content);
+            Assert.Equal(expectedJson, requestContent);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
         [Fact]
         public async Task BatchResponseContent_InitializeWithEmptyResponseContentAsync()
         {
-            string jsonResponse = "{ responses: [] }";
+            string jsonResponse = "{ \"responses\": [] }";
             HttpContent content = new StringContent(jsonResponse);
             HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest);
             httpResponseMessage.Content = content;
@@ -221,7 +221,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                   "                },\n" +
                                   "                \"body\": {\n" +
                                   "                    \"contentType\": \"html\",\n" +
-                                  "                    \"content\": \"<html>\\r\\n<head>\\r\\n<meta http-\",\n" +
+                                  "                    \"content\": \"<html>\\r\\n<head>\\r\\n<meta http-\"\n" +
 
                                   "                },\n" +
                                   "                \"start\": {\n" +


### PR DESCRIPTION
### Changes proposed in this PR
This pull request introduces the use of System.Text.Json for marshalling and unmarshalling of batch requests and therefore the change involves the replacement of Newtonsoft in the batch request code.

- As System.Text.Json still does not have a writable Json Dom(equivalents for JArray,JObject etc) the code involves the use of the Utf8JsonWriter to write out json in instances where json writing is needed.

- The previous tests that existed are unbroken by the change. This therefore validates that the functionality remains the same with the added benefits of System.Text.Json. 😄 

### Usage (Unchanged)
Making of batch requests remains the same and can be done as before as follows: - 

```csharp
// Create http GET request.
HttpRequestMessage httpRequestMessage1 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/");

// Create http POST request.
String jsonContent = "{" +
            "\"displayName\": \"My Notebook\"" +
            "}";
HttpRequestMessage httpRequestMessage2 = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/onenote/notebooks");
httpRequestMessage2.Content = new StringContent(jsonContent, Encoding.UTF8, "application/json");

// Create batch request steps with request ids.
BatchRequestStep requestStep1 = new BatchRequestStep("1", httpRequestMessage1, null);
BatchRequestStep requestStep2 = new BatchRequestStep("2", httpRequestMessage2, new List<string> { "1" });

// Add batch request steps to BatchRequestContent.
BatchRequestContent batchRequestContent = new BatchRequestContent();
batchRequestContent.AddBatchRequestStep(requestStep1);
batchRequestContent.AddBatchRequestStep(requestStep2);

// Send batch request with BatchRequestContent.
HttpResponseMessage response = await httpClient.PostAsync("https://graph.microsoft.com/v1.0/$batch", batchRequestContent);

// Handle http responses using BatchResponseContent.
BatchResponseContent batchResponseContent = new BatchResponseContent(response);
Dictionary<string, HttpResponseMessage> responses = await batchResponseContent.GetResponsesAsync();
HttpResponseMessage httpResponse = await batchResponseContent.GetResponseByIdAsync("1");
string nextLink = await batchResponseContent.GetNextLinkAsync();
```

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- [Batch Request Content SDK Design](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/content/BatchRequestContent.md)
- [Batch Response Content SDK Design](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/content/BatchResponseContent.md)