### PR TITLE
Sync dev and 2.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -69,14 +69,14 @@ steps:
   displayName: 'Run enabled tests'
   inputs:
     testAssemblyVer2: |
-      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      **/netcoreapp3.1/Microsoft.Graph.DotnetCore.Core.Test.dll
       !**/*TestAdapter.dll
       !**/obj/**
     diagnosticsEnabled: true
     configuration: debug
     searchFolder: 'tests'
     platform: AnyCPU
-    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
 - task: PowerShell@2
   displayName: 'Enable signing'

--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -104,7 +104,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
     Pattern: Microsoft.Graph.Core.dll
     signConfigType: inlineSignParams
@@ -130,7 +130,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
     Pattern: Microsoft.Graph.Core.dll
     signConfigType: inlineSignParams
@@ -184,7 +184,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
     Pattern: '*.nupkg'
     signConfigType: inlineSignParams

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -93,7 +93,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core) (AKV)'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
     Pattern: Microsoft.Graph.Core.dll
     signConfigType: inlineSignParams

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -91,7 +91,7 @@ steps:
     clean: true
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
+  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core) (AKV)'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
     FolderPath: src/Microsoft.Graph.Core/bin/release
@@ -119,7 +119,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
     Pattern: Microsoft.Graph.Core.dll
     signConfigType: inlineSignParams
@@ -173,7 +173,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'
   inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
     Pattern: '*.nupkg'
     signConfigType: inlineSignParams

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -66,14 +66,14 @@ steps:
   displayName: 'Run enabled tests'
   inputs:
     testAssemblyVer2: |
-      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      **/netcoreapp3.1/Microsoft.Graph.DotnetCore.Core.Test.dll
       !**/*TestAdapter.dll
       !**/obj/**
     diagnosticsEnabled: true
     configuration: debug
     searchFolder: 'tests'
     platform: AnyCPU
-    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
 - task: PowerShell@2
   displayName: 'Enable signing'

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -71,14 +71,14 @@ steps:
   displayName: 'Run enabled tests'
   inputs:
     testAssemblyVer2: |
-      **/netcoreapp2.2/Microsoft.Graph.DotnetCore.Core.Test.dll
+      **/netcoreapp3.1/Microsoft.Graph.DotnetCore.Core.Test.dll
       !**/*TestAdapter.dll
       !**/obj/**
     diagnosticsEnabled: true
     configuration: debug
     searchFolder: 'tests'
     platform: AnyCPU
-    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v2.2'
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
 - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
   displayName: 'Graph Client Tooling pipeline fail notification'

--- a/scripts/IncrementPreviewVersion.ps1
+++ b/scripts/IncrementPreviewVersion.ps1
@@ -15,12 +15,13 @@
 
 #>
 
+[CmdletBinding()]
 Param(
-    [parameter(Mandatory = $true)]
-    [string]$packageName,
+    [parameter(Mandatory = $false)]
+    [string]$packageName = 'microsoft.graph.core',
 
-    [parameter(Mandatory = $true)]
-    [string]$projectPath
+    [parameter(Mandatory = $false)]
+    [string]$projectPath = '.\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj'
 )
 
 $xmlDoc = New-Object System.Xml.XmlDocument
@@ -31,9 +32,9 @@ $versionSuffixString = $xmlDoc.Project.PropertyGroup[0].VersionSuffix
 
 # Don't do anything if a VersionSuffix has been set in the .csproj.
 if ($versionSuffixString -ne '' -and $versionSuffixString -ne $null) {
-    Write-Host "The VersionSuffix has been set as $versionSuffixString in the csproj file. `
-    Skip the automatic setting or incrementing of the version suffix. Delete the value in `
-    VersionSuffix to enable auto-incrementing the preview version." -ForegroundColor Yellow
+    Write-Host "`tThe VersionSuffix has been set as $versionSuffixString in the csproj file. `
+`tSkip the automatic setting or incrementing of the version suffix. Delete the value in `
+`tVersionSuffix to enable auto-incrementing the preview version." -ForegroundColor Yellow
 
     Exit 0
 }
@@ -51,19 +52,31 @@ $url = "https://api.nuget.org/v3-flatcontainer/$packageName/index.json"
 # Call the NuGet API for the package and get the highest SemVer 2.0.0 version for the package.
 # Per rules https://semver.org/spec/v2.0.0.html#spec-item-11
 $nugetIndex = Invoke-RestMethod -Uri $url -Method Get
-$highestPublishedVersion = $nugetIndex.versions[$nugetIndex.versions.Length - 1]
 
-# We do need to make sure it is listed. For example, we didn't properly suffix M.G.A so the
-# highest reported version is incorrect.
+# We need the versionPrefix from the csproj so that we target the 
+# the highest version. This enables us to support v1.x.x and vNext.x.x
+$versionPrefix = $xmlDoc.Project.PropertyGroup[0].VersionPrefix
 
-# We assume that the Version takes the form of 'x.y.z' with an optional '-preview.n' appended for preview releases.
-Write-Host "The highest published version of $packageName is $highestPublishedVersion"
-
-# Set or increment the VersionSuffix.
-if ($highestPublishedVersion.Indexof('-preview') -eq -1) {
+# Only consider versions that match the version prefix in the csproj.
+$versionmatches = $nugetIndex.versions -match $versionPrefix
+if ($versionmatches.Count -eq 0) {
+    # if the version hasn't been published, we need to add a preview versionSuffix.
+    # Add an initial preview versionSuffix
     $versionSuffixString = 'preview.1' # Build applies the hyphen
 }
-else {
+else { 
+    # We have published preview versions for this version prefix.
+
+    # Only look at preview versions, also to referred to as versionSuffix
+    $versionmatches = $versionmatches -match 'preview'
+
+    # Assumption: the API returns the versions in order.
+    $highestPublishedVersion = $versionmatches[$versionmatches.Count - 1]
+
+    # We assume that the Version takes the form of 'x.y.z' with an optional '-preview.n' appended for preview releases.
+    Write-Host "The highest published version of $packageName is $highestPublishedVersion"
+
+    # if the version has been published with a versionSuffix, then increment the suffix.    
     # A preview has been previously released. Let's increment the VersionSuffix.
     $currentPreviewVersion = [int]$highestPublishedVersion.Split('-')[1].Split('.')[1]
 
@@ -72,7 +85,7 @@ else {
     $versionSuffixString = "preview.{0}" -f $incrementedPreviewVersion
 }
 
-Write-Host "The preview version is now $versionSuffixString" -ForegroundColor Green
+Write-Host "The preview version is now $versionPrefix-$versionSuffixString" -ForegroundColor Green
 
 $xmlDoc.Project.PropertyGroup[0].VersionSuffix = $versionSuffixString
 $xmlDoc.Save($projectPath)

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -4,7 +4,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net461;MonoAndroid80;Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;MonoAndroid80;Xamarin.iOS10;Xamarin.Mac20;</TargetFrameworks>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
     <PackageId>Microsoft.Graph.Core</PackageId>
@@ -36,6 +36,13 @@
     <DefineConstants>$(DefineConstants);iOS</DefineConstants>
     <DebugType>full</DebugType>
     <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);macOS</DefineConstants>
+    <DebugType>full</DebugType>
+    <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets</LanguageTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
@@ -71,6 +78,15 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
+    <Reference Include="Xamarin.Mac" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
     <Reference Include="Mono.Android" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,11 +22,17 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-      - Adds support for TokenCredential from Azure.Core
-      - [Breaking Change] Adds support for System.Text,Json and drops Newtonsoft.Json dependency
-      - [Breaking Change] Fix for incorrect task cancellation #28
-      - Added GraphResponse object for wrapping responses
-      - [Breaking Change] IBaseRequest now takes IResponseHandler as a member
+- Adds support for TokenCredential from Azure.Core
+- [Breaking Change] Adds support for System.Text,Json and drops Newtonsoft.Json dependency
+- [Breaking Change] Fix for incorrect task cancellation #28
+- Added GraphResponse object for wrapping responses
+- [Breaking Change] IBaseRequest now takes IResponseHandler as a member
+- Support Mac Http handlers(v1.0 feature)
+- Compression header handling(v1.0 feature)
+- Fix DefaultMaxSliceSize in LargeFileUpload task(v1.0 feature)
+- Fix for NullReference exception thrown when contentType is empty(v1.0 feature)
+- Add support for content with parameters(v1.0 feature)
+- Add continuous access evaluation(CAE) support(v1.0 feature)
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Graph
 
                     if (!string.IsNullOrEmpty(this.ContentType))
                     {
-                        request.Content.Headers.ContentType = new MediaTypeHeaderValue(this.ContentType);
+                        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(this.ContentType);
                     }
                 }
 

--- a/src/Microsoft.Graph.Core/Requests/BaseRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequestBuilder.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The base request builder class.
     /// </summary>
-    public class BaseRequestBuilder
+    public class BaseRequestBuilder : IBaseRequestBuilder
     {
         /// <summary>
         /// Constructs a new <see cref="BaseRequestBuilder"/>.

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -179,15 +179,20 @@ namespace Microsoft.Graph
                     throw new ArgumentNullException(nameof(handlers), "DelegatingHandler array contains null item.");
                 }
 
+#if iOS || macOS
 #if iOS
-                // Skip CompressionHandler since NSUrlSessionHandler automatically handles decompression on iOS and it can't be turned off.
+                // Skip CompressionHandler since NSUrlSessionHandler automatically handles decompression on iOS and macOS and it can't be turned off.
                 // See issue https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/481 for more details.
                 if (finalHandler.GetType().Equals(typeof(NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
+#elif macOS
+                 if (finalHandler.GetType().Equals(typeof(Foundation.NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
+#endif
                 {
                     // Skip chaining of CompressionHandler.
                     continue;
                 }
 #endif
+
                 // Check for duplicate handler by type.
                 if (!existingHandlerTypes.Add(handler.GetType()))
                 {
@@ -206,11 +211,11 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Gets a platform's native http handler i.e. NSUrlSessionHandler for Xamarin.iOS, AndroidClientHandler for Xamarin.Android and HttpClientHandler for others.
+        /// Gets a platform's native http handler i.e. NSUrlSessionHandler for Xamarin.iOS and Xamarin.Mac, AndroidClientHandler for Xamarin.Android and HttpClientHandler for others.
         /// </summary>
         /// <param name="proxy">The proxy to be used with created client.</param>
         /// <returns>
-        /// 1. NSUrlSessionHandler for Xamarin.iOS 
+        /// 1. NSUrlSessionHandler for Xamarin.iOS and Xamarin.Mac
         /// 2. AndroidClientHandler for Xamarin.Android.
         /// 3. HttpClientHandler for other platforms.
         /// </returns>
@@ -218,6 +223,8 @@ namespace Microsoft.Graph
         {
 #if iOS
             return new NSUrlSessionHandler { AllowAutoRedirect = false };
+#elif macOS
+            return new Foundation.NSUrlSessionHandler { AllowAutoRedirect = false };
 #elif ANDROID
             return new Xamarin.Android.Net.AndroidClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
 #else

--- a/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
         /// <summary>
         /// A MiddlewareOptions property
         /// </summary>
-        public IDictionary<string, IMiddlewareOption> MiddlewareOptions { get; set; }
+        public IDictionary<string, IMiddlewareOption> MiddlewareOptions {
+            get => _middlewareOptions ?? (_middlewareOptions = new Dictionary<string, IMiddlewareOption>());
+            set => _middlewareOptions = value;
+        }
 
         /// <summary>
         /// A CancellationToken property
@@ -36,5 +39,7 @@ namespace Microsoft.Graph
         /// A <see cref="GraphUserAccount"/> property representing the logged in user
         /// </summary>
         public GraphUserAccount User { get; set; }
+
+        private IDictionary<string, IMiddlewareOption> _middlewareOptions;
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Graph
 
                 HttpResponseMessage response = await base.SendAsync(httpRequestMessage, cancellationToken);
 
-                // Chcek if response is a 401 & is not a streamed body (is buffered)
+                // Check if response is a 401 & is not a streamed body (is buffered)
                 if (IsUnauthorized(response) && httpRequestMessage.IsBuffered())
                 {
                     // re-issue the request to get a new access token

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -7,7 +7,11 @@ namespace Microsoft.Graph
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using System;
+    using System.Linq;
     using System.Net;
+    using System.Text;
+
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
     /// </summary>
@@ -77,8 +81,14 @@ namespace Microsoft.Graph
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
                 var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
 
-                // Authenticate request using AuthenticationProvider
+                // extract the www-authenticate header and add claims to the request context
+                if (httpResponseMessage.Headers.WwwAuthenticate.Any())
+                {
+                    var wwwAuthenticateHeader = httpResponseMessage.Headers.WwwAuthenticate.ToString();
+                    AddClaimsToRequestContext(newRequest, wwwAuthenticateHeader);
+                }
 
+                // Authenticate request using AuthenticationProvider
                 await authProvider.AuthenticateRequestAsync(newRequest);
                 httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
@@ -130,6 +140,48 @@ namespace Microsoft.Graph
                 // We will add this check once we re-write a new HttpProvider.
                 return await base.SendAsync(httpRequestMessage, cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Add claims to the request context of the given request message
+        /// </summary>
+        /// <param name="wwwAuthenticateHeader">String representation of www Authenticate Header</param>
+        /// <param name="newRequest">Request message to add claims to</param>
+        private void AddClaimsToRequestContext(HttpRequestMessage newRequest, string wwwAuthenticateHeader)
+        {
+            int claimsStart = wwwAuthenticateHeader.IndexOf("claims=", StringComparison.OrdinalIgnoreCase);
+            if (claimsStart < 0) 
+                return; // do nothing as there is no claims in www Authenticate Header
+
+            claimsStart += 8; // jump to the index after the opening quotation mark
+
+            // extract and decode the Base 64 encoded claims property
+            byte[] bytes = Convert.FromBase64String(wwwAuthenticateHeader.Substring(claimsStart, wwwAuthenticateHeader.Length - claimsStart - 1));
+            string claimsChallenge = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+
+            // Try to get the current options otherwise create new ones
+            AuthenticationHandlerOption authenticationHandlerOption = newRequest.GetMiddlewareOption<AuthenticationHandlerOption>() ?? AuthOption;
+            IAuthenticationProviderOption authenticationProviderOption = authenticationHandlerOption.AuthenticationProviderOption ?? new CaeAuthenticationProviderOption();
+            
+            // make sure that there is no information loss due to casting by copying over the scopes information if necessary
+            CaeAuthenticationProviderOption caeAuthenticationProviderOption;
+            if (authenticationProviderOption is CaeAuthenticationProviderOption option)
+            {
+                caeAuthenticationProviderOption = option;
+            }
+            else
+            {
+                caeAuthenticationProviderOption = new CaeAuthenticationProviderOption(authenticationProviderOption);
+            }
+
+            // update the claims property in the options
+            caeAuthenticationProviderOption.Claims = claimsChallenge;
+            authenticationHandlerOption.AuthenticationProviderOption = caeAuthenticationProviderOption;
+
+            // update the request context with the updated options
+            GraphRequestContext requestContext = newRequest.GetRequestContext();
+            requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
+            newRequest.Properties[typeof(GraphRequestContext).ToString()] = requestContext;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Threading.Tasks;
     using System.Net.Http.Headers;
     using System.IO.Compression;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A <see cref="DelegatingHandler"/> implementation that handles compression.
@@ -53,7 +54,13 @@ namespace Microsoft.Graph
             // Decompress response content when Content-Encoding: gzip header is present.
             if (ShouldDecompressContent(response))
             {
-                response.Content = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                // Copy Content Headers to the destination stream content
+                foreach (var httpContentHeader in response.Content.Headers)
+                {
+                    streamContent.Headers.TryAddWithoutValidation(httpContentHeader.Key, httpContentHeader.Value);
+                }
+                response.Content = streamContent;
             }
 
             return response;

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/CaeAuthenticationProviderOption.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    internal class CaeAuthenticationProviderOption : ICaeAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public CaeAuthenticationProviderOption()
+        {
+        }
+
+        /// <summary>
+        /// Create instance of <see cref="CaeAuthenticationProviderOption"/> from an <see cref="IAuthenticationProviderOption"/> instance
+        /// </summary>
+        public CaeAuthenticationProviderOption(IAuthenticationProviderOption authenticationProviderOption)
+        {
+            this.Scopes = authenticationProviderOption?.Scopes;
+        }
+
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        public string Claims { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ICaeAuthenticationProviderOption.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// An interface used to pass auth provider options in a request.
+    /// Auth providers will be in charge of implementing this interface and providing <see cref="IBaseRequest"/> extensions to set it's values.
+    /// </summary>
+    public interface ICaeAuthenticationProviderOption : IAuthenticationProviderOption
+    {
+        /// <summary>
+        /// Microsoft Graph scopes property.
+        /// </summary>
+        string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Claims challenge for the authentication
+        /// </summary>
+        string Claims { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// </summary>
     public class LargeFileUploadTask<T>
     {
-        private const int DefaultMaxSliceSize = 4 * 1024 * 1024;
+        private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
         private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;Xamarin.iOS10;MonoAndroid80</TargetFrameworks>
     <AssemblyName>Microsoft.Graph.DotnetCore.Core.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Core.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
-    <RuntimeFrameworkVersion>2.2.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	<DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
@@ -53,7 +53,7 @@
 	<ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -25,7 +25,15 @@
 	<DebugType>full</DebugType>
 	<LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets</LanguageTargets>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);macOS</DefineConstants>
+    <DebugType>full</DebugType>
+    <LanguageTargets>$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets</LanguageTargets>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
 	<TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
 	<TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
@@ -60,7 +68,17 @@
 	<Reference Include="System.Xml" />
 	<Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.Mac20' ">
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Xamarin.Mac" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
 	<Reference Include="Microsoft.CSharp" />
 	<Reference Include="Mono.Android" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -183,6 +183,53 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public async Task SendAsyncSupportsContentTypeWithParameters()
+        {
+            // Arrange
+            var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
+
+            // Create a request that has content type with parameters 
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json; odata=verbose" }; 
+
+            using (var httpResponseMessage = new HttpResponseMessage())
+            using (var responseStream = new MemoryStream())
+            using (var streamContent = new StreamContent(responseStream))
+            {
+                httpResponseMessage.Content = streamContent;
+
+                this.httpProvider.Setup(
+                    provider => provider.SendAsync(
+                        It.Is<HttpRequestMessage>(
+                            request =>
+                                string.Equals(request.Content.Headers.ContentType.ToString(), "application/json; odata=verbose")
+                               && request.RequestUri.ToString().Equals(requestUrl)),
+                        HttpCompletionOption.ResponseContentRead,
+                        CancellationToken.None))
+                        .Returns(Task.FromResult(httpResponseMessage));
+
+                var expectedResponseItem = new DerivedTypeClass { Id = "id" };
+                this.serializer.Setup(
+                    serializer => serializer.SerializeObject(It.IsAny<string>()))
+                    .Returns(string.Empty);
+                this.serializer.Setup(
+                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<string>()))
+                    .Returns(expectedResponseItem);
+
+                // Act
+                var responseItem = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
+
+                // Assert
+                Assert.NotNull(responseItem);
+                Assert.Equal(expectedResponseItem.Id, responseItem.Id);
+                Assert.NotNull(baseRequest.Client.AuthenticationProvider);
+                Assert.NotNull(baseRequest.GetHttpRequestMessage().GetRequestContext().ClientRequestId);
+                Assert.Equal(baseRequest.GetHttpRequestMessage().GetMiddlewareOption<AuthenticationHandlerOption>().AuthenticationProvider, 
+                    baseRequest.Client.AuthenticationProvider);
+                Assert.Equal("application/json; odata=verbose", baseRequest.ContentType);
+            }
+        }
+
+        [Fact]
         public async Task SendAsync_ResponseHeaders()
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -41,14 +41,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         // and 'GraphClientFactory.DefaultHttpHandler' can easily be modified
         // by other tests since it's a static delegate.
 
-#if iOS
+#if iOS || macOS
         [Fact]
         public void Should_CreatePipeline_Without_CompressionHandler()
         {
             using (AuthenticationHandler authenticationHandler = (AuthenticationHandler)GraphClientFactory.CreatePipeline(handlers))
             using (RetryHandler retryHandler = (RetryHandler)authenticationHandler.InnerHandler)
             using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
+#if iOS
             using (NSUrlSessionHandler innerMost = (NSUrlSessionHandler)redirectHandler.InnerHandler)
+#elif macOS
+            using (Foundation.NSUrlSessionHandler innerMost = (Foundation.NSUrlSessionHandler)redirectHandler.InnerHandler)
+#endif
             {
                 Assert.NotNull(authenticationHandler);
                 Assert.NotNull(retryHandler);
@@ -57,7 +61,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.IsType<AuthenticationHandler>(authenticationHandler);
                 Assert.IsType<RetryHandler>(retryHandler);
                 Assert.IsType<RedirectHandler>(redirectHandler);
+#if iOS
                 Assert.IsType<NSUrlSessionHandler>(innerMost);
+#elif macOS
+                Assert.IsType<Foundation.NSUrlSessionHandler>(innerMost);
+#endif
             }
         }
 #else

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -115,6 +115,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 #elif iOS
                 Assert.IsType<NSUrlSessionHandler>(defaultHttpProvider.httpMessageHandler);
                 Assert.False((defaultHttpProvider.httpMessageHandler as NSUrlSessionHandler).AllowAutoRedirect);
+#elif macOS
+                Assert.IsType<Foundation.NSUrlSessionHandler>(defaultHttpProvider.httpMessageHandler);
+                Assert.False((defaultHttpProvider.httpMessageHandler as Foundation.NSUrlSessionHandler).AllowAutoRedirect);
 #else
                 Assert.IsType<HttpClientHandler>(defaultHttpProvider.httpMessageHandler);
                 Assert.False((defaultHttpProvider.httpMessageHandler as HttpClientHandler).AllowAutoRedirect);
@@ -553,12 +556,16 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 #endif
         #endregion
 
-        #region iOS
-#if iOS
+        #region iOS_macOS
+#if iOS || macOS
         [Fact]
         public void HttpProvider_CustomNSUrlSessionHandler()
         {
+#if iOS
             using (var httpClientHandler = new NSUrlSessionHandler())
+#elif macOS
+            using (var httpClientHandler = new Foundation.NSUrlSessionHandler())
+#endif
             using (var httpProvider = new HttpProvider(httpClientHandler, false, null))
             {
                 Assert.Equal(httpClientHandler, httpProvider.httpMessageHandler);
@@ -567,6 +574,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             }
         }
 #endif
-        #endregion
+#endregion
+        }
     }
-}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -514,6 +514,39 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.NotSame(ErrorConstants.Messages.UnexpectedExceptionResponse, exception.Error.Message);
         }
 
+        /// <summary>
+        /// Testing that ErrorResponse can't be deserialized and causes the GeneralException 
+        /// code to be thrown in a ServiceException.
+        /// This test validates that the NullReference exception is no longer thrown according to
+        /// https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/113
+        /// </summary>
+        [Fact]
+        public async Task SendAsync_DoesNotThrowNullReferenceExceptionWhenHeaderContentTypeIsNull()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent(""))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.Content.Headers.ContentType = null;
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.httpProvider.SendAsync(httpRequestMessage));
+
+                // Assert that we creating an GeneralException error.
+                Assert.Same(ErrorConstants.Codes.GeneralException, exception.Error.Code);
+                Assert.Same(ErrorConstants.Messages.UnexpectedExceptionResponse, exception.Error.Message);
+
+                // Assert that the response is null since we have no contentType.
+                Assert.Null(exception.RawResponseBody);
+
+            }
+        }
+
         #region NETCORE
         // Skip this test for Xamain since it never throws an exception.
 #if NETCORE

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/CompressionHandlerTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
     using System.Threading.Tasks;
     using System.Threading;
     using System.Net.Http.Headers;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Xunit.Abstractions;
 
     public class CompressionHandlerTests : IDisposable
     {
@@ -93,6 +96,58 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
             Assert.Same(httpResponse, compressedResponse);
             Assert.Same(httpRequestMessage, compressedResponse.RequestMessage);
             Assert.NotEqual(stringToCompress, responseContentString);
+        }
+
+        /// <summary>
+        /// Compression Handler should keep content headers after decompression
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CompressionHandler_should_keep_headers_after_decompression()
+        {
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+
+            string stringToCompress = "Microsoft Graph";
+            StringContent stringContent = new StringContent(stringToCompress);
+            stringContent.Headers.ContentType = new MediaTypeHeaderValue(CoreConstants.MimeTypeNames.Application.Json);
+
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MockCompressedContent(stringContent)
+            };
+            httpResponse.Content.Headers.ContentEncoding.Add(CoreConstants.Encoding.GZip);
+            httpResponse.Headers.CacheControl = new CacheControlHeaderValue { Private = true };
+            // Examples of Custom Headers returned by Microsoft Graph
+            httpResponse.Headers.Add(CoreConstants.Headers.ClientRequestId, Guid.NewGuid().ToString());
+            httpResponse.Headers.Add("request-id", Guid.NewGuid().ToString());
+            httpResponse.Headers.Add("OData-Version", "4.0");
+
+            this.testHttpMessageHandler.SetHttpResponse(httpResponse);
+
+            HttpResponseMessage compressedResponse = await this.invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            string decompressedResponseString = await compressedResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(decompressedResponseString, stringToCompress);
+
+            // Ensure that headers in the compressedResponse are the same as in the original, expected response.
+            Assert.NotEmpty(compressedResponse.Headers);
+            Assert.NotEmpty(compressedResponse.Content.Headers);
+            Assert.Equal(httpResponse.Headers, compressedResponse.Headers, new HttpHeaderComparer());
+            Assert.Equal(httpResponse.Content.Headers, compressedResponse.Content.Headers, new HttpHeaderComparer());
+        }
+
+        internal class HttpHeaderComparer : IEqualityComparer<KeyValuePair<string, IEnumerable<string>>>
+        {
+            public bool Equals(KeyValuePair<string, IEnumerable<string>> x, KeyValuePair<string, IEnumerable<string>> y)
+            {
+                // For each key, the collection of header values should be equal.
+                return x.Key == y.Key && x.Value.SequenceEqual(y.Value);
+            }
+
+            public int GetHashCode(KeyValuePair<string, IEnumerable<string>> obj)
+            {
+                return obj.Key.GetHashCode();
+            }
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -368,5 +368,38 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             }
         }
+
+        /// <summary>
+        /// Testing that ErrorResponse can't be deserialized and causes the GeneralException 
+        /// code to be thrown in a ServiceException.
+        /// This test validates that the NullReference exception is no longer thrown according to
+        /// https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/113
+        /// </summary>
+        [Fact]
+        public async Task SendAsync_DoesNotThrowNullReferenceExceptionWhenHeaderContentTypeIsNull()
+        {
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))
+            using (var stringContent = new StringContent(""))
+            using (var httpResponseMessage = new HttpResponseMessage())
+            {
+                httpResponseMessage.Content = stringContent;
+                httpResponseMessage.Content.Headers.ContentType = null;
+
+                httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
+                httpResponseMessage.RequestMessage = httpRequestMessage;
+
+                this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
+
+                ServiceException exception = await Assert.ThrowsAsync<ServiceException>(async () => await this.simpleHttpProvider.SendAsync(httpRequestMessage));
+
+                // Assert that we creating an GeneralException error.
+                Assert.Same(ErrorConstants.Codes.GeneralException, exception.Error.Code);
+                Assert.Same(ErrorConstants.Messages.UnexpectedExceptionResponse, exception.Error.Message);
+
+                // Assert that the response is null since we have no contentType.
+                Assert.Null(exception.RawResponseBody);
+
+            }
+        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 };
 
                 // Act with constructor without chunk length
-                var fileUploadTask = new LargeFileUploadTask<DriveItem>(uploadSession, stream);
+                var fileUploadTask = new LargeFileUploadTask<TestDriveItem>(uploadSession, stream);
                 var uploadSlices = fileUploadTask.GetUploadSliceRequests();
 
                 // Assert


### PR DESCRIPTION
This PR syncs changes made in the dev branch to the feature/2.0 by cherrypicking relevant commits to the dev branch since the last sync (i.e 1.20.0 release)

The relevant PRs/commits include 
- #101 Fix typo
- #110 Support Mac Http handlers
- #118 Compression header handling
- #121 Fix Preview increment script
- #130 Use new service connection in pipelines
- #146 Create dependabot.yml
- #159 Fix DefaultMaxSliceSize in LargeFileUpload task 
- #164 Fix for NullReference exception thrown when contentType is empty
- #169 Add support for content with parameters
- #173 Add continuous access evaluation(CAE) support



**Exceptions**
- Dependabot PRs (i.e.#156, #153, #149, #150, #148 ,#151 and #154) have been skipped as dependabot will create PRs separately in the future.
- PR #135 has been skipped from this PR due to direct conflicts in usage of Newtonsoft and System.Text.Json. This will be handled in a separate PR to the 2.0 branch.