### PR TITLE
Polymorphic deserialization fix

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -198,7 +198,6 @@ namespace Microsoft.Graph
 
                 writer.WriteEndObject();//close the root object
                 await writer.FlushAsync();
-                await stream.FlushAsync();
 
                 //Reset the position since we want the caller to use this stream
                 stream.Position = 0;

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -196,10 +196,9 @@ namespace Microsoft.Graph
                 }
                 writer.WriteEndArray();
 
-                
                 writer.WriteEndObject();//close the root object
-                writer.Flush();
-                stream.Flush();
+                await writer.FlushAsync();
+                await stream.FlushAsync();
 
                 //Reset the position since we want the caller to use this stream
                 stream.Position = 0;

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Graph
                     });
             }
 
-            PopulateObject(instance, jsonDocument.RootElement, objectType,options);
+            PopulateObject(instance, jsonDocument.RootElement, options);
             return (T)instance;
         }
 
@@ -111,10 +111,11 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="target">The target object</param>
         /// <param name="json">The json element undergoing deserialization</param>
-        /// <param name="objectType">The target object <see cref="Type"/></param>
         /// <param name="options">The options to use for deserialization.</param>
-        private void PopulateObject(object target, JsonElement json, Type objectType, JsonSerializerOptions options)
+        private void PopulateObject(object target, JsonElement json, JsonSerializerOptions options)
         {
+            // We use the target type information since it maybe be derived. We do not want to leave out extra properties in the child class and put them in the additional data unnecessarily
+            Type objectType = target.GetType();
             switch (json.ValueKind)
             {
                 case JsonValueKind.Object:

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
             using (StreamReader reader = new StreamReader(requestStream))
             {
-                requestContent = reader.ReadToEnd();
+                requestContent = await reader.ReadToEndAsync();
             }
             
             string expectedContent = "{\"requests\":[{\"id\":\"2\",\"url\":\"/me\",\"method\":\"GET\"}]}";

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -51,6 +51,25 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeDerivedTypeFromAbstractParent()
+        {
+            var id = "id";
+            var name = "name";
+
+            var stringToDeserialize = string.Format(
+                "{{\"id\":\"{0}\", \"@odata.type\":\"#microsoft.graph.dotnetCore.core.test.testModels.derivedTypeClass\", \"name\":\"{1}\"}}",
+                id,
+                name);
+
+            //The type information from "@odata.type" should lead to correctly deserializing to the derived type
+            var derivedType = this.serializer.DeserializeObject<AbstractEntityType>(stringToDeserialize) as DerivedTypeClass;
+
+            Assert.NotNull(derivedType);
+            Assert.Equal(id, derivedType.Id);
+            Assert.Equal(name, derivedType.Name);
+        }
+
+        [Fact]
         public void DeserializeInvalidODataType()
         {
             var id = "id";


### PR DESCRIPTION
This PR involves : -

- Changing Flush method calls to the async versions in the BatchRequestContent.cs
- Fixing incorrect deserialization from abstract parent types. When using the DerivedTypeConverter, this would lead lead to extra properties of the child class being put in the additional data rather than being deserialized to the correct properties.
  The change involves using the derived types properties rather than the parent type properties.
