### PR TITLE
Support JSON array of primitives

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -169,9 +169,15 @@ namespace Microsoft.Graph
                     {
                         string parentWithIndex = $"{parent}[{i}]";
 
-                        JObject collectionItem = collection[i] as JObject;
-
-                        await GetObjectProperties(collectionItem, changes, parentWithIndex);
+                        if (collection[i] is JObject)
+                        {
+                            JObject collectionItem = collection[i] as JObject;
+                            await GetObjectProperties(collectionItem, changes, parentWithIndex);
+                        }
+                        else // Assuming that this is a JValue.
+                        {
+                            changes.Add(parentWithIndex);
+                        }
                     }
                 }
                 else if (property.Value is JValue)


### PR DESCRIPTION
Fixes #93. The propertyValue of an array item can be a JObject or a JValue in the case of a primitive.

@andtu - It wasn't handling this:

            "proxyAddresses": [
                "SMTP:user@contoso.com"
            ],