### PR TITLE
Change Method type in IBaseRequest to enum

### DIFF
--- a/src/Microsoft.Graph.Core/CoreConstants.cs
+++ b/src/Microsoft.Graph.Core/CoreConstants.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Graph
             {
                 /// JSON content type value
                 public const string Json = "application/json";
+
+                /// Stream content type value
+                public const string Stream = "application/octet-stream";
             }
         }
 

--- a/src/Microsoft.Graph.Core/CoreConstants.cs
+++ b/src/Microsoft.Graph.Core/CoreConstants.cs
@@ -138,7 +138,28 @@ namespace Microsoft.Graph
             /// <summary>
             /// The DELETE method.
             /// </summary>
-            DELETE
+            DELETE,
+
+            /// <summary>
+            /// The HEAD method.
+            /// </summary>
+            HEAD,
+
+            /// <summary>
+            /// The CONNECT method.
+            /// </summary>
+            CONNECT,
+
+            /// <summary>
+            /// The OPTIONS method.
+            /// </summary>
+            OPTIONS,
+
+            /// <summary>
+            /// The TRACE method.
+            /// </summary>
+            TRACE
+
         }
     }
 }

--- a/src/Microsoft.Graph.Core/CoreConstants.cs
+++ b/src/Microsoft.Graph.Core/CoreConstants.cs
@@ -112,57 +112,5 @@ namespace Microsoft.Graph
             /// gzip encoding.
             public const string GZip = "gzip";
         }
-
-        /// <summary>
-        /// Enum used specify Http methods
-        /// </summary>
-        public enum HttpMethods
-        {
-            /// <summary>
-            /// The GET method.
-            /// </summary>
-            GET,
-
-            /// <summary>
-            /// The POST method.
-            /// </summary>
-            POST,
-
-            /// <summary>
-            /// The PATCH method.
-            /// </summary>
-            PATCH,
-
-            /// <summary>
-            /// The PUT method.
-            /// </summary>
-            PUT,
-
-            /// <summary>
-            /// The DELETE method.
-            /// </summary>
-            DELETE,
-
-            /// <summary>
-            /// The HEAD method.
-            /// </summary>
-            HEAD,
-
-            /// <summary>
-            /// The CONNECT method.
-            /// </summary>
-            CONNECT,
-
-            /// <summary>
-            /// The OPTIONS method.
-            /// </summary>
-            OPTIONS,
-
-            /// <summary>
-            /// The TRACE method.
-            /// </summary>
-            TRACE
-
-        }
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/SerializerExtentions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/SerializerExtentions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
         public static HttpContent SerializeAsJsonContent(this ISerializer serializer, object source )
         {
             var stringContent = serializer.SerializeObject(source);
-            return new StringContent(stringContent, Encoding.UTF8, "application/json");
+            return new StringContent(stringContent, Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json);
         }
         
     }

--- a/src/Microsoft.Graph.Core/HttpMethods.cs
+++ b/src/Microsoft.Graph.Core/HttpMethods.cs
@@ -1,0 +1,58 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// Enum used specify Http methods
+    /// </summary>
+    public enum HttpMethods
+    {
+        /// <summary>
+        /// The GET method.
+        /// </summary>
+        GET,
+
+        /// <summary>
+        /// The POST method.
+        /// </summary>
+        POST,
+
+        /// <summary>
+        /// The PATCH method.
+        /// </summary>
+        PATCH,
+
+        /// <summary>
+        /// The PUT method.
+        /// </summary>
+        PUT,
+
+        /// <summary>
+        /// The DELETE method.
+        /// </summary>
+        DELETE,
+
+        /// <summary>
+        /// The HEAD method.
+        /// </summary>
+        HEAD,
+
+        /// <summary>
+        /// The CONNECT method.
+        /// </summary>
+        CONNECT,
+
+        /// <summary>
+        /// The OPTIONS method.
+        /// </summary>
+        OPTIONS,
+
+        /// <summary>
+        /// The TRACE method.
+        /// </summary>
+        TRACE
+
+    }
+}

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -39,6 +39,7 @@
 - Prevents potential deadlock from occurring when AuthenticateRequestAsync(request) is called. #188 (v1.0 feature)
 - [Breaking Change] Remove serialization of headers and statusCode into AdditionalData #206
 - Fix deserialization of empty streams to be consistent with empty strings
