### PR TITLE
Compression header handling

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Threading.Tasks;
     using System.Net.Http.Headers;
     using System.IO.Compression;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation that handles compression.
@@ -53,7 +54,13 @@ namespace Microsoft.Graph
             // Decompress response content when Content-Encoding: gzip header is present.
             if (ShouldDecompressContent(response))
             {
-                response.Content = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                // Copy Content Headers to the destination stream content
+                foreach (var httpContentHeader in response.Content.Headers)
+                {
+                    streamContent.Headers.TryAddWithoutValidation(httpContentHeader.Key, httpContentHeader.Value);
+                }
+                response.Content = streamContent;
             }
 
             return response;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
             string responseContentString = await compressedResponse.Content.ReadAsStringAsync();
 
             // Ensure that headers in the compressedResponse are the same as in the original, expected response.
+            Assert.NotEmpty(compressedResponse.Headers);
             Assert.NotEmpty(compressedResponse.Content.Headers);
             Assert.Equal(httpResponse.Headers, compressedResponse.Headers, new HttpHeaderComparer());
             Assert.Equal(httpResponse.Content.Headers, compressedResponse.Content.Headers, new HttpHeaderComparer());

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
     using System.Threading.Tasks;
     using System.Threading;
     using System.Net.Http.Headers;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Xunit.Abstractions;
 
     public class CompressionHandlerTests : IDisposable
     {
@@ -93,6 +96,55 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
             Assert.Same(httpResponse, compressedResponse);
             Assert.Same(httpRequestMessage, compressedResponse.RequestMessage);
             Assert.NotEqual(stringToCompress, responseContentString);
+        }
+
+        /// <summary>
+        /// Compression Handler should keep content headers after decompression
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CompressionHandler_should_keep_headers_after_decompression()
+        {
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+
+            string stringToCompress = "Microsoft Graph";
+            StringContent stringContent = new StringContent(stringToCompress);
+            stringContent.Headers.ContentType = new MediaTypeHeaderValue(CoreConstants.MimeTypeNames.Application.Json);
+
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MockCompressedContent(stringContent)
+            };
+            httpResponse.Content.Headers.ContentEncoding.Add(CoreConstants.Encoding.GZip);
+            httpResponse.Headers.CacheControl = new CacheControlHeaderValue { Private = true };
+            // Examples of Custom Headers returned by Microsoft Graph
+            httpResponse.Headers.Add(CoreConstants.Headers.ClientRequestId, Guid.NewGuid().ToString());
+            httpResponse.Headers.Add("request-id", Guid.NewGuid().ToString());
+            httpResponse.Headers.Add("OData-Version", "4.0");
+
+            this.testHttpMessageHandler.SetHttpResponse(httpResponse);
+
+            HttpResponseMessage compressedResponse = await this.invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            string responseContentString = await compressedResponse.Content.ReadAsStringAsync();
+
+            // Ensure that headers in the compressedResponse are the same as in the original, expected response.
+            Assert.NotEmpty(compressedResponse.Content.Headers);
+            Assert.Equal(httpResponse.Headers, compressedResponse.Headers, new HttpHeaderComparer());
+            Assert.Equal(httpResponse.Content.Headers, compressedResponse.Content.Headers, new HttpHeaderComparer());
+        }
+
+        internal class HttpHeaderComparer : IEqualityComparer<KeyValuePair<string, IEnumerable<string>>>
+        {
+            public bool Equals(KeyValuePair<string, IEnumerable<string>> x, KeyValuePair<string, IEnumerable<string>> y)
+            {
+                // For each key, the collection of header values should be equal.
+                return x.Key == y.Key && x.Value.SequenceEqual(y.Value);
+            }
+
+            public int GetHashCode(KeyValuePair<string, IEnumerable<string>> obj)
+            {
+                return obj.Key.GetHashCode();
+            }
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
@@ -125,7 +125,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
             this.testHttpMessageHandler.SetHttpResponse(httpResponse);
 
             HttpResponseMessage compressedResponse = await this.invoker.SendAsync(httpRequestMessage, new CancellationToken());
-            string responseContentString = await compressedResponse.Content.ReadAsStringAsync();
+            string decompressedResponseString = await compressedResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(decompressedResponseString, stringToCompress);
 
             // Ensure that headers in the compressedResponse are the same as in the original, expected response.
             Assert.NotEmpty(compressedResponse.Headers);


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Address [AB#4768](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4768)

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
 - CompressionHandler currently doesn't forward HttpContent headers to the next middleware in the chain. This change fixes that by copying the headers from the source HttpContent to the destination StreamHttpContent. 
- Adds tests to confirm custom and content headers are always copied after compression. 
