### PR TITLE
1.23.0 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,7 +22,8 @@
     <VersionPrefix>1.23.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-    - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask 
+- Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
+- Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -24,6 +24,7 @@
     <PackageReleaseNotes>
 - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
 - Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
+- Fix for #165: Add support for content types with parameters to BaseRequest
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,10 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.22.0</VersionPrefix>
+    <VersionPrefix>1.23.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <PackageReleaseNotes>- BaseRequestBuilder is now an IBaseRequestBuilder.
-- Requests that return an OData primitive now work as expected. 
+    <PackageReleaseNotes>
+    - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask 
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
@@ -82,7 +82,7 @@
   <Reference Include="System.Xml" />
   <Reference Include="Microsoft.CSharp" />
   <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-  <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
   <Reference Include="Xamarin.Mac" />
@@ -91,7 +91,7 @@
   <Reference Include="System.Xml" />
   <Reference Include="Microsoft.CSharp" />
   <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-  <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
   <Reference Include="Mono.Android" />
@@ -100,7 +100,7 @@
   <Reference Include="System.Xml" />
   <Reference Include="Microsoft.CSharp" />
   <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-  <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -25,6 +25,7 @@
 - Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
 - Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
 - Fix for #165: Add support for content types with parameters to BaseRequest
+- Add support for Continuous Access Evaluation(CAE)
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -110,6 +110,6 @@
   </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Graph
 
                     if (!string.IsNullOrEmpty(this.ContentType))
                     {
-                        request.Content.Headers.ContentType = new MediaTypeHeaderValue(this.ContentType);
+                        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(this.ContentType);
                     }
                 }
 

--- a/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
         /// <summary>
         /// A MiddlewareOptions property
         /// </summary>
-        public IDictionary<string, IMiddlewareOption> MiddlewareOptions { get; set; }
+        public IDictionary<string, IMiddlewareOption> MiddlewareOptions {
+            get => _middlewareOptions ?? (_middlewareOptions = new Dictionary<string, IMiddlewareOption>());
+            set => _middlewareOptions = value;
+        }
 
         /// <summary>
         /// A CancellationToken property
@@ -36,5 +39,7 @@ namespace Microsoft.Graph
         /// A <see cref="GraphUserAccount"/> property representing the logged in user
         /// </summary>
         public GraphUserAccount User { get; set; }
+
+        private IDictionary<string, IMiddlewareOption> _middlewareOptions;
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -7,7 +7,11 @@ namespace Microsoft.Graph
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using System;
+    using System.Linq;
     using System.Net;
+    using System.Text;
+
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
     /// </summary>
@@ -77,8 +81,14 @@ namespace Microsoft.Graph
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
                 var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
 
-                // Authenticate request using AuthenticationProvider
+                // extract the www-authenticate header and add claims to the request context
+                if (httpResponseMessage.Headers.WwwAuthenticate.Any())
+                {
+                    var wwwAuthenticateHeader = httpResponseMessage.Headers.WwwAuthenticate.ToString();
+                    AddClaimsToRequestContext(newRequest, wwwAuthenticateHeader);
+                }
 
+                // Authenticate request using AuthenticationProvider
                 await authProvider.AuthenticateRequestAsync(newRequest);
                 httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