+- [Breaking Change] Method type in IBaseRequest changes from string to enum 
     </PackageReleaseNotes>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Graph
             IBaseClient client,
             IEnumerable<Option> options = null)
         {
-            this.Method = CoreConstants.HttpMethods.GET;
+            this.Method = HttpMethods.GET;
             this.Client = client;
             this.responseHandler = new ResponseHandler(client.HttpProvider.Serializer);
             this.Headers = new List<HeaderOption>();
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or sets the HTTP method string for the request.
         /// </summary>
-        public CoreConstants.HttpMethods Method { get; set; }
+        public HttpMethods Method { get; set; }
 
         /// <summary>
         /// Gets the <see cref="QueryOption"/> collection for the request.

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Graph
             IBaseClient client,
             IEnumerable<Option> options = null)
         {
-            this.Method = "GET";
+            this.Method = CoreConstants.HttpMethods.GET;
             this.Client = client;
             this.responseHandler = new ResponseHandler(client.HttpProvider.Serializer);
             this.Headers = new List<HeaderOption>();
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or sets the HTTP method string for the request.
         /// </summary>
-        public string Method { get; set; }
+        public CoreConstants.HttpMethods Method { get; set; }
 
         /// <summary>
         /// Gets the <see cref="QueryOption"/> collection for the request.
@@ -304,7 +304,7 @@ namespace Microsoft.Graph
         public HttpRequestMessage GetHttpRequestMessage(CancellationToken cancellationToken)
         {
             var queryString = this.BuildQueryString();
-            var request = new HttpRequestMessage(new HttpMethod(this.Method), string.Concat(this.RequestUrl, queryString));
+            var request = new HttpRequestMessage(new HttpMethod(this.Method.ToString()), string.Concat(this.RequestUrl, queryString));
             this.AddHeadersToRequest(request);
             this.AddRequestContextToRequest(request, cancellationToken);
             return request;

--- a/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Graph.Core.Requests
         public async Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken)
         {
             this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
-            this.Method = CoreConstants.HttpMethods.POST;
+            this.Method = HttpMethods.POST;
             using (Stream serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false))
             {
                 HttpResponseMessage httpResponseMessage = await this.SendRequestAsync(serializableContent, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Graph.Core.Requests
         public async Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken)
         {
             this.ContentType = "application/json";
-            this.Method = "POST";
+            this.Method = CoreConstants.HttpMethods.POST;
             using (Stream serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false))
             {
                 HttpResponseMessage httpResponseMessage = await this.SendRequestAsync(serializableContent, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Graph.Core.Requests
         /// <returns></returns>
         public async Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken)
         {
-            this.ContentType = "application/json";
+            this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
             this.Method = CoreConstants.HttpMethods.POST;
             using (Stream serializableContent = await batchRequestContent.GetBatchRequestContentAsync().ConfigureAwait(false))
             {

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Graph
                         error = errorResponse.Error;
                     }
 
-                    if (httpResponseMessage.Content?.Headers.ContentType.MediaType == "application/json")
+                    if (httpResponseMessage.Content?.Headers.ContentType.MediaType == CoreConstants.MimeTypeNames.Application.Json)
                     {
                         rawResponseBody = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
                     }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == CoreConstants.MimeTypeNames.Application.Json)
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or sets the HTTP method string for the request.
         /// </summary>
-        string Method { get; }
+        CoreConstants.HttpMethods Method { get; }
 
         /// <summary>
         /// Gets the URL for the request, without query string.

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or sets the HTTP method string for the request.
         /// </summary>
-        CoreConstants.HttpMethods Method { get; }
+        HttpMethods Method { get; }
 
         /// <summary>
         /// Gets the URL for the request, without query string.

--- a/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/SimpleHttpProvider.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Graph
                         }
                     }
 
-                    if (response.Content?.Headers.ContentType?.MediaType == "application/json")
+                    if (response.Content?.Headers.ContentType?.MediaType == CoreConstants.MimeTypeNames.Application.Json)
                     {
                         string rawResponseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Graph
         /// <returns>The task to await.</returns>
         public async Task DeleteAsync(CancellationToken cancellationToken)
         {
-            this.Method = "DELETE";
+            this.Method = CoreConstants.HttpMethods.DELETE;
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {
             }
@@ -64,7 +64,7 @@ namespace Microsoft.Graph
         /// <returns>The Item.</returns>
         public async Task<IUploadSession> GetAsync(CancellationToken cancellationToken)
         {
-            this.Method = "GET";
+            this.Method = CoreConstants.HttpMethods.GET;
 
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Graph
         /// <returns>The task to await.</returns>
         public async Task DeleteAsync(CancellationToken cancellationToken)
         {
-            this.Method = CoreConstants.HttpMethods.DELETE;
+            this.Method = HttpMethods.DELETE;
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {
             }
@@ -64,7 +64,7 @@ namespace Microsoft.Graph
         /// <returns>The Item.</returns>
         public async Task<IUploadSession> GetAsync(CancellationToken cancellationToken)
         {
-            this.Method = CoreConstants.HttpMethods.GET;
+            this.Method = HttpMethods.GET;
 
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Graph
         /// is true, then the item has completed, and the value is the created item from the server.</returns>
         public virtual async Task<UploadResult<T>> PutAsync(Stream stream, CancellationToken cancellationToken)
         {
-            this.Method = CoreConstants.HttpMethods.PUT;
+            this.Method = HttpMethods.PUT;
             this.ContentType = CoreConstants.MimeTypeNames.Application.Stream;
             using (var response = await this.SendRequestAsync(stream, cancellationToken).ConfigureAwait(false))
             {

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Graph
         public virtual async Task<UploadResult<T>> PutAsync(Stream stream, CancellationToken cancellationToken)
         {
             this.Method = CoreConstants.HttpMethods.PUT;
-            this.ContentType = "application/octet-stream";
+            this.ContentType = CoreConstants.MimeTypeNames.Application.Stream;
             using (var response = await this.SendRequestAsync(stream, cancellationToken).ConfigureAwait(false))
             {
                 return await this.responseHandler.HandleResponse<T>(response);

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Graph
         /// is true, then the item has completed, and the value is the created item from the server.</returns>
         public virtual async Task<UploadResult<T>> PutAsync(Stream stream, CancellationToken cancellationToken)
         {
-            this.Method = "PUT";
+            this.Method = CoreConstants.HttpMethods.PUT;
             this.ContentType = "application/octet-stream";
             using (var response = await this.SendRequestAsync(stream, cancellationToken).ConfigureAwait(false))
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
         public async Task CloneAsync_WithHttpContent()
         {
             HttpRequestMessage originalRequest = new HttpRequestMessage(HttpMethod.Post, "http://example.com");
-            originalRequest.Content = new StringContent("Sample Content", Encoding.UTF8, "application/json");
+            originalRequest.Content = new StringContent("Sample Content", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json);
 
             HttpRequestMessage clonedRequest = await originalRequest.CloneAsync();
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 new QueryOption("query2", "value2"),
             };
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient, options) { Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient, options) { Method = HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
             Assert.Equal(HttpMethod.Put, httpRequestMessage.Method);
@@ -88,7 +88,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 new HeaderOption(CoreConstants.Headers.ClientRequestId, clientRequestId)
             };
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient, headers) { Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient, headers) { Method = HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -102,7 +102,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string requestUrl = string.Concat(this.baseUrl, "foo/bar");
             string clientRequestId = Guid.NewGuid().ToString();
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -117,7 +117,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string clientRequestId = Guid.NewGuid().ToString();
 
             var client = new BaseClient(baseUrl: "http://localhost.foo", authenticationProvider: null);
-            var baseRequest = new BaseRequest(requestUrl, client) { Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, client) { Method = HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -131,7 +131,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = CoreConstants.HttpMethods.DELETE };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = HttpMethods.DELETE };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
             Assert.Equal(HttpMethod.Delete, httpRequestMessage.Method);
@@ -310,7 +310,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task SendStreamRequestAsync()
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/photo/$value");
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json, Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json, Method = HttpMethods.PUT };
 
             using (var requestStream = new MemoryStream())
             using (var httpResponseMessage = new HttpResponseMessage())

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 new QueryOption("query2", "value2"),
             };
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient, options) { Method = "PUT" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient, options) { Method = CoreConstants.HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
             Assert.Equal(HttpMethod.Put, httpRequestMessage.Method);
@@ -88,7 +88,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 new HeaderOption(CoreConstants.Headers.ClientRequestId, clientRequestId)
             };
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient, headers) { Method = "PUT" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient, headers) { Method = CoreConstants.HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -102,7 +102,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string requestUrl = string.Concat(this.baseUrl, "foo/bar");
             string clientRequestId = Guid.NewGuid().ToString();
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = "PUT" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = CoreConstants.HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -117,7 +117,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string clientRequestId = Guid.NewGuid().ToString();
 
             var client = new BaseClient(baseUrl: "http://localhost.foo", authenticationProvider: null);
-            var baseRequest = new BaseRequest(requestUrl, client) { Method = "PUT" };
+            var baseRequest = new BaseRequest(requestUrl, client) { Method = CoreConstants.HttpMethods.PUT };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
@@ -131,7 +131,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = "DELETE" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { Method = CoreConstants.HttpMethods.DELETE };
 
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
             Assert.Equal(HttpMethod.Delete, httpRequestMessage.Method);
@@ -310,7 +310,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task SendStreamRequestAsync()
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/photo/$value");
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json", Method = "PUT" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json", Method = CoreConstants.HttpMethods.PUT };
 
             using (var requestStream = new MemoryStream())
             using (var httpResponseMessage = new HttpResponseMessage())

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json };
 
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -157,7 +157,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     provider => provider.SendAsync(
                         It.Is<HttpRequestMessage>(
                             request =>
-                                string.Equals(request.Content.Headers.ContentType.ToString(), "application/json")
+                                string.Equals(request.Content.Headers.ContentType.ToString(), CoreConstants.MimeTypeNames.Application.Json)
                                && request.RequestUri.ToString().Equals(requestUrl)),
                         HttpCompletionOption.ResponseContentRead,
                         CancellationToken.None))
@@ -238,7 +238,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json };
 
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -250,7 +250,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     provider => provider.SendAsync(
                         It.Is<HttpRequestMessage>(
                             request =>
-                                string.Equals(request.Content.Headers.ContentType.ToString(), "application/json")
+                                string.Equals(request.Content.Headers.ContentType.ToString(), CoreConstants.MimeTypeNames.Application.Json)
                                && request.RequestUri.ToString().Equals(requestUrl)),
                         HttpCompletionOption.ResponseContentRead,
                         CancellationToken.None))
@@ -270,7 +270,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
 
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json" };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json };
 
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -279,7 +279,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     provider => provider.SendAsync(
                         It.Is<HttpRequestMessage>(
                             request =>
-                                string.Equals(request.Content.Headers.ContentType.ToString(), "application/json")
+                                string.Equals(request.Content.Headers.ContentType.ToString(), CoreConstants.MimeTypeNames.Application.Json)
                                && request.RequestUri.ToString().Equals(requestUrl)),
                         HttpCompletionOption.ResponseContentRead,
                         CancellationToken.None))
