### PR TITLE
Add source link to enable debugging of our NuGet package

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -41,10 +41,10 @@ steps:
   clean: true
   fetchDepth: 1
 
-# - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-#   displayName: 'Run CredScan'
-#   inputs:
-#     debugMode: false
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
 
 - task: PowerShell@2
   displayName: 'Validate updated version'
@@ -99,78 +99,78 @@ steps:
     configuration: release
     clean: true
 
-# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-#   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
-#   inputs:
-#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-#     FolderPath: src/Microsoft.Graph.Core/bin/release
-#     Pattern: Microsoft.Graph.Core.dll
-#     signConfigType: inlineSignParams
-#     inlineOperation: |
-#      [
-#          {
-#              "keyCode": "CP-233863-SN",
-#              "operationSetCode": "StrongNameSign",
-#              "parameters": [],
-#              "toolName": "sign",
-#              "toolVersion": "1.0"
-#          },
-#          {
-#              "keyCode": "CP-233863-SN",
-#              "operationSetCode": "StrongNameVerify",
-#              "parameters": [],
-#              "toolName": "sign",
-#              "toolVersion": "1.0"
-#          }
-#      ]
-#     SessionTimeout: 20
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph.Core/bin/release
+    Pattern: Microsoft.Graph.Core.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameSign",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
 
-# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-#   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
-#   inputs:
-#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-#     FolderPath: src/Microsoft.Graph.Core/bin/release
-#     Pattern: Microsoft.Graph.Core.dll
-#     signConfigType: inlineSignParams
-#     inlineOperation: |
-#      [
-#          {
-#              "keyCode": "CP-230012",
-#              "operationSetCode": "SigntoolSign",
-#              "parameters": [
-#                  {
-#                      "parameterName": "OpusName",
-#                      "parameterValue": "Microsoft"
-#                  },
-#                  {
-#                      "parameterName": "OpusInfo",
-#                      "parameterValue": "http://www.microsoft.com"
-#                  },
-#                  {
-#                      "parameterName": "FileDigest",
-#                      "parameterValue": "/fd \"SHA256\""
-#                  },
-#                  {
-#                      "parameterName": "PageHash",
-#                      "parameterValue": "/NPH"
-#                  },
-#                  {
-#                      "parameterName": "TimeStamp",
-#                      "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-#                  }
-#              ],
-#              "toolName": "sign",
-#              "toolVersion": "1.0"
-#          },
-#          {
-#              "keyCode": "CP-230012",
-#              "operationSetCode": "SigntoolVerify",
-#              "parameters": [],
-#              "toolName": "sign",
-#              "toolVersion": "1.0"
-#          }
-#      ]
-#     SessionTimeout: 20
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph.Core/bin/release
+    Pattern: Microsoft.Graph.Core.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolSign",
+             "parameters": [
+                 {
+                     "parameterName": "OpusName",
+                     "parameterValue": "Microsoft"
+                 },
+                 {
+                     "parameterName": "OpusInfo",
+                     "parameterValue": "http://www.microsoft.com"
+                 },
+                 {
+                     "parameterName": "FileDigest",
+                     "parameterValue": "/fd \"SHA256\""
+                 },
+                 {
+                     "parameterName": "PageHash",
+                     "parameterValue": "/NPH"
+                 },
+                 {
+                     "parameterName": "TimeStamp",
+                     "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                 }
+             ],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
 
 - task: MSBuild@1
   displayName: 'Create NuGet package for preview release'
@@ -179,31 +179,31 @@ steps:
     configuration: 'release'
     msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
-# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-#   displayName: 'ESRP NuGet CodeSigning'
-#   inputs:
-#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-#     FolderPath: '$(Build.ArtifactStagingDirectory)'
-#     Pattern: '*nupkg'
-#     signConfigType: inlineSignParams
-#     inlineOperation: |
-#           [
-#               {
-#                   "keyCode": "CP-401405",
-#                   "operationSetCode": "NuGetSign",
-#                   "parameters": [ ],
-#                   "toolName": "sign",
-#                   "toolVersion": "1.0"
-#               },
-#               {
-#                   "keyCode": "CP-401405",
-#                   "operationSetCode": "NuGetVerify",
-#                   "parameters": [ ],
-#                   "toolName": "sign",
-#                   "toolVersion": "1.0"
-#               }
-#           ]
-#     SessionTimeout: 20
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP NuGet CodeSigning'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    Pattern: '*nupkg'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+          [
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetSign",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              },
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetVerify",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              }
+          ]
+    SessionTimeout: 20
 
 - task: CopyFiles@2
   displayName: 'Copy release scripts to artifact staging directory'
@@ -220,12 +220,12 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: PreviewReleaseArtifact
 
-# - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
-#   displayName: 'Graph Client Tooling pipeline fail notification'
-#   inputs:
-#     addressType: serviceEndpoint
-#     serviceEndpointName: 'microsoftgraph pipeline status'
-#     title: '$(Build.DefinitionName) failure notification'
-#     text: 'This pipeline has failed. View the build details for further information. This is a blocking failure.'
-#   condition: and(failed(), ne(variables['Build.Reason'], 'Manual'))
-#   enabled: true
+- task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
+  displayName: 'Graph Client Tooling pipeline fail notification'
+  inputs:
+    addressType: serviceEndpoint
+    serviceEndpointName: 'microsoftgraph pipeline status'
+    title: '$(Build.DefinitionName) failure notification'
+    text: 'This pipeline has failed. View the build details for further information. This is a blocking failure.'
+  condition: and(failed(), ne(variables['Build.Reason'], 'Manual'))
+  enabled: true

--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -173,11 +173,12 @@ steps:
 #     SessionTimeout: 20
 
 # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
-- powershell: |
-    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
-  env:
-    BUILD_CONFIGURATION: release
-  displayName: dotnet pack
+- task: MSBuild@1
+  displayName: 'Create NuGet package for preview release'
+  inputs:
+    solution: '**/Microsoft.Graph.Core.csproj'
+    configuration: 'release'
+    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
 # - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
 #   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -41,10 +41,10 @@ steps:
   clean: true
   fetchDepth: 1
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan'
-  inputs:
-    debugMode: false
+# - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+#   displayName: 'Run CredScan'
+#   inputs:
+#     debugMode: false
 
 - task: PowerShell@2
   displayName: 'Validate updated version'
