### PR TITLE
Add http method constants

### DIFF
--- a/src/Microsoft.Graph.Core/CoreConstants.cs
+++ b/src/Microsoft.Graph.Core/CoreConstants.cs
@@ -109,5 +109,36 @@ namespace Microsoft.Graph
             /// gzip encoding.
             public const string GZip = "gzip";
         }
+
+        /// <summary>
+        /// Enum used specify Http methods
+        /// </summary>
+        public enum HttpMethods
+        {
+            /// <summary>
+            /// The GET method.
+            /// </summary>
+            GET,
+
+            /// <summary>
+            /// The POST method.
+            /// </summary>
+            POST,
+
+            /// <summary>
+            /// The PATCH method.
+            /// </summary>
+            PATCH,
+
+            /// <summary>
+            /// The PUT method.
+            /// </summary>
+            PUT,
+
+            /// <summary>
+            /// The DELETE method.
+            /// </summary>
+            DELETE
+        }
     }
 }


### PR DESCRIPTION
This moves the http method constants from the service library to core following discussion https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/905