@@ -310,7 +310,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task SendStreamRequestAsync()
         {
             var requestUrl = string.Concat(this.baseUrl, "/me/photo/$value");
-            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = "application/json", Method = CoreConstants.HttpMethods.PUT };
+            var baseRequest = new BaseRequest(requestUrl, this.baseClient) { ContentType = CoreConstants.MimeTypeNames.Application.Json, Method = CoreConstants.HttpMethods.PUT };
 
             using (var requestStream = new MemoryStream())
             using (var httpResponseMessage = new HttpResponseMessage())
@@ -390,7 +390,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     ""givenName"": ""Joe"",
                     ""surName"": ""Brown"",
                     ""@odata.type"":""test""
-                    }", Encoding.UTF8, "application/json")
+                    }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json)
                 };
                 testHttpMessageHandler.AddResponseMapping(requestUrl, responseMessage);
                 MockCustomHttpProvider customHttpProvider = new MockCustomHttpProvider(testHttpMessageHandler);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.OriginalString, baseRequest.RequestUrl);
-            Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.Method.Method, baseRequest.Method);
+            Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.Method.Method, baseRequest.Method.ToString());
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphResponseTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     ""givenName"": ""Joe"",
                     ""surName"": ""Brown"",
                     ""@odata.type"":""test""
-                }", Encoding.UTF8, "application/json")
+                }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json)
             };
 
             // create a custom responseHandler

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             using (var httpResponseMessage = new HttpResponseMessage())
             {
                 httpResponseMessage.Content = stringContent;
-                httpResponseMessage.Content.Headers.ContentType.MediaType = "application/json";
+                httpResponseMessage.Content.Headers.ContentType.MediaType = CoreConstants.MimeTypeNames.Application.Json;
 
                 httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
                 httpResponseMessage.RequestMessage = httpRequestMessage;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     ""givenName"": ""Joe"",
                     ""surName"": ""Brown"",
                     ""@odata.type"":""test""
-                }", Encoding.UTF8, "application/json")
+                }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json)
             };
             hrm.Headers.Add("test", "value");
 
