### PR TITLE
Fix for Request().WithShouldRetry is not called

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/RetryHandlerOption.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Graph
 
         /// <summary>
         /// A delegate that's called to determine whether a request should be retried or not.
-        /// The delegate method should accept a delay time in seconds of, number of retry attempts and <see cref="HttpResponseMessage"/> as it's parameters and return a <see cref="bool"/>. This defaults to true
+        /// The delegate method should accept a delay time in seconds of, number of retry attempts and <see cref="HttpResponseMessage"/> as it's parameters and return a <see cref="bool"/>. This defaults to false
         /// </summary>
-        public Func<int, int, HttpResponseMessage, bool> ShouldRetry { get; set; } = (delay, attempt, response) => true;
+        public Func<int, int, HttpResponseMessage, bool> ShouldRetry { get; set; } = (delay, attempt, response) => false;
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Graph
             var response = await base.SendAsync(httpRequest, cancellationToken);
 
             // Check whether retries are permitted and that the MaxRetry value is a non - negative, non - zero value
-            if (ShouldRetry(response) && httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && RetryOption.ShouldRetry(RetryOption.Delay, 0, response))
+            if (httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && (ShouldRetry(response) || RetryOption.ShouldRetry(RetryOption.Delay, 0, response)))
             {
                 response = await SendRetryAsync(response, cancellationToken);
             }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/Options/RetrytHandlerOptionTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/Options/RetrytHandlerOptionTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware.Options
             var retryOptions = new RetryHandlerOption();
             Assert.Equal(RetryHandlerOption.DEFAULT_DELAY, retryOptions.Delay);
             Assert.Equal(RetryHandlerOption.DEFAULT_MAX_RETRY, retryOptions.MaxRetry);
-            Assert.True(retryOptions.ShouldRetry(0, 0, null));
+            Assert.False(retryOptions.ShouldRetry(0, 0, null));
             Assert.Equal(TimeSpan.Zero, retryOptions.RetriesTimeLimit);
         }
 


### PR DESCRIPTION
This PR closes #190 

When a user specifies the custom delegate `ShouldRetry` in the RetryHandlerOption.cs the delegate will not be respected if the request does not respect the conditions set out in the `ShouldRetry` private method [here](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/ba5eb6825f9de8e12707907ade8d548314688574/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs#L192).  This is in turn leads to the result that users can only filter out requests to be retried rather than filtering in more options to be retried.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/242)