### PR TITLE
Handle empty streams similar to empty string content

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -38,6 +38,7 @@
 - Fixes setting of response headers in ServiceException so that customers have access to correlation ids #193 (v1.0 feature)
 - Prevents potential deadlock from occurring when AuthenticateRequestAsync(request) is called. #188 (v1.0 feature)
 - [Breaking Change] Remove serialization of headers and statusCode into AdditionalData #206
+- Fix deserialization of empty streams to be consistent with empty strings
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Serialization/Serializer.cs
+++ b/src/Microsoft.Graph.Core/Serialization/Serializer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Graph
         /// <returns>The deserialized object.</returns>
         public T DeserializeObject<T>(Stream stream)
         {
-            if (stream == null)
+            if (stream == null || stream.Length == 0 )
             {
                 return default(T);
             }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -106,6 +106,23 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void DeserializeEmptyStringOrStream()
+        {
+            var stringToDeserialize = string.Empty;
+
+            // Asset empty stream deserializes to null
+            using (var serializedStream = new MemoryStream(Encoding.UTF8.GetBytes(stringToDeserialize)))
+            {
+                var instance = this.serializer.DeserializeObject<DerivedTypeClass>(serializedStream);
+                Assert.Null(instance);
+            }
+
+            // Asset empty string deserializes to null
+            var stringInstance = this.serializer.DeserializeObject<DerivedTypeClass>(stringToDeserialize);
+            Assert.Null(stringInstance);
+        }
+
+        [Fact]
         public void DeserializeUnknownEnumValue()
         {
             var enumValue = "newValue";


### PR DESCRIPTION
This PR updates the Serializer to handle empty streams the same way it would handle empty strings to return default objects.

Tests have been added to validate this behaviour as well.