@@ -60,7 +60,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 Content = new StringContent(testString,
                                 Encoding.UTF8,
-                                "application/json")
+                                CoreConstants.MimeTypeNames.Application.Json)
             };
         
             // Act
@@ -110,8 +110,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var hrm = new HttpResponseMessage()
             {
                 Content = new StringContent(testString, 
-                                            Encoding.UTF8, 
-                                            "application/json")
+                                            Encoding.UTF8,
+                                            CoreConstants.MimeTypeNames.Application.Json)
             };
         
             // Act
@@ -159,7 +159,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 Content = new StringContent(testString,
                                             Encoding.UTF8,
-                                            "application/json")
+                                            CoreConstants.MimeTypeNames.Application.Json)
             };
 
             // Act
@@ -190,7 +190,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 Content = new StringContent(testString,
                                             Encoding.UTF8,
-                                            "application/json")
+                                            CoreConstants.MimeTypeNames.Application.Json)
             };
 
             // Assuming this is the developers model that they want to update based on delta query.
@@ -300,7 +300,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 Content = new StringContent(testString,
                                             Encoding.UTF8,
-                                            "application/json")
+                                            CoreConstants.MimeTypeNames.Application.Json)
             };
 
             // Act

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/SimpleHttpProviderTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             using (var httpResponseMessage = new HttpResponseMessage())
             {
                 httpResponseMessage.Content = stringContent;
-                httpResponseMessage.Content.Headers.ContentType.MediaType = "application/json";
+                httpResponseMessage.Content.Headers.ContentType.MediaType = CoreConstants.MimeTypeNames.Application.Json;
 
                 httpResponseMessage.StatusCode = HttpStatusCode.BadRequest;
                 httpResponseMessage.RequestMessage = httpRequestMessage;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadResponseHandlerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     ""id"": ""912310013A123"",
                     ""name"": ""largeFile.vhd"",
                     ""size"": 33
-                }", Encoding.UTF8, "application/json"),
+                }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json),
                 StatusCode = statusCode//upload successful!
             };
 
