### PR TITLE
Support native plaform Http handlers for Xamarin.Mac

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -4,7 +4,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.1;net45;Xamarin.iOS10;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
     <PackageId>Microsoft.Graph.Core</PackageId>
@@ -34,6 +34,13 @@
     <DefineConstants>$(DefineConstants);iOS</DefineConstants>
     <DebugType>full</DebugType>
     <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);macOS</DefineConstants>
+    <DebugType>full</DebugType>
+    <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
@@ -72,6 +79,15 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
 	<Reference Include="Xamarin.iOS" />
+	<Reference Include="System" />
+	<Reference Include="System.Core" />
+	<Reference Include="System.Xml" />
+	<Reference Include="Microsoft.CSharp" />
+	<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+	<PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
+	<Reference Include="Xamarin.Mac" />
 	<Reference Include="System" />
 	<Reference Include="System.Core" />
 	<Reference Include="System.Xml" />

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -179,8 +179,8 @@ namespace Microsoft.Graph
                     throw new ArgumentNullException(nameof(handlers), "DelegatingHandler array contains null item.");
                 }
 
-#if iOS
-                // Skip CompressionHandler since NSUrlSessionHandler automatically handles decompression on iOS and it can't be turned off.
+#if iOS || macOS
+                // Skip CompressionHandler since NSUrlSessionHandler automatically handles decompression on iOS and macOS and it can't be turned off.
                 // See issue https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/481 for more details.
                 if (finalHandler.GetType().Equals(typeof(NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
                 {
@@ -206,17 +206,17 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Gets a platform's native http handler i.e. NSUrlSessionHandler for Xamarin.iOS, AndroidClientHandler for Xamarin.Android and HttpClientHandler for others.
+        /// Gets a platform's native http handler i.e. NSUrlSessionHandler for Xamarin.iOS and Xamarin.Mac, AndroidClientHandler for Xamarin.Android and HttpClientHandler for others.
         /// </summary>
         /// <param name="proxy">The proxy to be used with created client.</param>
         /// <returns>
-        /// 1. NSUrlSessionHandler for Xamarin.iOS 
+        /// 1. NSUrlSessionHandler for Xamarin.iOS and Xamarin.Mac
         /// 2. AndroidClientHandler for Xamarin.Android.
         /// 3. HttpClientHandler for other platforms.
         /// </returns>
         internal static HttpMessageHandler GetNativePlatformHttpHandler(IWebProxy proxy = null)
         {
-#if iOS
+#if iOS || macOS
             return new NSUrlSessionHandler { AllowAutoRedirect = false };
 #elif ANDROID
             return new Xamarin.Android.Net.AndroidClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;Xamarin.iOS10;MonoAndroid70</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;Xamarin.iOS10;Xamarin.Mac20;MonoAndroid70</TargetFrameworks>
     <AssemblyName>Microsoft.Graph.DotnetCore.Core.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Core.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -23,6 +23,14 @@
 	<DefineConstants>$(DefineConstants);iOS</DefineConstants>
 	<DebugType>full</DebugType>
 	<LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">
+	<TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+	<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+	<DefineConstants>$(DefineConstants);macOS</DefineConstants>
+	<DebugType>full</DebugType>
+	<LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
@@ -61,7 +69,17 @@
 	<Reference Include="System.Runtime.Serialization" />
 	<PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
+	<Reference Include="Microsoft.CSharp" />
+	<Reference Include="Xamarin.Mac" />
+	<Reference Include="System" />
+	<Reference Include="System.Core" />
+	<Reference Include="System.Xml" />
+	<Reference Include="System.Runtime.Serialization" />
+	<PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
 	<Reference Include="Microsoft.CSharp" />
 	<Reference Include="Mono.Android" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         // and 'GraphClientFactory.DefaultHttpHandler' can easily be modified
         // by other tests since it's a static delegate.
 
-#if iOS
+#if iOS || macOS
         [Fact]
         public void Should_CreatePipeline_Without_CompressionHandler()
         {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 #if ANDROID
                 Assert.IsType<Xamarin.Android.Net.AndroidClientHandler>(defaultHttpProvider.httpMessageHandler);
                 Assert.False((defaultHttpProvider.httpMessageHandler as Xamarin.Android.Net.AndroidClientHandler).AllowAutoRedirect);
-#elif iOS
+#elif iOS || macOS
                 Assert.IsType<NSUrlSessionHandler>(defaultHttpProvider.httpMessageHandler);
                 Assert.False((defaultHttpProvider.httpMessageHandler as NSUrlSessionHandler).AllowAutoRedirect);
 #else
@@ -554,8 +554,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 #endif
         #endregion
 
-        #region iOS
-#if iOS
+        #region iOS_macOS
+#if iOS || macOS
         [Fact]
         public void HttpProvider_CustomNSUrlSessionHandler()
         {


### PR DESCRIPTION
This PR adds support for native http handler when targeting Xamarin.Mac (NSUrlSessionHandler)

### Fixes

#413 Cannot download multiple OneDrive files concurrently since v.1.13.0-beta
