### PR TITLE
Release: Support composable functions from the generated service library

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,13 +19,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.23.0</VersionPrefix>
+    <VersionPrefix>1.24.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for #120: Exception thrown when slice size is not specified for LargeFileUploadTask
-- Fix for #113: NullReferenceException thrown when error response does not have content type header is empty.
-- Fix for #165: Add support for content types with parameters to BaseRequest
-- Add support for Continuous Access Evaluation(CAE)
+- Support composable functions.
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestBuilderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestBuilderTests.cs
@@ -4,10 +4,17 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 {
+    using Microsoft.Graph.DotnetCore.Core.Test.TestModels;
     using Moq;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
     using Xunit;
     public class BaseRequestBuilderTests
     {
+        const string requestUrl = "https://localhost:443/microsoft.graph.composablefunction0";
+
         [Fact]
         public void BaseRequestBuilder()
         {
@@ -31,6 +38,116 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var appendedUrl = requestBuilder.AppendSegmentToRequestUrl(newUrlSegment);
 
             Assert.Equal(string.Join("/", requestUrl, newUrlSegment), appendedUrl);
+        }
+
+        /// <summary>
+        /// Test that: 
+        /// 1) composable functions have all parameters set.
+        /// 2) query options are not yet applied to the URL before HttpRequestMessage is formed.
+        /// 3) query options are applied to the URL after HttpRequestMessage is formed.
+        /// </summary>
+        [Fact]
+        public void ComposableFunctionTest()
+        {
+            var client = new BaseClient(" ", new HttpClient()); // base url needs to be a non-zero length string.
+            var parameter_first_function = "A1:B1";
+            var parameter_second_function = "test-value";
+            var queryOptions = new List<Option>() { new QueryOption("filter", "name"), 
+                                                    new QueryOption("orderby", "date") };
+
+            // Create the composed function request builders
+            var composableFunctionRequestBuilder0 = new ComposableFunctionRequestBuilder0(requestUrl, client, parameter_first_function);
+            var composedRequestUrl = composableFunctionRequestBuilder0.RequestBuilder1(parameter_second_function).Request(queryOptions).RequestUrl;
+
+            // Get the URL formed with query parameters.
+            var actualUrl = composableFunctionRequestBuilder0.RequestBuilder1(parameter_second_function)
+                                                       .Request(queryOptions)
+                                                       .GetHttpRequestMessage()
+                                                       .RequestUri
+                                                       .ToString();
+
+
+            var expected = @"https://localhost:443/microsoft.graph.composablefunction0(address='A1:B1')/microsoft.graph.composablefunction1(anotherValue='test-value')";
+            var expectedFullUrl = "https://localhost/microsoft.graph.composablefunction0(address='A1:B1')/microsoft.graph.composablefunction1(anotherValue='test-value')?filter=name&orderby=date";
+
+            Assert.Equal(expected, composedRequestUrl);
+            Assert.Equal(expectedFullUrl, actualUrl);
+        }
+
+        [Fact]
+        public void ComposableFunctionTestWithSecondParameter()
+        {
+            var client = new BaseClient(" ", new HttpClient()); // base url needs to be a non-zero length string.
+            var parameter_first_function = "A1:B1";
+            var parameter_second_function = "test-value";
+            var parameter_second_function_second_param = "test-value2";
+
+            // Create the composed function request builders
+            var composableFunctionRequestBuilder0 = new ComposableFunctionRequestBuilder0(requestUrl, client, parameter_first_function);
+            var composedRequestUrl = composableFunctionRequestBuilder0.RequestBuilder1(parameter_second_function, parameter_second_function_second_param).Request().RequestUrl;
+
+            var expected = @"https://localhost:443/microsoft.graph.composablefunction0(address='A1:B1')/microsoft.graph.composablefunction1(anotherValue='test-value',secondValue='test-value2')";
+
+            Assert.Equal(expected, composedRequestUrl);
+        }
+
+        /// <summary>
+        /// Test that null values are accepted for nullable parameters.
+        /// </summary>
+        [Fact]
+        public void ComposableFunctionWithNullParamTest()
+        {
+            var client = new BaseClient(" ", new HttpClient()); // base url needs to be a non-zero length string.
+            string parameter_first_function = null;
+            var parameter_second_function = "test-value";
+
+            // Create the composed function request builders
+            var composableFunctionRequestBuilder0 = new ComposableFunctionRequestBuilder0(requestUrl, client, parameter_first_function);
+            var composedRequestUrl = composableFunctionRequestBuilder0.RequestBuilder1(parameter_second_function).Request().RequestUrl;
+
+            var expected = @"https://localhost:443/microsoft.graph.composablefunction0(address=null)/microsoft.graph.composablefunction1(anotherValue='test-value')";
+
+            Assert.Equal(expected, composedRequestUrl);
+        }
+
+        /// <summary>
+        /// Test that parenthesis are added for a function without a parameter.
+        /// This will help distinguish functions without parameters from cast
+        /// syntax.
+        /// </summary>
+        [Fact]
+        public void ComposableFunctionWithNoParamsTest()
+        {
+            
+            var client = new BaseClient(" ", new HttpClient()); // base url needs to be a non-zero length string.
+            var parameter_second_function = "test-value";
+
+            // Create the composed function request builders
+            var composableFunctionRequestBuilder0 = new ComposableFunctionRequestBuilder0(requestUrl, client);
+            var composedRequestUrl = composableFunctionRequestBuilder0.RequestBuilder1(parameter_second_function).Request().RequestUrl;
+
+            var expected = @"https://localhost:443/microsoft.graph.composablefunction0()/microsoft.graph.composablefunction1(anotherValue='test-value')";
+
+            Assert.Equal(expected, composedRequestUrl);
+        }
+
+        /// <summary>
+        /// Functions only support filter and orderby
+        /// </summary>
+        [Theory]
+        [InlineData("filter", "name")]
+        [InlineData("orderby", "test")]
+        public void ComposableFunctionExpectedQueryOptionTest(string name, string value)
+        {
+            var client = new BaseClient(" ", new HttpClient()); // base url needs to be a non-zero length string.
+            var queryOptions = new List<Option>() { new QueryOption(name, value) };
+
+            // Create the composed function request builders
+            var composableFunctionRequestBuilder1 = new ComposableFunctionRequestBuilder1(requestUrl, client, string.Empty);
+
+            var baseRequest = composableFunctionRequestBuilder1.Request(queryOptions);
+            var isQueryParamSet = baseRequest.QueryOptions.Any(qp => qp.Name.ToLower() == name);
+            Assert.True(isQueryParamSet, $"The expected query parameter \"{name}\" was not set.");
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ComposableFunctionRequestBuilder0.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ComposableFunctionRequestBuilder0.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
+{
+
+    class ComposableFunctionRequestBuilder0 : BaseFunctionMethodRequestBuilder<IBaseRequest>
+    {
+        /// <summary>
+        /// The requestUrl should contain a method called microsoft.graph.composablefunction0
+        /// </summary>
+        /// <param name="requestUrl"></param>
+        /// <param name="client"></param>
+        public ComposableFunctionRequestBuilder0(
+            string requestUrl,
+            IBaseClient client)
+            : base(requestUrl, client)
+        {
+            this.SetFunctionParameters();
+        }
+
+        public ComposableFunctionRequestBuilder0(
+            string requestUrl,
+            IBaseClient client,
+            string address)
+            : base(requestUrl, client)
+        {
+            this.SetParameter("address", address, true);
+            this.SetFunctionParameters();
+        }
+
+        protected override IBaseRequest CreateRequest(string functionUrl, IEnumerable<Option> options)
+        {
+            // Don't need this right now. Can implement if we need it.
+            throw new NotImplementedException();
+        }
+
+        public ComposableFunctionRequestBuilder1 RequestBuilder1(string anotherValue)
+        {
+            return new ComposableFunctionRequestBuilder1(
+                this.AppendSegmentToRequestUrl("microsoft.graph.composablefunction1"),
+                this.Client,
+                anotherValue);
+        }
+
+        public ComposableFunctionRequestBuilder1 RequestBuilder1(string anotherValue, string secondValue)
+        {
+            return new ComposableFunctionRequestBuilder1(
+                this.AppendSegmentToRequestUrl("microsoft.graph.composablefunction1"),
+                this.Client,
+                anotherValue,
+                secondValue);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ComposableFunctionRequestBuilder1.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ComposableFunctionRequestBuilder1.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
+{
+
+    class ComposableFunctionRequestBuilder1 : BaseFunctionMethodRequestBuilder<IBaseRequest>
+    {
+        /// <summary>
+        /// The requestUrl should contain a method called ComposableFunction0
+        /// </summary>
+        /// <param name="requestUrl"></param>
+        /// <param name="client"></param>
+        public ComposableFunctionRequestBuilder1(
+            string requestUrl,
+            IBaseClient client)
+            : base(requestUrl, client)
+        {
+        }
+
+        public ComposableFunctionRequestBuilder1(
+            string requestUrl,
+            IBaseClient client,
+            string anotherValue)
+            : base(requestUrl, client)
+        {
+            this.SetParameter("anotherValue", anotherValue, true);
+            this.SetFunctionParameters();
+        }
+
+        public ComposableFunctionRequestBuilder1(
+            string requestUrl,
+            IBaseClient client,
+            string anotherValue,
+            string secondValue)
+            : base(requestUrl, client)
+        {
+            this.SetParameter("anotherValue", anotherValue, true);
+            this.SetParameter("secondValue", secondValue, true);
+            this.SetFunctionParameters();
+        }
+
+        protected override IBaseRequest CreateRequest(string functionUrl, IEnumerable<Option> options)
+        {
+            // Gives us access to the URL for test
+            return new BaseRequest(functionUrl, this.Client, options);
+        }
+    }
+}


### PR DESCRIPTION
This was already reviewed in #183 

* Parameter string is now set before the Request method is called. The generator must now support `SetFunctionParameters()` after parameters are set in a request builder.
* Update BaseFunctionMethodRequestBuilder

- Remove the setting of parameters in Request. This is now done in `SetFunctionParameters()` in the generated request builders.
- Removed unused code. passParametersInQueryString was never set (always true) and the query options were only ever set via CreateRequest(). Definitely need another set of eyes on this.
- We want composable functions to always emit with parenthesis to distinguish from cast syntax. This is a change as functions without parameters weren't emitting parens. `SetFunctionParameters()` has to be called for each function request builder cstor.
- Remove queryoptions and passParametersInQueryString
