### PR TITLE
DeltaResponseHandler with System.Text.Json

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -67,9 +67,16 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run enabled tests'
-  # inputs:
-  #   testAssemblyVer2: '**\Microsoft.Graph.DotnetCore.Core.Test.dll'
-  #   searchFolder: '$(System.DefaultWorkingDirectory)'
+  inputs:
+    testAssemblyVer2: |
+      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      !**/*TestAdapter.dll
+      !**/obj/**
+    diagnosticsEnabled: true
+    configuration: debug
+    searchFolder: 'tests'
+    platform: AnyCPU
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
 
 - task: PowerShell@2
   displayName: 'Enable signing'

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -64,9 +64,16 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run enabled tests'
-  # inputs:
-  #   testAssemblyVer2: '**\Microsoft.Graph.DotnetCore.Core.Test.dll'
-  #   searchFolder: '$(System.DefaultWorkingDirectory)'
+  inputs:
+    testAssemblyVer2: |
+      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      !**/*TestAdapter.dll
+      !**/obj/**
+    diagnosticsEnabled: true
+    configuration: debug
+    searchFolder: 'tests'
+    platform: AnyCPU
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
 
 - task: PowerShell@2
   displayName: 'Enable signing'

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -69,9 +69,16 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run enabled tests'
-  # inputs:
-  #   testAssemblyVer2: '**\Microsoft.Graph.DotnetCore.Core.Test.dll'
-  #   searchFolder: '$(System.DefaultWorkingDirectory)'
+  inputs:
+    testAssemblyVer2: |
+      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      !**/*TestAdapter.dll
+      !**/obj/**
+    diagnosticsEnabled: true
+    configuration: debug
+    searchFolder: 'tests'
+    platform: AnyCPU
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
 
 - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
   displayName: 'Graph Client Tooling pipeline fail notification'

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -23,6 +23,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Adds support for TokenCredential from Azure.Core
+      - Adds support for System.Text,Json and drops Newtonsoft.Json dependency
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -83,7 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.9.0" />
     <PackageReference Include="Azure.Core" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadResponseHandler.cs
@@ -67,7 +67,10 @@ namespace Microsoft.Graph
                      */
                     if (response.StatusCode == HttpStatusCode.Created)
                     {
-                        uploadResult.ItemResponse = this._serializer.DeserializeObject<T>(responseSteam);
+                        if(responseSteam.Length > 0) //system.text.json wont deserialize an empty string
+                        {
+                            uploadResult.ItemResponse = this._serializer.DeserializeObject<T>(responseSteam);
+                        }
                         uploadResult.Location = response.Headers.Location;
                     }
                     else

--- a/src/Microsoft.Graph.Core/Serialization/InterfaceConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/InterfaceConverter.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Graph
             return (T)derivedTypeConverter.Read(ref reader, typeof(T), options);
         }
 
+        /// <summary>
+        /// Serializes object to writer
+        /// </summary>
+        /// <param name="writer">The <see cref="Utf8JsonWriter"/> to serialize to</param>
+        /// <param name="value">The value to serialize</param>
+        /// <param name="options">The serializer options to use.</param>
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(writer, value, typeof(T));

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Authentication/IntegrateWindowsTokenCredentialTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Authentication
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => new IntegratedWindowsTokenCredential(null));
 
-            Assert.Equal(ex.ParamName, "publicClientApplication");
+            Assert.Equal("publicClientApplication", ex.ParamName);
         }
 
     }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -42,7 +42,6 @@
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 	<PackageReference Include="Moq" Version="4.10.1" />
 	<PackageReference Include="xunit" Version="2.4.1" />
-	<PackageReference Include="Microsoft.Graph" Version="1.*" />
 	<ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
   

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
     using System.Net.Http;
     using Xunit;
     using System.Threading.Tasks;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
 
     public class BatchResponseContentTests
     {
@@ -125,7 +126,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
         }
 
 
