### PR TITLE
corrected DefaultMaxSliceSize value

### DIFF
--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class LargeFileUploadTask<T>
     {
-        private const int DefaultMaxSliceSize = 4 * 1024 * 1024;
+        private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
         private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;


### PR DESCRIPTION
default max slice is not a multiple of 320 and also the header suggests 5 MiB instead of 4

> /// If less than 0, default value of 5 MiB is used. .</param>
