### PR TITLE
Add Continuous Access Evaluation (CAE) support

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -25,6 +25,7 @@
 - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
 - Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
 - Fix for #165: Add support for content types with parameters to BaseRequest
+- Add support for Continuous Access Evaluation(CAE)
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
         /// <summary>
         /// A MiddlewareOptions property
         /// </summary>
-        public IDictionary<string, IMiddlewareOption> MiddlewareOptions { get; set; }
+        public IDictionary<string, IMiddlewareOption> MiddlewareOptions {
+            get => _middlewareOptions ?? (_middlewareOptions = new Dictionary<string, IMiddlewareOption>());
+            set => _middlewareOptions = value;
+        }
 
         /// <summary>
         /// A CancellationToken property
@@ -36,5 +39,7 @@ namespace Microsoft.Graph
         /// A <see cref="GraphUserAccount"/> property representing the logged in user
         /// </summary>
         public GraphUserAccount User { get; set; }
+
+        private IDictionary<string, IMiddlewareOption> _middlewareOptions;
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -7,7 +7,11 @@ namespace Microsoft.Graph
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using System;
+    using System.Linq;
     using System.Net;
+    using System.Text;
+
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
     /// </summary>
@@ -77,8 +81,14 @@ namespace Microsoft.Graph
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
                 var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
 
-                // Authenticate request using AuthenticationProvider
+                // extract the www-authenticate header and add claims to the request context
+                if (httpResponseMessage.Headers.WwwAuthenticate.Any())
+                {
+                    var wwwAuthenticateHeader = httpResponseMessage.Headers.WwwAuthenticate.ToString();
+                    AddClaimsToRequestContext(newRequest, wwwAuthenticateHeader);
+                }
 
+                // Authenticate request using AuthenticationProvider
                 await authProvider.AuthenticateRequestAsync(newRequest);
                 httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