-        [Fact(Skip = "Service Library needs to support System.Text.Json Attributes")]
+        [Fact]
         public async Task BatchResponseContent_GetResponseByIdAsyncWithDeseirializer()
         {
             // Arrange
@@ -163,31 +164,31 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             BatchResponseContent batchResponseContent = new BatchResponseContent(httpResponseMessage);
 
             // Act
-            User user = await batchResponseContent.GetResponseByIdAsync<User>("1");
+            TestUser user = await batchResponseContent.GetResponseByIdAsync<TestUser>("1");
             // Assert we have a valid user
             Assert.Equal("MOD Administrator", user.DisplayName);
 
             // Act
-            Drive drive = await batchResponseContent.GetResponseByIdAsync<Drive>("2");
+            TestDrive drive = await batchResponseContent.GetResponseByIdAsync<TestDrive>("2");
             // Assert we have a valid drive object
             Assert.Equal("b!random-VkHdanfIomf", drive.Id);
             Assert.Equal("OneDrive", drive.Name);
 
             // Act
-            Notebook notebook = await batchResponseContent.GetResponseByIdAsync<Notebook>("3");
+            TestNoteBook notebook = await batchResponseContent.GetResponseByIdAsync<TestNoteBook>("3");
             // Assert we have a valid notebook object
             Assert.Equal("1-9f4fe8ea-7e6e-486e-a8f4-nothing-here", notebook.Id);
             Assert.Equal("My Notebook -442293399", notebook.DisplayName);
 
             // Act
-            ServiceException serviceException = await Assert.ThrowsAsync<ServiceException>(() => batchResponseContent.GetResponseByIdAsync<DriveItem>("4"));
+            ServiceException serviceException = await Assert.ThrowsAsync<ServiceException>(() => batchResponseContent.GetResponseByIdAsync<TestDriveItem>("4"));
             // Assert we detect the incorrect response and give usable Service Exception
             Assert.Equal("20117", serviceException.Error.Code);
             Assert.Equal(HttpStatusCode.Conflict, serviceException.StatusCode);//status 409
             Assert.NotNull(serviceException.RawResponseBody);
         }
 
