### PR TITLE
Fix for incorrect task cancellation

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -24,6 +24,7 @@
     <PackageReleaseNotes>
       - Adds support for TokenCredential from Azure.Core
       - Adds support for System.Text,Json and drops Newtonsoft.Json dependency
+      - Fix for incorrect task cancellation #28
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -244,15 +244,9 @@ namespace Microsoft.Graph
             {
                 return await this.httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
             }
-            catch (TaskCanceledException exception)
+            catch (OperationCanceledException)
             {
-                throw new ServiceException(
-                        new Error
-                        {
-                            Code = ErrorConstants.Codes.Timeout,
-                            Message = ErrorConstants.Messages.RequestTimedOut,
-                        },
-                        exception);
+                throw;
             }
             catch(ServiceException exception)
             {

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -196,15 +196,9 @@ namespace Microsoft.Graph
             {
                 return await this.httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
             }
-            catch (TaskCanceledException exception)
+            catch (OperationCanceledException)
             {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.Timeout,
-                        Message = ErrorConstants.Messages.RequestTimedOut,
-                    },
-                    exception);
+                throw;
             }
             catch (ServiceException)
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -134,23 +134,22 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
         [Fact]
 
-        public async Task SendAsync_ThrowsClientTimeoutException()
+        public async Task SendAsync_RethrowsTaskCancelledException()
         {
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
             {
                 this.simpleHttpProvider.Dispose();
 
-                var clientException = new TaskCanceledException();
+                var message = "Task cancelled";
+                var clientException = new TaskCanceledException(message);
                 var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
                 var httpClient = GraphClientFactory.Create(handlers: defaultHandlers, finalHandler: new ExceptionHttpMessageHandler(clientException));
                 this.simpleHttpProvider = new SimpleHttpProvider(httpClient, this.serializer.Object);
 
-                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(
+                TaskCanceledException exception = await Assert.ThrowsAsync<TaskCanceledException>(async () => await this.simpleHttpProvider.SendAsync(
                     httpRequestMessage, HttpCompletionOption.ResponseContentRead, CancellationToken.None));
 
-                Assert.True(exception.IsMatch(ErrorConstants.Codes.Timeout));
-                Assert.Equal(ErrorConstants.Messages.RequestTimedOut, exception.Error.Message);
-                Assert.Equal(clientException, exception.InnerException);
+                Assert.Equal(message,exception.Message);
             }
         }
 


### PR DESCRIPTION
<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #28

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Refactored SimpleHttpProvider and HttpProvider to enable the bubbling up of the TaskCancelledException for correct task management by client apps
- Updated tests to capture this 😃 

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://stackoverflow.com/questions/47890382/periodic-timeout-exception-when-i-cancel-onedrive-task-that-reads-file-informati
- https://stackoverflow.com/a/47900445/987850