### PR TITLE
Add `IBaseRequestBuilder` interface to `BaseRequestBuilder` class

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/BaseRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequestBuilder.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The base request builder class.
     /// </summary>
-    public class BaseRequestBuilder
+    public class BaseRequestBuilder : IBaseRequestBuilder
     {
         /// <summary>
         /// Constructs a new <see cref="BaseRequestBuilder"/>.


### PR DESCRIPTION
This seems to be the only implementation of a RequestBuilder which doesn't have its corresponding interface?

This is part of a problem (also see https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/722) for anything use `BaseFunctionMethodRequestBuilder` as a RequestBuilder because it doesn't implement the interface and inherits from the base class directly here:

https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/61405c1b8931dd6635b97f4e3ba68d81d56b13de/src/Microsoft.Graph.Core/Requests/BaseFunctionMethodRequestBuilder.cs#L13

Therefore things like the [`IDriveRecentRequestBuilder`](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph/Requests/Generated/IDriveRecentRequestBuilder.cs)'s implementation is not compatible to case to a generic `IBaseRequestBuilder`:

https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/9b74c2674969008669e4c46ac85bda7e6ad8a728/src/Microsoft.Graph/Requests/Generated/DriveRecentRequestBuilder.cs#L19

```cs
public partial class DriveRecentRequestBuilder : BaseFunctionMethodRequestBuilder<IDriveRecentRequest>, IDriveRecentRequestBuilder
```

This prevents a nice common way to receive RequestBuilders for general calls to the graph and make them on behalf of a developer as part of an auxiliary API.