### PR TITLE
GraphResponse object

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -23,8 +23,10 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
       - Adds support for TokenCredential from Azure.Core
-      - Adds support for System.Text,Json and drops Newtonsoft.Json dependency
-      - Fix for incorrect task cancellation #28
+      - [Breaking Change] Adds support for System.Text,Json and drops Newtonsoft.Json dependency
+      - [Breaking Change] Fix for incorrect task cancellation #28
+      - Added GraphResponse object for wrapping responses
+      - [Breaking Change] IBaseRequest now takes IResponseHandler as a member
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -219,6 +219,38 @@ namespace Microsoft.Graph
         /// <param name="serializableObject">The serializable object to send.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
+        /// <returns>The <see cref="GraphResponse"/> object.</returns>
+        public async Task<GraphResponse> SendAsyncWithGraphResponse(
+            object serializableObject,
+            CancellationToken cancellationToken,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+        {
+            var response = await this.SendRequestAsync(serializableObject, cancellationToken, completionOption).ConfigureAwait(false);
+            return new GraphResponse(this, response);
+        }
+
+        /// <summary>
+        /// Sends the request.
+        /// </summary>
+        /// <param name="serializableObject">The serializable object to send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
+        /// <returns>The <see cref="GraphResponse"/> object.</returns>
+        public async Task<GraphResponse<T>> SendAsyncWithGraphResponse<T>(
+            object serializableObject,
+            CancellationToken cancellationToken,
+            HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+        {
+            var response = await this.SendRequestAsync(serializableObject, cancellationToken, completionOption).ConfigureAwait(false);
+            return new GraphResponse<T>(this, response);
+        }
+
+        /// <summary>
+        /// Sends the request.
+        /// </summary>
+        /// <param name="serializableObject">The serializable object to send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The <see cref="HttpResponseMessage"/> object.</returns>
         public async Task<HttpResponseMessage> SendRequestAsync(
             object serializableObject,

--- a/src/Microsoft.Graph.Core/Requests/GraphResponse.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphResponse.cs
@@ -1,0 +1,66 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    /// <summary>
+    /// The GraphResponse Object
+    /// </summary>
+    public class GraphResponse :IDisposable
+    {
+        /// <summary>
+        /// The GraphResponse Constructor
+        /// </summary>
+        /// <param name="iBaseRequest">The Request made for the response</param>
+        /// <param name="httpResponseMessage">The response</param>
+        public GraphResponse(IBaseRequest iBaseRequest, HttpResponseMessage httpResponseMessage)
+        {
+            this.httpResponseMessage = httpResponseMessage;
+            this.BaseRequest = iBaseRequest;
+        }
+
+        private readonly HttpResponseMessage httpResponseMessage;
+        
+        /// <summary>
+        /// The Response Status code
+        /// </summary>
+        public HttpStatusCode StatusCode => httpResponseMessage.StatusCode;
+        
+        /// <summary>
+        /// The Response Content
+        /// </summary>
+        public HttpContent Content => httpResponseMessage.Content;
+        
+        /// <summary>
+        /// The Response Headers
+        /// </summary>
+        public HttpResponseHeaders HttpHeaders => httpResponseMessage.Headers;
+
+        /// <summary>
+        /// The reference to the Request
+        /// </summary>
+        public IBaseRequest BaseRequest;
+
+        /// <summary>
+        /// Get the native Response Message
+        /// </summary>
+        /// <returns></returns>
+        public HttpResponseMessage ToHttpResponseMessage()
+        {
+            return httpResponseMessage;
+        }
+
+        /// <summary>
+        /// Cleanup
+        /// </summary>
+        public void Dispose()
+        {
+            httpResponseMessage?.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
@@ -1,0 +1,33 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The GraphResponse Object
+    /// </summary>
+    public class GraphResponse<T> : GraphResponse
+    {
+        /// <summary>
+        /// The GraphResponse Constructor
+        /// </summary>
+        /// <param name="iBaseRequest">The Request made for the response</param>
+        /// <param name="httpResponseMessage">The response</param>
+        public GraphResponse(IBaseRequest iBaseRequest, HttpResponseMessage httpResponseMessage)
+            : base(iBaseRequest, httpResponseMessage)
+        {
+        }
+
+        /// <summary>
+        /// Gets the deserialized object 
+        /// </summary>
+        public async Task<T> GetResponseObjectAsync()
+        {
+            return await this.BaseRequest.ResponseHandler.HandleResponse<T>(this.ToHttpResponseMessage());
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Graph
         IDictionary<string, IMiddlewareOption> MiddlewareOptions { get; }
 
         /// <summary>
+        /// Gets the <see cref="IResponseHandler"/> for the request.
+        /// </summary>
+        IResponseHandler ResponseHandler { get; }
+
+        /// <summary>
         /// Gets the <see cref="HttpRequestMessage"/> representation of the request.
         /// </summary>
         /// <returns>The <see cref="HttpRequestMessage"/> representation of the request.</returns>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
@@ -1,0 +1,88 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
+    using Xunit;
+
+    public class GraphResponseTests : RequestTestBase
+    {
+        [Fact]
+        public void GraphResponse_Initialize()
+        {
+            // Arrange
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            BaseRequest baseRequest = new BaseRequest("http://localhost", this.baseClient) ;
+
+            // Act
+            GraphResponse response = new GraphResponse(baseRequest, responseMessage);
+
+            // Assert
+            Assert.Equal(responseMessage, response.ToHttpResponseMessage());
+            Assert.Equal(responseMessage.StatusCode, response.StatusCode);
+            Assert.Equal(baseRequest, response.BaseRequest);
+
+        }
+
+        [Fact]
+        public void GraphResponse_ValidateHeaders()
+        {
+            // Arrange
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Headers.Add("Authorization","bearer token");// add a test header
+            BaseRequest baseRequest = new BaseRequest("http://localhost", this.baseClient);
+
+            // Act
+            GraphResponse response = new GraphResponse(baseRequest, responseMessage);
+
+            // Assert
+            Assert.Equal(responseMessage, response.ToHttpResponseMessage());
+            Assert.Equal(responseMessage.Headers.Count(), response.HttpHeaders.Count());
+            Assert.Equal("Authorization", responseMessage.Headers.First().Key);
+            Assert.Equal("bearer token", responseMessage.Headers.First().Value.First());
+
+        }
+
+        [Fact]
+        public async Task ValidateResponseHandlerAsync()
+        {
+            // Arrange
+            HttpResponseMessage responseMessage = new HttpResponseMessage()
+            {
+                Content = new StringContent(@"{
+                    ""id"": ""123"",
+                    ""givenName"": ""Joe"",
+                    ""surName"": ""Brown"",
+                    ""@odata.type"":""test""
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // create a custom responseHandler
+            IResponseHandler responseHandler = new ResponseHandler(new Serializer());
+            BaseRequest baseRequest = new BaseRequest("http://localhost", this.baseClient)
+            {
+                ResponseHandler = responseHandler // use custom responseHandler
+            };
+
+
+            // Act
+            GraphResponse<TestUser> response = new GraphResponse<TestUser>(baseRequest, responseMessage);
+            TestUser user = await response.GetResponseObjectAsync();
+
+            // Assert
+            Assert.Equal("123", user.Id);
+            Assert.Equal("Joe", user.GivenName);
+            Assert.Equal("Brown", user.Surname);
+            Assert.Equal("OK", user.AdditionalData["statusCode"].ToString());
+
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the GraphResponse object which will act as a wrapper for properties like the status code and http headers.

This work is done according to the spec found here.
https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/GraphResponse.md

Currently, a user should be able to follow the following flow
```csharp
BaseClient client = new BaseClient(requestUrl, authenticationProvider, customHttpProvider);
BaseRequest baseRequest = new BaseRequest(requestUrl, client);

GraphResponse<TestUser> returnedResponse = await baseRequest.SendAsyncWithGraphResponse<TestUser>("string", CancellationToken.None);
TestUser user = await response.GetResponseObjectAsync();
```

Fixes [AB#4600](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4600)