### PR TITLE
Update ResponseHandler to remove serialization headers and statusCode into AdditionalData 

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -34,40 +34,13 @@ namespace Microsoft.Graph
         {
             if (response.Content != null)
             {
-                var responseString = await GetResponseString(response);
-                return serializer.DeserializeObject<T>(responseString);
+                using (var responseStream = await response.Content.ReadAsStreamAsync())
+                {
+                    return serializer.DeserializeObject<T>(responseStream);
+                }
             }
 
             return default(T);
         }
-
-        /// <summary>
-        /// Get the response content string
-        /// </summary>
-        /// <param name="hrm">The response object</param>
-        /// <returns>The full response string to return</returns>
-        private async Task<string> GetResponseString(HttpResponseMessage hrm)
-        {
-            var responseContent = "";
-
-            var content = await hrm.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            //Only add headers if we are going to return a response body
-            if (content.Length > 0)
-            {
-                var responseHeaders = hrm.Headers;
-                var statusCode = hrm.StatusCode;
-
-                Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
-                var responseHeaderString = serializer.SerializeObject(headerDictionary);
-
-                responseContent = content.Substring(0, content.Length - 1) + ", ";
-                responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
-                responseContent += "\"statusCode\": \"" + statusCode + "\"}";
-            }
-
-            return responseContent;
-        }
-
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -165,10 +165,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
                 var expectedResponseItem = new DerivedTypeClass { Id = "id" };
                 this.serializer.Setup(
-                    serializer => serializer.SerializeObject(It.IsAny<string>()))
-                    .Returns(string.Empty);
-                this.serializer.Setup(
-                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<string>()))
+                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<Stream>()))
                     .Returns(expectedResponseItem);
 
                 var responseItem = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
@@ -209,10 +206,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
                 var expectedResponseItem = new DerivedTypeClass { Id = "id" };
                 this.serializer.Setup(
-                    serializer => serializer.SerializeObject(It.IsAny<string>()))
-                    .Returns(string.Empty);
-                this.serializer.Setup(
-                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<string>()))
+                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<Stream>()))
                     .Returns(expectedResponseItem);
 
                 // Act
@@ -226,50 +220,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.Equal(baseRequest.GetHttpRequestMessage().GetMiddlewareOption<AuthenticationHandlerOption>().AuthenticationProvider, 
                     baseRequest.Client.AuthenticationProvider);
                 Assert.Equal("application/json; odata=verbose", baseRequest.ContentType);
-            }
-        }
-
-        [Fact]
-        public async Task SendAsync_ResponseHeaders()
-        {
-            var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json" };
-            var data = "{\"data\"}";
-
-            using (var httpResponseMessage = new HttpResponseMessage())
-            using (var responseStream = new MemoryStream(Encoding.ASCII.GetBytes(data)))
-            using (var streamContent = new StreamContent(responseStream))
-            {
-                httpResponseMessage.Content = streamContent;
-                httpResponseMessage.StatusCode = System.Net.HttpStatusCode.OK;
-
-                this.httpProvider.Setup(
-                    provider => provider.SendAsync(
-                        It.Is<HttpRequestMessage>(
-                            request =>
-                                string.Equals(request.Content.Headers.ContentType.ToString(), "application/json")
-                               && request.RequestUri.ToString().Equals(requestUrl)),
-                        HttpCompletionOption.ResponseContentRead,
-                        CancellationToken.None))
-                        .Returns(Task.FromResult(httpResponseMessage));
-
-                Dictionary<string, object> additionalData = new Dictionary<string, object>();
-                additionalData["responseHeaders"] = new Dictionary<string, List<string>>() { { "key", new List<string>() { "value" } } };
-
-                var expectedResponseItem = new DerivedTypeClass { Id = "id", AdditionalData = additionalData };
-
-                this.serializer.Setup(
-                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<string>()))
-                    .Returns(expectedResponseItem);
-                this.serializer.Setup(
-                    serializer => serializer.DeserializeObject<DerivedTypeClass>(It.IsAny<string>()))
-                    .Returns(expectedResponseItem);
-
-                var responseItem = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
-                Assert.NotNull(responseItem.AdditionalData["responseHeaders"]);
-                Assert.NotNull(baseRequest.Client.AuthenticationProvider);
-                Assert.NotNull(baseRequest.GetHttpRequestMessage().GetRequestContext().ClientRequestId);
-                Assert.Equal(expectedResponseItem.AdditionalData["responseHeaders"], responseItem.AdditionalData["responseHeaders"]);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal("123", user.Id);
             Assert.Equal("Joe", user.GivenName);
             Assert.Equal("Brown", user.Surname);
-            Assert.Equal("OK", user.AdditionalData["statusCode"].ToString());
 
         }
     }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -40,10 +40,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal("123", user.Id);
             Assert.Equal("Joe", user.GivenName);
             Assert.Equal("Brown", user.Surname);
-            Assert.Equal("OK", user.AdditionalData["statusCode"].ToString());
-            var headers = (JsonElement)(user.AdditionalData["responseHeaders"]);
-            var headerValue = headers.GetProperty("test");
-            Assert.Equal("value", headerValue.EnumerateArray().ElementAt(0).ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
This PR closes #206.

With the introduction of GraphResponse, customers now have a way to access the Http Response Headers and Http Response Status Code. 
This PR therefore undoes the workaround earlier implemented that puts this info into the AdditionalData to improve performance and memory usage by deserializing the data directly from a content stream.