### PR TITLE
Fix for potential deadlock on Authentication

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Graph
                 {
                     // Only call `AuthenticateRequestAsync` when a custom IHttpProvider is used or our HttpProvider is used without an auth handler.
                     if (ShouldAuthenticateRequest())
-                        await this.AuthenticateRequestAsync(request);
+                        await this.AuthenticateRequestAsync(request).ConfigureAwait(false);
 
                     request.Content = multipartContent;
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Graph
                         {
                             Code = ErrorConstants.Codes.GeneralException,
                             Message = ErrorConstants.Messages.LocationHeaderNotSetOnRedirect,
-                        });
+                        },
+                        response.Headers,
+                        response.StatusCode);
                 }
 
                 var redirectCount = 0;


### PR DESCRIPTION
This PR:-

- Fixes #193.  Sets response headers in ServiceException so that customers have access to correlation ids  
- Fixes #188 . Prevents potential deadlock from occurring when `AuthenticateRequestAsync(request)` is called.