@@ -99,111 +99,111 @@ steps:
     configuration: release
     clean: true
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-233863-SN",
-             "operationSetCode": "StrongNameSign",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-233863-SN",
-             "operationSetCode": "StrongNameVerify",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
+# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+#   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
+#   inputs:
+#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+#     FolderPath: src/Microsoft.Graph.Core/bin/release
+#     Pattern: Microsoft.Graph.Core.dll
+#     signConfigType: inlineSignParams
+#     inlineOperation: |
+#      [
+#          {
+#              "keyCode": "CP-233863-SN",
+#              "operationSetCode": "StrongNameSign",
+#              "parameters": [],
+#              "toolName": "sign",
+#              "toolVersion": "1.0"
+#          },
+#          {
+#              "keyCode": "CP-233863-SN",
+#              "operationSetCode": "StrongNameVerify",
+#              "parameters": [],
+#              "toolName": "sign",
+#              "toolVersion": "1.0"
+#          }
+#      ]
+#     SessionTimeout: 20
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolSign",
-             "parameters": [
-                 {
-                     "parameterName": "OpusName",
-                     "parameterValue": "Microsoft"
-                 },
-                 {
-                     "parameterName": "OpusInfo",
-                     "parameterValue": "http://www.microsoft.com"
-                 },
-                 {
-                     "parameterName": "FileDigest",
-                     "parameterValue": "/fd \"SHA256\""
-                 },
-                 {
-                     "parameterName": "PageHash",
-                     "parameterValue": "/NPH"
-                 },
-                 {
-                     "parameterName": "TimeStamp",
-                     "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                 }
-             ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolVerify",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
+# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+#   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
+#   inputs:
+#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+#     FolderPath: src/Microsoft.Graph.Core/bin/release
+#     Pattern: Microsoft.Graph.Core.dll
+#     signConfigType: inlineSignParams
+#     inlineOperation: |
+#      [
+#          {
+#              "keyCode": "CP-230012",
+#              "operationSetCode": "SigntoolSign",
+#              "parameters": [
+#                  {
+#                      "parameterName": "OpusName",
+#                      "parameterValue": "Microsoft"
+#                  },
+#                  {
+#                      "parameterName": "OpusInfo",
+#                      "parameterValue": "http://www.microsoft.com"
+#                  },
+#                  {
+#                      "parameterName": "FileDigest",
+#                      "parameterValue": "/fd \"SHA256\""
+#                  },
+#                  {
+#                      "parameterName": "PageHash",
+#                      "parameterValue": "/NPH"
+#                  },
+#                  {
+#                      "parameterName": "TimeStamp",
+#                      "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+#                  }
+#              ],
+#              "toolName": "sign",
+#              "toolVersion": "1.0"
+#          },
+#          {
+#              "keyCode": "CP-230012",
+#              "operationSetCode": "SigntoolVerify",
+#              "parameters": [],
+#              "toolName": "sign",
+#              "toolVersion": "1.0"
+#          }
+#      ]
+#     SessionTimeout: 20
 
-- task: MSBuild@1
-  displayName: 'Create NuGet package for preview release'
-  inputs:
-    solution: '**/Microsoft.Graph.Core.csproj'
-    configuration: 'release'
-    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
+# arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+- powershell: |
+    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+  env:
+    BUILD_CONFIGURATION: release
+  displayName: dotnet pack
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP NuGet CodeSigning'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)'
-    Pattern: '*.nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-          [
-              {
-                  "keyCode": "CP-401405",
-                  "operationSetCode": "NuGetSign",
-                  "parameters": [ ],
-                  "toolName": "sign",
-                  "toolVersion": "1.0"
-              },
-              {
-                  "keyCode": "CP-401405",
-                  "operationSetCode": "NuGetVerify",
-                  "parameters": [ ],
-                  "toolName": "sign",
-                  "toolVersion": "1.0"
-              }
-          ]
-    SessionTimeout: 20
+# - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+#   displayName: 'ESRP NuGet CodeSigning'
+#   inputs:
+#     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+#     FolderPath: '$(Build.ArtifactStagingDirectory)'
+#     Pattern: '*nupkg'
+#     signConfigType: inlineSignParams
+#     inlineOperation: |
+#           [
+#               {
+#                   "keyCode": "CP-401405",
+#                   "operationSetCode": "NuGetSign",
+#                   "parameters": [ ],
+#                   "toolName": "sign",
+#                   "toolVersion": "1.0"
+#               },
+#               {
+#                   "keyCode": "CP-401405",
+#                   "operationSetCode": "NuGetVerify",
+#                   "parameters": [ ],
+#                   "toolName": "sign",
+#                   "toolVersion": "1.0"
+#               }
+#           ]
+#     SessionTimeout: 20
 
 - task: CopyFiles@2
   displayName: 'Copy release scripts to artifact staging directory'
@@ -220,12 +220,12 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: PreviewReleaseArtifact
 
-- task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
-  displayName: 'Graph Client Tooling pipeline fail notification'
-  inputs:
-    addressType: serviceEndpoint
-    serviceEndpointName: 'microsoftgraph pipeline status'
-    title: '$(Build.DefinitionName) failure notification'
-    text: 'This pipeline has failed. View the build details for further information. This is a blocking failure.'
-  condition: and(failed(), ne(variables['Build.Reason'], 'Manual'))
-  enabled: true
+# - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
+#   displayName: 'Graph Client Tooling pipeline fail notification'
+#   inputs:
+#     addressType: serviceEndpoint
+#     serviceEndpointName: 'microsoftgraph pipeline status'
+#     title: '$(Build.DefinitionName) failure notification'
+#     text: 'This pipeline has failed. View the build details for further information. This is a blocking failure.'
+#   condition: and(failed(), ne(variables['Build.Reason'], 'Manual'))
+#   enabled: true

--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -172,7 +172,6 @@ steps:
 #      ]
 #     SessionTimeout: 20
 
-# arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
 - task: MSBuild@1
   displayName: 'Create NuGet package for preview release'
   inputs:

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -168,7 +168,7 @@ steps:
   inputs:
     solution: '**/Microsoft.Graph.Core.csproj'
     configuration: 'release'
-    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)'
+    msbuildArguments: '-t:pack /p:NoBuild=true /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/scripts/GetNugetPackageVersion.ps1
+++ b/scripts/GetNugetPackageVersion.ps1
@@ -23,12 +23,12 @@ Param(
 
 Write-Host "Get the NuGet package version and set it in the global variable: VERSION_STRING" -ForegroundColor Magenta
 
-$nugetPackageName = (Get-ChildItem $packageDirPath | Where Name -match Microsoft.Graph).Name
+$nugetPackageName = (Get-ChildItem (Join-Path $packageDirPath *.nupkg) -Exclude *.symbols.nupkg).Name
 
 Write-Host "Found NuGet package: $nugetPackageName" -ForegroundColor Magenta
 
 ## Extracts the package version from nupkg file name.
-$packageVersion = $nugetPackageName -replace "^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z]+)?)\.nupkg$", '$2'
+$packageVersion = $nugetPackageName.Replace("Microsoft.Graph.Core.", "").Replace(".nupkg", "")
 
 Write-Host "##vso[task.setvariable variable=VERSION_STRING]$($packageVersion)";
 Write-Host "Updated the VERSION_STRING environment variable with the package version value '$packageVersion'." -ForegroundColor Green

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -19,12 +19,18 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>1.25.0</VersionPrefix>
+    <VersionPrefix>1.25.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix InvalidOperationException when Location header is relative #214
-- Drain the responses before retry attempt or throwing Too Many Retries exception.
+- Include symbols
     </PackageReleaseNotes>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <!-- https://github.com/clairernovotny/DeterministicBuilds#deterministic-builds -->
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <!--We manually configure LanguageTargets for Xamarin due to .Net SDK TFMs limitation https://github.com/dotnet/sdk/issues/491 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
@@ -112,5 +118,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #126 
Related to: https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/247
Related to: https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/937

- Bumped minor version
- Added `msbuild` flags to generate symbols (see #227 for the `dotnet cli` blocker)
- Changed singing filter to include both nupkg and snupkg files
- Changed file filter to extract a single file for version information
- Updated csproj to allow sourcelink