### PR TITLE
Fix for culture dependent DateTimeOffset serialization.

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/DateTimeOffsetConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DateTimeOffsetConverter.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Graph
         {
             if (dateTimeOffsetValue != null)
             {
-                writer.WriteStringValue(dateTimeOffsetValue.ToString());
+                // use the serializer's native implementation with ISO 8601-1:2019 format support(and also faster)
+                JsonSerializer.Serialize(writer, dateTimeOffsetValue, typeof(DateTimeOffset));
             }
             else
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
 {
+    using Microsoft.Graph.Core.Models;
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels;
     using System;
     using System.Collections.Generic;
@@ -342,12 +343,33 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         [Fact]
         public void SerializeDateTimeOffsetValue()
         {
-            var dateTimeOffset = DateTimeOffset.Parse("2016-11-20T18:23:45.9356913Z");
-            // Expect the string to be ISO 8601-1:2019 format
+            // Arrange
+            var dateTimeOffset = DateTimeOffset.Parse("2016-11-20T18:23:45.9356913+00:00");
             var expectedDateTimeOffsetString = "\"2016-11-20T18:23:45.9356913+00:00\""; 
-
+            // Act
             var serializedString = this.serializer.SerializeObject(dateTimeOffset);
+
+            // Assert
+            // Expect the string to be ISO 8601-1:2019 format
             Assert.Equal(expectedDateTimeOffsetString, serializedString);
+        }
+
+        [Fact]
+        public void SerializeUploadSessionValues()
+        {
+            // Arrange
+            var uploadSession = new UploadSession()
+            {
+                ExpirationDateTime = DateTimeOffset.Parse("2016-11-20T18:23:45.9356913+00:00"),
+                UploadUrl = "http://localhost",
+                NextExpectedRanges = new List<string> { "0 - 1000" }
+            };
+            var expectedString = @"{""expirationDateTime"":""2016-11-20T18:23:45.9356913+00:00"",""nextExpectedRanges"":[""0 - 1000""],""uploadUrl"":""http://localhost""}";
+            // Act
+            var serializedString = this.serializer.SerializeObject(uploadSession);
+            // Assert
+            // Expect the string to be ISO 8601-1:2019 format
+            Assert.Equal(expectedString, serializedString);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
 
         [Theory]
         [InlineData("2016-11-20T18:23:45.9356913+00:00", "\"2016-11-20T18:23:45.9356913+00:00\"")]
-        [InlineData("1992-10-26T80:30:15.1456919+07:00", "\"1992-10-26T80:30:15.1456919+07:00\"")]// make sure different offset is okay as well
+        [InlineData("1992-10-26T08:30:15.1456919+07:00", "\"1992-10-26T08:30:15.1456919+07:00\"")]// make sure different offset is okay as well
         public void SerializeDateTimeOffsetValue(string dateTimeOffsetString, string expectedJsonValue)
         {
             // Arrange

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -340,6 +340,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void SerializeDateTimeOffsetValue()
+        {
+            var dateTimeOffset = DateTimeOffset.Parse("2016-11-20T18:23:45.9356913Z");
+            // Expect the string to be ISO 8601-1:2019 format
+            var expectedDateTimeOffsetString = "\"2016-11-20T18:23:45.9356913+00:00\""; 
+
+            var serializedString = this.serializer.SerializeObject(dateTimeOffset);
+            Assert.Equal(expectedDateTimeOffsetString, serializedString);
+        }
+
+        [Fact]
         public void VerifyTypeMappingCache()
         {
             // Clear the cache so it won't have mappings from previous tests.

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -340,18 +340,19 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
             Assert.Equal(expectedSerializedString, serializedString);
         }
 
-        [Fact]
-        public void SerializeDateTimeOffsetValue()
+        [Theory]
+        [InlineData("2016-11-20T18:23:45.9356913+00:00", "\"2016-11-20T18:23:45.9356913+00:00\"")]
+        [InlineData("1992-10-26T80:30:15.1456919+07:00", "\"1992-10-26T80:30:15.1456919+07:00\"")]// make sure different offset is okay as well
+        public void SerializeDateTimeOffsetValue(string dateTimeOffsetString, string expectedJsonValue)
         {
             // Arrange
-            var dateTimeOffset = DateTimeOffset.Parse("2016-11-20T18:23:45.9356913+00:00");
-            var expectedDateTimeOffsetString = "\"2016-11-20T18:23:45.9356913+00:00\""; 
+            var dateTimeOffset = DateTimeOffset.Parse(dateTimeOffsetString);
             // Act
             var serializedString = this.serializer.SerializeObject(dateTimeOffset);
 
             // Assert
             // Expect the string to be ISO 8601-1:2019 format
-            Assert.Equal(expectedDateTimeOffsetString, serializedString);
+            Assert.Equal(expectedJsonValue, serializedString);
         }
 
         [Fact]


### PR DESCRIPTION
This PR closes #232 

This fixes the serialization of DateTimeOffset objects to no longer be culture dependent to emit consistent values for the strings accoring to the ISO 8601-1:2019 format