@@ -130,6 +140,48 @@ namespace Microsoft.Graph
                 // We will add this check once we re-write a new HttpProvider.
                 return await base.SendAsync(httpRequestMessage, cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Add claims to the request context of the given request message
+        /// </summary>
+        /// <param name="wwwAuthenticateHeader">String representation of www Authenticate Header</param>
+        /// <param name="newRequest">Request message to add claims to</param>
+        private void AddClaimsToRequestContext(HttpRequestMessage newRequest, string wwwAuthenticateHeader)
+        {
+            int claimsStart = wwwAuthenticateHeader.IndexOf("claims=", StringComparison.OrdinalIgnoreCase);
+            if (claimsStart < 0) 
+                return; // do nothing as there is no claims in www Authenticate Header
+
+            claimsStart += 8; // jump to the index after the opening quotation mark
+
+            // extract and decode the Base 64 encoded claims property
+            byte[] bytes = Convert.FromBase64String(wwwAuthenticateHeader.Substring(claimsStart, wwwAuthenticateHeader.Length - claimsStart - 1));
+            string claimsChallenge = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+
+            // Try to get the current options otherwise create new ones
+            AuthenticationHandlerOption authenticationHandlerOption = newRequest.GetMiddlewareOption<AuthenticationHandlerOption>() ?? AuthOption;
+            IAuthenticationProviderOption authenticationProviderOption = authenticationHandlerOption.AuthenticationProviderOption ?? new CaeAuthenticationProviderOption();
+            
+            // make sure that there is no information loss due to casting by copying over the scopes information if necessary
+            CaeAuthenticationProviderOption caeAuthenticationProviderOption;
+            if (authenticationProviderOption is CaeAuthenticationProviderOption option)
+            {
+                caeAuthenticationProviderOption = option;
+            }
+            else
+            {
+                caeAuthenticationProviderOption = new CaeAuthenticationProviderOption(authenticationProviderOption);
+            }
+
+            // update the claims property in the options
+            caeAuthenticationProviderOption.Claims = claimsChallenge;
+            authenticationHandlerOption.AuthenticationProviderOption = caeAuthenticationProviderOption;
+
+            // update the request context with the updated options
+            GraphRequestContext requestContext = newRequest.GetRequestContext();
+            requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
+            newRequest.Properties[typeof(GraphRequestContext).ToString()] = requestContext;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Graph
     /// An interface used to pass auth provider options in a request.
     /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
     /// </summary>
-    public class CaeAuthenticationProviderOption : ICaeAuthenticationProviderOption
+    internal class CaeAuthenticationProviderOption : ICaeAuthenticationProviderOption
     {
         /// <summary>
         /// Default constructor

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Graph
         /// </summary>
         public CaeAuthenticationProviderOption(IAuthenticationProviderOption authenticationProviderOption)
         {
-            this.Scopes = authenticationProviderOption.Scopes;
+            this.Scopes = authenticationProviderOption?.Scopes;
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    public class CaeAuthenticationProviderOption : ICaeAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public CaeAuthenticationProviderOption()
+        {
+        }
+
+        /// <summary>
+        /// Create instance of <see cref="CaeAuthenticationProviderOption"/> from an <see cref="IAuthenticationProviderOption"/> instance
+        /// </summary>
+        public CaeAuthenticationProviderOption(IAuthenticationProviderOption authenticationProviderOption)
+        {
+            this.Scopes = authenticationProviderOption.Scopes;
+        }
+
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        public string Claims { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    public interface ICaeAuthenticationProviderOption : IAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        string Claims { get; set; }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var middleWareOption = requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] as AuthenticationHandlerOption;
             Assert.NotNull(middleWareOption);
 
-            var authProviderOption = middleWareOption.AuthenticationProviderOption as CaeAuthenticationProviderOption;
+            var authProviderOption = middleWareOption.AuthenticationProviderOption as ICaeAuthenticationProviderOption;
             Assert.NotNull(authProviderOption);
 
             // Assert the decoded claims string is as expected

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using System;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using Xunit;
     using System.Threading.Tasks;
@@ -268,5 +269,94 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.Same(ex.Error.Message, ErrorConstants.Messages.AuthenticationProviderMissing);
             }
         }
+
+        [Fact]
+        public async Task AuthHandler_ShouldRetryUnauthorizedGetRequestAndExtractWWWAuthenticateHeaders()
+        {
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/bar");
+            
+            var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            unauthorizedResponse.Headers.WwwAuthenticate.Add(
+                new AuthenticationHeaderValue("authorization_url", 
+                    "authorization_url=\"https://login.microsoftonline.com/common/oauth2/authorize\"," +
+                            "error=\"insufficient_claims\"," +
+                            "claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6ZmFsc2UsInZhbHVlIjoxNTM5Mjg0Mzc2fX19\""));
+
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, expectedResponse);
+
+            var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+
+            var requestContext = response.RequestMessage.GetRequestContext();
+
+            var middleWareOption = requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] as AuthenticationHandlerOption;
+            Assert.NotNull(middleWareOption);
+
+            var authProviderOption = middleWareOption.AuthenticationProviderOption as CaeAuthenticationProviderOption;
+            Assert.NotNull(authProviderOption);
+
+            // Assert the decoded claims string is as expected
+            Assert.Equal("{\"access_token\":{\"nbf\":{\"essential\":false,\"value\":1539284376}}}", authProviderOption.Claims);
+            Assert.Same(response, expectedResponse);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+        }
+
+        [Fact]
+        // Test with a request that already has an auth provider option present
+        public async Task AuthHandler_ShouldRetryUnauthorizedGetRequestAndExtractWWWAuthenticateHeadersShouldNotLoseScopesInformation()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/bar");
+            var authenticationHandlerOption = new AuthenticationHandlerOption();
+            var authenticationProviderOption = new AuthenticationProviderOptionTest
+            {
+                Scopes = new string[] { "User.Read" }
+            };
+            authenticationHandlerOption.AuthenticationProviderOption = authenticationProviderOption;
+
+            // set the original AuthenticationProviderOptionTest as the auth provider
+            var originalRequestContext = httpRequestMessage.GetRequestContext();
+            originalRequestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
+            httpRequestMessage.Properties[typeof(GraphRequestContext).ToString()] = originalRequestContext;
+
+            var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            unauthorizedResponse.Headers.WwwAuthenticate.Add(
+                new AuthenticationHeaderValue("authorization_url",
+                    "authorization_url=\"https://login.microsoftonline.com/common/oauth2/authorize\"," +
+                    "error=\"insufficient_claims\"," +
+                    "claims=\"eyJhY2Nlc3NfdG9rZW4iOnsibmJmIjp7ImVzc2VudGlhbCI6ZmFsc2UsInZhbHVlIjoxNTM5Mjg0Mzc2fX19\""));
+
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            
+            // Act
+            testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, expectedResponse);
+            var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var requestContext = response.RequestMessage.GetRequestContext();
+
+            // Assert
+            var middleWareOption = requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] as AuthenticationHandlerOption;
+            Assert.NotNull(middleWareOption);
+
+            var authProviderOption = middleWareOption.AuthenticationProviderOption as ICaeAuthenticationProviderOption;
+            Assert.NotNull(authProviderOption);
+
+            // Assert the decoded claims string is as expected
+            Assert.Equal("{\"access_token\":{\"nbf\":{\"essential\":false,\"value\":1539284376}}}", authProviderOption.Claims);
+            Assert.Same(response, expectedResponse);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
+
+            // Assert that we still have the original scopes information
+            Assert.Single(authProviderOption.Scopes);
+            Assert.Equal("User.Read", authProviderOption.Scopes[0]);
+        }
+    }
+
+    /// <summary>
+    /// Test class that implements the <see cref="IAuthenticationProviderOption"/> interface
+    /// </summary>
+    internal class AuthenticationProviderOptionTest : IAuthenticationProviderOption
+    {
+        public string[] Scopes { get; set; }
     }
 }


### PR DESCRIPTION
This PR fixes #166

The PR involves extracting the claims property from WwwAuthenticate headers from 401 responses. The claims property is then Base64 decoded before being placed in the GraphContext through the `AuthenticationHandlerOption` property.

Placing the claims in the GraphContext will then enable the relevant AuthProviders to read the claims property and use it during the Authentication phase.

Related Links
- #166
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth/pull/91