### PR TITLE
Add support for content type with parameters to BaseRequest

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -24,6 +24,7 @@
     <PackageReleaseNotes>
 - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
 - Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
+- Fix for #165: Add support for content types with parameters to BaseRequest
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Graph
 
                     if (!string.IsNullOrEmpty(this.ContentType))
                     {
-                        request.Content.Headers.ContentType = new MediaTypeHeaderValue(this.ContentType);
+                        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(this.ContentType);
                     }
                 }
 


### PR DESCRIPTION
Fixes #165 

This PR adds support to Base Request for content types with parameters so that content types  like `application/json; odata=verbose` do not throw a Format Exception.

Test has been added to validate this change.