@@ -130,6 +140,48 @@ namespace Microsoft.Graph
                 // We will add this check once we re-write a new HttpProvider.
                 return await base.SendAsync(httpRequestMessage, cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Add claims to the request context of the given request message
+        /// </summary>
+        /// <param name="wwwAuthenticateHeader">String representation of www Authenticate Header</param>
+        /// <param name="newRequest">Request message to add claims to</param>
+        private void AddClaimsToRequestContext(HttpRequestMessage newRequest, string wwwAuthenticateHeader)
+        {
+            int claimsStart = wwwAuthenticateHeader.IndexOf("claims=", StringComparison.OrdinalIgnoreCase);
+            if (claimsStart < 0) 
+                return; // do nothing as there is no claims in www Authenticate Header
+
+            claimsStart += 8; // jump to the index after the opening quotation mark
+
+            // extract and decode the Base 64 encoded claims property
+            byte[] bytes = Convert.FromBase64String(wwwAuthenticateHeader.Substring(claimsStart, wwwAuthenticateHeader.Length - claimsStart - 1));
+            string claimsChallenge = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+
+            // Try to get the current options otherwise create new ones
+            AuthenticationHandlerOption authenticationHandlerOption = newRequest.GetMiddlewareOption<AuthenticationHandlerOption>() ?? AuthOption;
+            IAuthenticationProviderOption authenticationProviderOption = authenticationHandlerOption.AuthenticationProviderOption ?? new CaeAuthenticationProviderOption();
+            
+            // make sure that there is no information loss due to casting by copying over the scopes information if necessary
+            CaeAuthenticationProviderOption caeAuthenticationProviderOption;
+            if (authenticationProviderOption is CaeAuthenticationProviderOption option)
+            {
+                caeAuthenticationProviderOption = option;
+            }
+            else
+            {
+                caeAuthenticationProviderOption = new CaeAuthenticationProviderOption(authenticationProviderOption);
+            }
+
+            // update the claims property in the options
+            caeAuthenticationProviderOption.Claims = claimsChallenge;
+            authenticationHandlerOption.AuthenticationProviderOption = caeAuthenticationProviderOption;
+
+            // update the request context with the updated options
+            GraphRequestContext requestContext = newRequest.GetRequestContext();
+            requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
+            newRequest.Properties[typeof(GraphRequestContext).ToString()] = requestContext;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    internal class CaeAuthenticationProviderOption : ICaeAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public CaeAuthenticationProviderOption()
+        {
+        }
+
+        /// <summary>
+        /// Create instance of <see cref="CaeAuthenticationProviderOption"/> from an <see cref="IAuthenticationProviderOption"/> instance
+        /// </summary>
+        public CaeAuthenticationProviderOption(IAuthenticationProviderOption authenticationProviderOption)
+        {
+            this.Scopes = authenticationProviderOption?.Scopes;
+        }
+
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        public string Claims { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    public interface ICaeAuthenticationProviderOption : IAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        string Claims { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class LargeFileUploadTask<T>
     {
-        private const int DefaultMaxSliceSize = 4 * 1024 * 1024;
+        private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
         private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;

--- a/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
+++ b/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
@@ -99,7 +99,7 @@
       <Version>27.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Core.Utils">
-      <Version>27.0.2</Version>
+      <Version>28.0.0.3</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.5.3.2</Version>

--- a/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
+++ b/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
@@ -102,7 +102,7 @@
       <Version>27.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.0.1</Version>
+      <Version>1.5.3.2</Version>
     </PackageReference>
     <PackageReference Include="xunit.abstractions">
       <Version>2.0.3</Version>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -64,7 +64,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime.Serialization" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
    
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
@@ -74,7 +74,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime.Serialization" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid70' ">
@@ -84,7 +84,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Runtime.Serialization" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
    <ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -44,7 +44,7 @@
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.Graph" Version="3.*" />
     <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0">
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.Graph" Version="3.*" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -369,5 +369,38 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             }
         }
+
+        /// <summary>
+        /// Testing that ErrorResponse can't be deserialized and causes the GeneralException 
+        /// code to be thrown in a ServiceException.
+        /// This test validates that the NullReference exception is no longer thrown according to
+        /// https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/113
+        /// </summary>
+        [Fact]
+        public async Task SendAsync_DoesNotThrowNullReferenceExceptionWhenHeaderContentTypeIsNull()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent(""))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.Content.Headers.ContentType = null;
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+
+                // Assert that we creating an GeneralException error.
+                Assert.Same(ErrorConstants.Codes.GeneralException, exception.Error.Code);
+                Assert.Same(ErrorConstants.Messages.UnexpectedExceptionResponse, exception.Error.Message);
+
+                // Assert that the response is null since we have no contentType.
+                Assert.Null(exception.RawResponseBody);
+
+            }
+        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -37,6 +37,37 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         }
 
         [Fact]
+        public void ShouldNotThrowArgumentExceptionOnConstructorWithoutSliceSize()
+        {
+            // Try to upload 1Mb stream without specifying the slice size(should default to 5Mb)
+            byte[] mockData = new byte[1000000];
+            using (Stream stream = new MemoryStream(mockData))
+            {
+                // Arrange
+                IUploadSession uploadSession = new Graph.Core.Models.UploadSession
+                {
+                    NextExpectedRanges = new List<string>() { "0-" },
+                    UploadUrl = "http://localhost",
+                    ExpirationDateTime = DateTimeOffset.Parse("2019-11-07T06:39:31.499Z")
+                };
+
+                // Act with constructor without chunk length
+                var fileUploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, stream);
+                var uploadSlices = fileUploadTask.GetUploadSliceRequests();
+
+                // Assert
+                //We have only 1 slices
+                Assert.Single(uploadSlices);
+
+                var onlyUploadSlice = uploadSlices.First();
+                Assert.Equal(stream.Length, onlyUploadSlice.TotalSessionLength);
+                Assert.Equal(0, onlyUploadSlice.RangeBegin);
+                Assert.Equal(stream.Length - 1, onlyUploadSlice.RangeEnd);
+                Assert.Equal(stream.Length , onlyUploadSlice.RangeLength); //verify the last slice is the right size
+            }
+        }
+
+        [Fact]
         public void BreaksDownStreamIntoRangesCorrectly()
         {
             byte[] mockData = new byte[1000000];//create a stream of about 1M so we can split it into a few 320K slices


### PR DESCRIPTION
This PR creates a new release for the core library with the following fixes

- Dependabot updates(#148,#149,#150,#151,#153,#154,#156)
- Fix for NullReference exception thrown when contentType is empty (#164)
- Fix DefaultMaxSliceSize in LargeFileUpload task (#159) 
- Add support for content type with parameters (#169)
- Add Continuous Access Evaluation (CAE) support (#173)