### PR TITLE
Fix DefaultMaxSliceSize in LargeFileUpload task

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,7 +22,7 @@
     <VersionPrefix>1.23.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask 
+    - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask 
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,10 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.22.0</VersionPrefix>
+    <VersionPrefix>1.23.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <PackageReleaseNotes>- BaseRequestBuilder is now an IBaseRequestBuilder.
-- Requests that return an OData primitive now work as expected. 
+    <PackageReleaseNotes>
+      - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask 
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class LargeFileUploadTask<T>
     {
-        private const int DefaultMaxSliceSize = 4 * 1024 * 1024;
+        private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
         private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -37,6 +37,37 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         }
 
         [Fact]
+        public void ShouldNotThrowArgumentExceptionOnConstructorWithoutSliceSize()
+        {
+            // Try to upload 1Mb stream without specifying the slice size(should default to 5Mb)
+            byte[] mockData = new byte[1000000];
+            using (Stream stream = new MemoryStream(mockData))
+            {
+                // Arrange
+                IUploadSession uploadSession = new Graph.Core.Models.UploadSession
+                {
+                    NextExpectedRanges = new List<string>() { "0-" },
+                    UploadUrl = "http://localhost",
+                    ExpirationDateTime = DateTimeOffset.Parse("2019-11-07T06:39:31.499Z")
+                };
+
+                // Act with constructor without chunk length
+                var fileUploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, stream);
+                var uploadSlices = fileUploadTask.GetUploadSliceRequests();
+
+                // Assert
+                //We have only 1 slices
+                Assert.Single(uploadSlices);
+
+                var onlyUploadSlice = uploadSlices.First();
+                Assert.Equal(stream.Length, onlyUploadSlice.TotalSessionLength);
+                Assert.Equal(0, onlyUploadSlice.RangeBegin);
+                Assert.Equal(stream.Length - 1, onlyUploadSlice.RangeEnd);
+                Assert.Equal(stream.Length , onlyUploadSlice.RangeLength); //verify the last slice is the right size
+            }
+        }
+
+        [Fact]
         public void BreaksDownStreamIntoRangesCorrectly()
         {
             byte[] mockData = new byte[1000000];//create a stream of about 1M so we can split it into a few 320K slices


### PR DESCRIPTION
<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #120

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- This PR fixes the exception thrown when creating a LargeFileUpload without specifying the slice size since the default value is not a multiple of 320KB

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/73
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/158