@@ -79,7 +79,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                   ""12345-55232"",
                   ""77829-99375""
                   ]
-                }", Encoding.UTF8, "application/json"),
+                }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json),
                 StatusCode = HttpStatusCode.OK//upload successful!
             };
 
@@ -113,7 +113,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                                 ""date"": ""2019-11-21T13:57:37""
                             }
                         }
-                    }", Encoding.UTF8, "application/json"),
+                    }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json),
                 StatusCode = HttpStatusCode.Unauthorized//error
             };
 
@@ -146,7 +146,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var hrm = new HttpResponseMessage
             {
-                Content = new StringContent(malformedResponse, Encoding.UTF8, "application/json"),
+                Content = new StringContent(malformedResponse, Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json),
                 StatusCode = HttpStatusCode.Unauthorized//error
             };
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                   ""77829-99375""
                   ]
                 }";
-                HttpContent content = new StringContent(responseJSON, Encoding.UTF8, "application/json");
+                HttpContent content = new StringContent(responseJSON, Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json);
                 responseMessage.Content = content;
 
                 // 2. Map the response

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public System.Threading.Tasks.Task<TestEvent> AddAsync(TestEvent eventsEvent, CancellationToken cancellationToken)
         {
             this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
-            this.Method = CoreConstants.HttpMethods.POST;
+            this.Method = HttpMethods.POST;
             return this.SendAsync<TestEvent>(eventsEvent, cancellationToken);
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         /// <returns>The collection page.</returns>
         public async System.Threading.Tasks.Task<ITestEventDeltaCollectionPage> GetAsync(CancellationToken cancellationToken)
         {
-            this.Method = CoreConstants.HttpMethods.GET;
+            this.Method = HttpMethods.GET;
             var response = await this.SendAsync<TestEventDeltaCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         /// <returns>The created Event.</returns>
         public System.Threading.Tasks.Task<TestEvent> AddAsync(TestEvent eventsEvent, CancellationToken cancellationToken)
         {
-            this.ContentType = "application/json";
+            this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
             this.Method = CoreConstants.HttpMethods.POST;
             return this.SendAsync<TestEvent>(eventsEvent, cancellationToken);
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaRequest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public System.Threading.Tasks.Task<TestEvent> AddAsync(TestEvent eventsEvent, CancellationToken cancellationToken)
         {
             this.ContentType = "application/json";
-            this.Method = "POST";
+            this.Method = CoreConstants.HttpMethods.POST;
             return this.SendAsync<TestEvent>(eventsEvent, cancellationToken);
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         /// <returns>The collection page.</returns>
         public async System.Threading.Tasks.Task<ITestEventDeltaCollectionPage> GetAsync(CancellationToken cancellationToken)
         {
-            this.Method = "GET";
+            this.Method = CoreConstants.HttpMethods.GET;
             var response = await this.SendAsync<TestEventDeltaCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {


### PR DESCRIPTION
This PR closes #217 

It involves the changing of the Method type from string to enum to prevent erroneous inputs and provide central references. 

This PR also replaces the inline use of string values for "application/json" and "application/octet-stream" with Constants provided in the CoreConstants file.

The aim is to use these constants in the service library using central references from the core library to prevent redefinitions of constant values.

Related 
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/905