-        [Fact(Skip = "Service Library needs to support System.Text.Json Attributes")]
+        [Fact]
         public async Task BatchResponseContent_GetResponseByIdAsyncWithDeserializerWorksWithDateTimeOffsets()
         {
             // Arrange an example Event object with a few properties
@@ -246,7 +247,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             BatchResponseContent batchResponseContent = new BatchResponseContent(httpResponseMessage);
 
             // Act
-            Event eventItem = await batchResponseContent.GetResponseByIdAsync<Event>("3");
+            TestEvent eventItem = await batchResponseContent.GetResponseByIdAsync<TestEvent>("3");
 
             // Assert we have a valid datetime in the event
             Assert.Equal("2019-07-30T23:00:00.0000000", eventItem.End.DateTime);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/RetryHandlerTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
 
-        [Theory]
+        [Theory(Skip = "skip test")] // Takes 9 minutes to run for each scenario
         [InlineData(HttpStatusCode.GatewayTimeout)]  // 504
         [InlineData(HttpStatusCode.ServiceUnavailable)]  // 503
         [InlineData((HttpStatusCode)429)] // 429

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -1,21 +1,23 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 {
-    using Newtonsoft.Json.Linq;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Text;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Xunit;
     using Microsoft.Graph;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using System.Linq;
+    using System;
 
     public class ResponseHandlerTests
     {
-        [Fact(Skip = "Service Library needs to support System.Text.Json Attributes")]
+        [Fact]
         public async Task HandleUserResponse()
         {
             // Arrange
@@ -32,52 +34,110 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             hrm.Headers.Add("test", "value");
 
             // Act
-            var user = await responseHandler.HandleResponse<User>(hrm);
+            var user = await responseHandler.HandleResponse<TestUser>(hrm);
 
             //Assert
             Assert.Equal("123", user.Id);
             Assert.Equal("Joe", user.GivenName);
             Assert.Equal("Brown", user.Surname);
-            Assert.Equal("OK", user.AdditionalData["statusCode"]);
-            var headers = (JObject)(user.AdditionalData["responseHeaders"]);
-            Assert.Equal("value", (string)headers["test"][0]);
+            Assert.Equal("OK", user.AdditionalData["statusCode"].ToString());
+            var headers = (JsonElement)(user.AdditionalData["responseHeaders"]);
+            var headerValue = headers.GetProperty("test");
+            Assert.Equal("value", headerValue.EnumerateArray().ElementAt(0).ToString());
         }
 
-        [Fact(Skip = "To Do: Refactor Delta Response Handler")]
+        /// <summary>
+        /// We assumed that JSON arrays only contained objects. We need to test that
+        /// we account for array of primitives.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task HandleEventDeltaResponseWithArrayOfPrimitives()
+        {
+            // Arrange
+            var deltaResponseHandler = new DeltaResponseHandler();
+        
+            // Contains string, int, and boolean arrays.
+            var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(user)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/users/delta?$skiptoken=R0usmci39O\",\"value\":[{\"id\":\"AAMkADVxTAAA=\",\"arrayOfString\":[\"SMTP:alexd@contoso.com\",\"SMTP:meganb@contoso.com\"]},{\"id\":\"AAMkADVxUAAA=\",\"arrayOfBool\":[true,false]},{\"id\":\"AAMkADVxVAAA=\",\"arrayOfInt\":[2,5]}]}";
+        
+            var hrm = new HttpResponseMessage()
+            {
+                Content = new StringContent(testString,
+                                Encoding.UTF8,
+                                "application/json")
+            };
+        
+            // Act
+            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<TestEventDeltaCollectionResponse>(hrm);
+        
+            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JsonElement>(hrm);
+            string actualStringValue = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(0)
+                .GetProperty("arrayOfString").EnumerateArray().ElementAt(0).ToString(); //value[0].arrayOfString[0]
+            bool actualBoolValue = Convert.ToBoolean(deltaJObjectResponse.GetProperty("value").EnumerateArray()
+                .ElementAt(1).GetProperty("arrayOfBool").EnumerateArray().ElementAt(1).ToString()); //value[1].arrayOfBool[1]
+            int actualIntValue = Convert.ToInt32((string)deltaJObjectResponse.GetProperty("value").EnumerateArray()
+                .ElementAt(2).GetProperty("arrayOfInt").EnumerateArray().ElementAt(1).ToString());// value[2].arrayOfInt[1]
+
+            string arrayOfString = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(0)
+                .GetProperty("changes").EnumerateArray().ElementAt(2).ToString();
+            string arrayOfBool = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(1)
+                .GetProperty("changes").EnumerateArray().ElementAt(2).ToString();
+            string arrayOfInt = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(2)
+                .GetProperty("changes").EnumerateArray().ElementAt(2).ToString();
+
+            // Assert that it actually deserialized into a model we expect.
+            Assert.True(deltaServiceLibResponse.Value is ITestEventDeltaCollectionPage); // We create a valid ICollectionPage.
+        
+            // Assert that the value is set.
+            Assert.Equal("SMTP:alexd@contoso.com", actualStringValue);
+            Assert.False(actualBoolValue);
+            Assert.Equal(5, actualIntValue);
+        
+            // Assert that the change manifest is set.
+            Assert.Equal("arrayOfString[1]", arrayOfString); // The third change is the second string array item.
+            Assert.Equal("arrayOfBool[1]", arrayOfBool);
+            Assert.Equal("arrayOfInt[1]", arrayOfInt);
+        }
+
+        [Fact]
         public async Task HandleEventDeltaResponse()
         {
             // Arrange
             var deltaResponseHandler = new DeltaResponseHandler();
-
+        
             // TestString represents a page of results with a nextLink. There are two changed events.
             // The events have key:value properties, key:object properties, and key:array properties.
             // To view and format this test string, replace all \" with ", and use a JSON formatter
             // to make it pretty.
             var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"EZ9r3czxY0m2jz8c45czkwAAFXcvIw==\",\"subject\":\"Get food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T19:30:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-10T21:30:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[{\"emailAddress\":{\"name\":\"George\",\"address\":\"george@contoso.onmicrosoft.com\"}},{\"emailAddress\":{\"name\":\"Jane\",\"address\":\"jane@contoso.onmicrosoft.com\"}}],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxTAAA=\"},{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"WEZ9r3czxY0m2jz8c45czkwAAFXcvJA==\",\"subject\":\"Prepare food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T22:00:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-11T00:00:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxUAAA=\"}]}";
-
+        
             var hrm = new HttpResponseMessage()
             {
                 Content = new StringContent(testString, 
                                             Encoding.UTF8, 
                                             "application/json")
             };
-
+        
             // Act
-            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
-            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JObject>(hrm);
-            string attendeeName = (string)deltaJObjectResponse.SelectToken("value[0].attendees[0].emailAddress.name");
-            string attendeeNameInChangelist = (deltaJObjectResponse["value"][0]["changes"] as JArray)[9].ToString();
-            var collectionPage = deltaServiceLibResponse.Value as CollectionPage<Event>;
+            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<TestEventDeltaCollectionResponse>(hrm);
+            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JsonElement>(hrm);
+            string attendeeName = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(0)
+                .GetProperty("attendees").EnumerateArray().ElementAt(0).GetProperty("emailAddress").GetProperty("name")
+                .ToString(); // value[0].attendees[0].emailAddress.name
+            string attendeeNameInChangelist = deltaJObjectResponse.GetProperty("value").EnumerateArray().ElementAt(0)
+                .GetProperty("changes").EnumerateArray().ElementAt(9).ToString();//eltaJObjectResponse["value"][0]["changes"][9]
+            
+            var collectionPage = deltaServiceLibResponse.Value as CollectionPage<TestEvent>;
             var collectionPageHasChanges = collectionPage[0].AdditionalData.TryGetValue("changes", out object obj);
-
+            
             // IEventDeltaCollectionPage is what the service library provides.
             // Can't test against the service library model, since it has a reference to the signed
             // public version of this library. see issue #57 for more info.
             // https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/57
             // Service library testing will need to happen in the service library repo once this is published on NuGet.
-
+            
             // Assert
-            Assert.True(deltaServiceLibResponse.Value is IEventDeltaCollectionPage); // We create a valid ICollectionPage.
+            Assert.True(deltaServiceLibResponse.Value is ITestEventDeltaCollectionPage); // We create a valid ICollectionPage.
             Assert.Equal("George", attendeeName); // We maintain the expected response body when we change it.
             Assert.Equal("attendees[0].emailAddress.name", attendeeNameInChangelist); // We expect that this property is in changelist.
             Assert.True(collectionPageHasChanges); // We expect that the CollectionPage is populated with the changes.
@@ -107,17 +167,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JObject>(hrm);
-            var hasItems = deltaJObjectResponse["value"].HasValues;
-            var odataContextFromJObject = deltaJObjectResponse["@odata.context"].ToString();
-            var odataDeltalinkFromJObject = deltaJObjectResponse["@odata.deltaLink"].ToString();
+            var deltaJObjectResponse = await deltaResponseHandler.HandleResponse<JsonElement>(hrm);
+            var itemsCount = deltaJObjectResponse.GetProperty("value").GetArrayLength();
+            var odataContextFromJObject = deltaJObjectResponse.GetProperty("@odata.context").ToString();
+            var odataDeltalinkFromJObject = deltaJObjectResponse.GetProperty("@odata.deltaLink").ToString();
 
-            Assert.False(hasItems); // We don't expect items in an empty collection page
+            Assert.Equal(0 ,itemsCount); // We don't expect items in an empty collection page
             Assert.Equal(odataContext, odataContextFromJObject); // We expect that the odata.context isn't transformed.
             Assert.Equal(odataDeltalink, odataDeltalinkFromJObject); // We expect that the odata.deltalink isn't transformed.
         }
 
-        [Fact(Skip = "To Do: Refactor Delta Response Handler")]
+        [Fact]
         public async Task HandleEventDeltaResponseWithNullValues()
         {
             // Arrange
@@ -138,22 +198,23 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Assuming this is the developers model that they want to update based on delta query.
-            Event myModel = new Event()
+            TestEvent myModel = new TestEvent()
             {
                 Subject = "Original subject",
-                Body = new ItemBody()
+                Body = new TestItemBody()
                 {
                     Content = "Original body",
-                    ContentType = BodyType.Text
+                    ContentType = TestBodyType.Text
                 },
                 AdditionalData = new Dictionary<string,object>()
             };
 
             // Act
-            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
-            var eventsDeltaCollectionPage = deltaServiceLibResponse.Value as CollectionPage<Event>;
+            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<TestEventDeltaCollectionResponse>(hrm);
+            var eventsDeltaCollectionPage = deltaServiceLibResponse.Value as CollectionPage<TestEvent>;
             eventsDeltaCollectionPage[0].AdditionalData.TryGetValue("changes", out object changes);
-            var changeList = (changes as JArray).ToObject<List<string>>();
+            var changesElement = (JsonElement)changes;
+            var changeList = JsonSerializer.Deserialize<List<string>>(changesElement.GetRawText());
 
             // Updating a non-schematized property on a model such as instance annotations, open types,
             // and schema extensions. We can assume that a customer's  model would not use a dictionary.
@@ -178,7 +239,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 if (myModel.Body == null)
                 {
-                    myModel.Body = new ItemBody();
+                    myModel.Body = new TestItemBody();
                 }
 
                 myModel.Body.Content = eventsDeltaCollectionPage[0].Body.Content;
@@ -196,7 +257,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 {
                     if (myModel.Attendees == null) // Attendees are being added for the first time.
                     {
-                        var attendees = new List<Attendee>();
+                        var attendees = new List<TestAttendee>();
                         attendees.AddRange(eventsDeltaCollectionPage[0].Attendees);
                         myModel.Attendees = attendees;
                     }
@@ -230,14 +291,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         /// Occurs in the response when we call with the deltalink and there are no items to sync.
         /// </summary>
         /// <returns></returns>
-        [Fact(Skip = "To Do: Refactor Delta Response Handler")]
+        [Fact]
         public async Task HandleEventDeltaResponseWithRemovedItem()
         {
             // Arrange
             var deltaResponseHandler = new DeltaResponseHandler();
-            var odataContext = @"https://graph.microsoft.com/v1.0/$metadata#Collection(event)";
-            var odataDeltalink = @"https://graph.microsoft.com/v1.0/me/mailfolders/inbox/messages/delta?$deltatoken=LztZwWjo5IivWBhyxw5rACKxf7mPm0oW6JZZ7fvKxYPS_67JnEYmfQQMPccy6FRun0DWJF5775dvuXxlZnMYhBubC1v4SBVT9ZjO8f7acZI.uCdGKSBS4YxPEbn_Q5zxLSq91WhpGoz9ZKeNZHMWgSA";
-
 
             // Result string with one removed item.
             var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[{\"@removed\":{\"reason\":\"removed\"},\"id\":\"AAMkADVxTAAA=\"}]}";
@@ -250,10 +308,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<EventDeltaCollectionResponse>(hrm);
-            var eventsDeltaCollectionPage = deltaServiceLibResponse.Value as CollectionPage<Event>;
+            var deltaServiceLibResponse = await deltaResponseHandler.HandleResponse<TestEventDeltaCollectionResponse>(hrm);
+            var eventsDeltaCollectionPage = deltaServiceLibResponse.Value as CollectionPage<TestEvent>;
             eventsDeltaCollectionPage[0].AdditionalData.TryGetValue("changes", out object changes);
-            var changeList = (changes as JArray).ToObject<List<string>>();
+            var changesElement = (JsonElement)changes;
+            var changeList = JsonSerializer.Deserialize<List<string>>(changesElement.GetRawText());
 
             // Assert
             Assert.True(changeList.Exists(x => x.Equals("@removed.reason")));

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadResponseHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -11,9 +11,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using System.Text;
     using System.Threading.Tasks;
     using Xunit;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
+
     public class UploadResponseHandlerTests
     {
-        [Theory(Skip = "Service Library needs to support System.Text.Json Attributes")]
+        [Theory]
         [InlineData(HttpStatusCode.Created)]
         [InlineData(HttpStatusCode.OK)]
         public async Task GetDriveItemOnCompletedUpload(HttpStatusCode statusCode)
@@ -31,7 +33,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var uploadResult = await responseHandler.HandleResponse<DriveItem>(hrm);
+            var uploadResult = await responseHandler.HandleResponse<TestDriveItem>(hrm);
             var driveItem = uploadResult.ItemResponse;
 
             //Assert
@@ -42,7 +44,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal(33, driveItem.Size);
         }
 
-        [Fact(Skip = "Service Library needs to support System.Text.Json Attributes")]
+        [Fact]
         public async Task GetFileAttachmentLocationItemOnCompletedUpload()
         {
             // Arrange
@@ -55,7 +57,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             hrm.StatusCode = HttpStatusCode.Created;//upload successful!
 
             // Act
-            var uploadResult = await responseHandler.HandleResponse<DriveItem>(hrm);
+            var uploadResult = await responseHandler.HandleResponse<TestDriveItem>(hrm);
             var fileAttachment = uploadResult.ItemResponse;
 
             //Assert
@@ -82,7 +84,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var uploadResult = await responseHandler.HandleResponse<DriveItem>(hrm);
+            var uploadResult = await responseHandler.HandleResponse<TestDriveItem>(hrm);
             var uploadSession = uploadResult.UploadSession;
 
             //Assert
@@ -116,7 +118,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var serviceException = await Assert.ThrowsAsync<ServiceException>(() => responseHandler.HandleResponse<DriveItem>(hrm));
+            var serviceException = await Assert.ThrowsAsync<ServiceException>(() => responseHandler.HandleResponse<TestDriveItem>(hrm));
 
             //Assert
             Assert.NotNull(serviceException);
@@ -149,7 +151,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             };
 
             // Act
-            var serviceException = await Assert.ThrowsAsync<ServiceException>(() => responseHandler.HandleResponse<DriveItem>(hrm));
+            var serviceException = await Assert.ThrowsAsync<ServiceException>(() => responseHandler.HandleResponse<TestDriveItem>(hrm));
 
             //Assert
             Assert.NotNull(serviceException);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using Xunit;
 
     public class UploadSliceRequests : RequestTestBase
@@ -41,7 +42,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 // 3. Create a batch request object to be tested
                 MockCustomHttpProvider customHttpProvider = new MockCustomHttpProvider(testHttpMessageHandler);
                 BaseClient client = new BaseClient(requestUrl, authenticationProvider.Object, customHttpProvider);
-                UploadSliceRequest<DriveItem> uploadSliceRequest = new UploadSliceRequest<DriveItem>(requestUrl, client, 0, 200, 1000);
+                UploadSliceRequest<TestDriveItem> uploadSliceRequest = new UploadSliceRequest<TestDriveItem>(requestUrl, client, 0, 200, 1000);
                 Stream stream = new MemoryStream(new byte[300]);
 
                 /* Act */

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
 {
     using Microsoft.Graph.DotnetCore.Core.Test.Requests;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -29,7 +30,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 int maxSliceSize = 1000;//invalid slice size that is not a multiple of 320
 
                 // Act 
-                var exception = Assert.Throws<ArgumentException>(() => new LargeFileUploadTask<DriveItem>(uploadSession, stream, maxSliceSize));
+                var exception = Assert.Throws<ArgumentException>(() => new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize));
 
                 // Assert
                 Assert.Equal("maxSliceSize", exception.ParamName);
@@ -53,7 +54,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 int maxSliceSize = 320 * 1024;
 
                 // Act 
-                var fileUploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, stream, maxSliceSize);
+                var fileUploadTask = new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize);
                 var uploadSlices = fileUploadTask.GetUploadSliceRequests();
 
                 // Assert

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/ITestEventDeltaCollectionPage.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/ITestEventDeltaCollectionPage.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    /// <summary>
+    /// The interface IUserEventsCollectionPage.
+    /// </summary>
+    [InterfaceConverter(typeof(InterfaceConverter<TestEventDeltaCollectionPage>))]
+    public interface ITestEventDeltaCollectionPage : ICollectionPage<TestEvent>
+    {
+        /// <summary>
+        /// Gets the next page <see cref="ITestEventDeltaCollectionPage"/> instance.
+        /// </summary>
+        TestEventDeltaRequest NextPageRequest { get; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest property.
+        /// </summary>
+        void InitializeNextPageRequest(IBaseClient client, string nextPageLinkString);
+    }
+
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestAttendee.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestAttendee.cs
@@ -1,0 +1,18 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    public class TestAttendee : TestRecipient
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestAttendee"/> class.
+        /// </summary>
+        public TestAttendee()
+        {
+            this.ODataType = "microsoft.graph.attendee";
+        }
+        
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestBodyType.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestBodyType.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The enum BodyType.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum TestBodyType
+    {
+
+        /// <summary>
+        /// Text
+        /// </summary>
+        Text = 0,
+
+        /// <summary>
+        /// Html
+        /// </summary>
+        Html = 1,
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDateTimeTimeZone.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDateTimeTimeZone.cs
@@ -1,0 +1,51 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The type DateTimeTimeZone.
+    /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<TestDateTimeTimeZone>))]
+    public partial class TestDateTimeTimeZone
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestDateTimeTimeZone"/> class.
+        /// </summary>
+        public TestDateTimeTimeZone()
+        {
+            this.ODataType = "microsoft.graph.dateTimeTimeZone";
+        }
+
+        /// <summary>
+        /// Gets or sets dateTime.
+        /// A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).
+        /// </summary>
+        [JsonPropertyName("dateTime")]
+        public string DateTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets timeZone.
+        /// Represents a time zone, for example, 'Pacific Standard Time'. See below for more possible values.
+        /// </summary>
+        [JsonPropertyName("timeZone")]
+        public string TimeZone { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDrive.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDrive.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    public partial class TestDrive
+    {
+        ///<summary>
+        /// The Drive constructor
+        ///</summary>
+        public TestDrive()
+        {
+            this.ODataType = "microsoft.graph.drive";
+        }
+
+        /// <summary>
+        /// Gets or sets id.
+        /// Read-only.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets name.
+        /// The name of the item. Read-write.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDriveItem.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestDriveItem.cs
@@ -1,0 +1,54 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    public partial class TestDriveItem
+    {
+        ///<summary>
+        /// The Drive constructor
+        ///</summary>
+        public TestDriveItem()
+        {
+            this.ODataType = "microsoft.graph.drive";
+        }
+
+        /// <summary>
+        /// Gets or sets id.
+        /// Read-only.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets name.
+        /// The name of the item. Read-write.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets size.
+        /// Size of the item in bytes. Read-only.
+        /// </summary>
+        [JsonPropertyName("size")]
+        public Int64? Size { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEmailAddress.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEmailAddress.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
     /// <summary>
     /// The type TestEmailAddress.
     /// </summary>
-    [JsonConverter(typeof(DerivedTypeConverter<TestEmailAddress>))]
     public partial class TestEmailAddress
     {
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEmailAddress.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEmailAddress.cs
@@ -1,0 +1,51 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The type TestEmailAddress.
+    /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<TestEmailAddress>))]
+    public partial class TestEmailAddress
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestEmailAddress"/> class.
+        /// </summary>
+        public TestEmailAddress()
+        {
+            this.ODataType = "microsoft.graph.emailAddress";
+        }
+
+        /// <summary>
+        /// Gets or sets name.
+        /// The display name of the person or entity.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets address.
+        /// The email address of the person or entity.
+        /// </summary>
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEvent.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEvent.cs
@@ -1,0 +1,82 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+
+    /// <summary>
+    /// The type TestEvent.
+    /// </summary>
+
+    public partial class TestEvent
+    {
+
+        ///<summary>
+        /// The Event constructor
+        ///</summary>
+        public TestEvent()
+        {
+            this.ODataType = "microsoft.graph.event";
+        }
+
+        /// <summary>
+        /// Gets or sets id.
+        /// Read-only.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets subject.
+        /// The text of the event's subject line.
+        /// </summary>
+        [JsonPropertyName("subject")]
+        public string Subject { get; set; }
+
+        /// <summary>
+        /// Gets or sets body.
+        /// The body of the message associated with the event. It can be in HTML or text format.
+        /// </summary>
+        [JsonPropertyName("body")]
+        public TestItemBody Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets end.
+        /// The date, time, and time zone that the event ends. By default, the end time is in UTC.
+        /// </summary>
+        [JsonPropertyName("end")]
+        public TestDateTimeTimeZone End { get; set; }
+
+        /// <summary>
+        /// Gets or sets start.
+        /// The date, time, and time zone that the event starts. By default, the start time is in UTC.
+        /// </summary>
+        [JsonPropertyName("start")]
+        public TestDateTimeTimeZone Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets attendees.
+        /// The collection of attendees for the event.
+        /// </summary>
+        [JsonPropertyName("attendees")]
+        public IEnumerable<TestAttendee> Attendees { get; set; }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionPage.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionPage.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    /// <summary>
+    /// The type UserEventsCollectionPage.
+    /// </summary>
+    public partial class TestEventDeltaCollectionPage : CollectionPage<TestEvent>, ITestEventDeltaCollectionPage
+    {
+        /// <summary>
+        /// Gets the next page <see cref="TestEventDeltaRequest"/> instance.
+        /// </summary>
+        public TestEventDeltaRequest NextPageRequest { get; private set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest property.
+        /// </summary>
+        public void InitializeNextPageRequest(IBaseClient client, string nextPageLinkString)
+        {
+            if (!string.IsNullOrEmpty(nextPageLinkString))
+            {
+                this.NextPageRequest = new TestEventDeltaRequest(
+                    nextPageLinkString,
+                    client,
+                    null);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    /// <summary>
+    /// The type UserEventsCollectionResponse.
+    /// </summary>
+
+    public class TestEventDeltaCollectionResponse
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ITestEventDeltaCollectionPage"/> value.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public ITestEventDeltaCollectionPage Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
@@ -1,0 +1,97 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Threading;
+
+    /// <summary>
+    /// The type UserEventsCollectionRequest.
+    /// </summary>
+    public partial class TestEventDeltaRequest : BaseRequest
+    {
+        /// <summary>
+        /// Constructs a new UserEventsCollectionRequest.
+        /// </summary>
+        /// <param name="requestUrl">The URL for the built request.</param>
+        /// <param name="client">The <see cref="IBaseClient"/> for handling requests.</param>
+        /// <param name="options">Query and header option name value pairs for the request.</param>
+        public TestEventDeltaRequest(
+            string requestUrl,
+            IBaseClient client,
+            IEnumerable<Option> options)
+            : base(requestUrl, client, options)
+        {
+        }
+
+        /// <summary>
+        /// Adds the specified Event to the collection via POST.
+        /// </summary>
+        /// <param name="eventsEvent">The Event to add.</param>
+        /// <returns>The created Event.</returns>
+        public System.Threading.Tasks.Task<TestEvent> AddAsync(TestEvent eventsEvent)
+        {
+            return this.AddAsync(eventsEvent, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Adds the specified Event to the collection via POST.
+        /// </summary>
+        /// <param name="eventsEvent">The Event to add.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Event.</returns>
+        public System.Threading.Tasks.Task<TestEvent> AddAsync(TestEvent eventsEvent, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            return this.SendAsync<TestEvent>(eventsEvent, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the collection page.
+        /// </summary>
+        /// <returns>The collection page.</returns>
+        public System.Threading.Tasks.Task<ITestEventDeltaCollectionPage> GetAsync()
+        {
+            return this.GetAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Gets the collection page.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The collection page.</returns>
+        public async System.Threading.Tasks.Task<ITestEventDeltaCollectionPage> GetAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "GET";
+            var response = await this.SendAsync<TestEventDeltaCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
+            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            {
+                if (response.AdditionalData != null)
+                {
+                    object nextPageLink;
+                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
+
+                    var nextPageLinkString = nextPageLink as string;
+
+                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    {
+                        response.Value.InitializeNextPageRequest(
+                            this.Client,
+                            nextPageLinkString);
+                    }
+
+                    // Copy the additional data collection to the page itself so that information is not lost
+                    response.Value.AdditionalData = response.AdditionalData;
+                }
+
+                return response.Value;
+            }
+
+            return null;
+        }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestItemBody.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestItemBody.cs
@@ -1,0 +1,52 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The type ItemBody.
+    /// </summary>
+
+    [JsonConverter(typeof(DerivedTypeConverter<TestItemBody>))]
+    public partial class TestItemBody
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestItemBody"/> class.
+        /// </summary>
+        public TestItemBody()
+        {
+            this.ODataType = "microsoft.graph.itemBody";
+        }
+
+        /// <summary>
+        /// Gets or sets contentType.
+        /// The type of the content. Possible values are text and html.
+        /// </summary>
+        [JsonPropertyName("contentType")]
+        public TestBodyType? ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets content.
+        /// The content of the item.
+        /// </summary>
+        [JsonPropertyName("content")]
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestNotebook.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestNotebook.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    public partial class TestNoteBook
+    {
+        ///<summary>
+        /// The Drive constructor
+        ///</summary>
+        public TestNoteBook()
+        {
+            this.ODataType = "microsoft.graph.notebook";
+        }
+
+        /// <summary>
+        /// Gets or sets id.
+        /// Read-only.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets name.
+        /// The name of the item. Read-write.
+        /// </summary>
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestRecipient.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestRecipient.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    public class TestRecipient
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestRecipient"/> class.
+        /// </summary>
+        public TestRecipient()
+        {
+            this.ODataType = "microsoft.graph.recipient";
+        }
+
+        /// <summary>
+        /// Gets or sets emailAddress.
+        /// The recipient's email address.
+        /// </summary>
+        [JsonPropertyName("emailAddress")]
+        public TestEmailAddress EmailAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The type User.
+    /// </summary>
+    public partial class TestUser 
+    {
+
+        ///<summary>
+        /// The User constructor
+        ///</summary>
+        public TestUser()
+        {
+            this.ODataType = "microsoft.graph.user";
+        }
+
+        /// <summary>
+        /// Gets or sets id.
+        /// Read-only.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets given name.
+        /// The given name (first name) of the user. Supports $filter.
+        /// </summary>
+        [JsonPropertyName("givenName")]
+        public string GivenName { get; set; }
+
+        /// <summary>
+        /// Gets or sets state.
+        /// The state or province in the user's address. Supports $filter.
+        /// </summary>
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+
+        /// <summary>
+        /// Gets or sets surname.
+        /// The user's surname (family name or last name). Supports $filter.
+        /// </summary>
+        [JsonPropertyName("surname")]
+        public string Surname { get; set; }
+
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
@@ -48,6 +48,13 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public string GivenName { get; set; }
 
         /// <summary>
+        /// Gets or sets Display name.
+        /// The displayName of the user. Supports $filter.
+        /// </summary>
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
         /// Gets or sets state.
         /// The state or province in the user's address. Supports $filter.
         /// </summary>


### PR DESCRIPTION
This PR migrates the DeltaResponseHandler to use System.Text.Json.

As a result the Newtonsoft dependency is now dropped from the project. 😄 

This PR also : -
- Adds a number of System.Text.Json compatible Test Models. 
This is done to drop the service library dependency that uses Newtonsoft causing a cyclic dependency on Newtonsoft and also to enable validation. (The models whould ideally be dropped once we have a compatible service library)
- Enables running of tests in the pipeline