### PR TITLE
Update System.Text.Json dependency to fix naming policies application to [Flags] enums

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -117,6 +117,6 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.9.0" />
     <PackageReference Include="Azure.Core" Version="1.0.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -293,6 +293,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void SerializeEnumValueWithFlags()
+        {
+            EnumTypeWithFlags enumValueWithFlags = EnumTypeWithFlags.FirstValue | EnumTypeWithFlags.SecondValue;
+
+            var expectedSerializedValue = "\"firstValue, secondValue\""; // All values should be camelCased
+
+            var serializedValue = this.serializer.SerializeObject(enumValueWithFlags);
+
+            Assert.Equal(expectedSerializedValue, serializedValue);
+        }
+
+        [Fact]
         public void SerializeDateEnumerableValue()
         {
             var now = DateTimeOffset.UtcNow;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/EnumTypeWithFlags.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/EnumTypeWithFlags.cs
@@ -1,0 +1,20 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
+{
+    using System.Text.Json.Serialization;
+    /// <summary>
+    /// Enum for testing enum serialization and deserialization.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [System.Flags]
+    public enum EnumTypeWithFlags
+    {
+        FirstValue = 1,
+
+        SecondValue = 2
+    }
+}


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/267

It involves updating the System.Text.Json dependency to resolve an issue where the naming policy was not applied accross enum values which are Flags. See https://github.com/dotnet/runtime/issues/31622

A test has been added to validate that the upgrade does indeed fix the issue.