### PR TITLE
Use TryGetProperty method rather than catching of KeyNotFoundException in DerivedTypeConverter

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Graph
             JsonElement type;
             try
             {
-                type = jsonDocument.RootElement.GetProperty(CoreConstants.Serialization.ODataType);
-            }
-            catch (KeyNotFoundException)
-            {
-                type = default;
+                // try to get the @odata.type property if we can
+                if (!jsonDocument.RootElement.TryGetProperty(CoreConstants.Serialization.ODataType, out type))
+                {
+                    type = default;
+                }
             }
             catch (InvalidOperationException)
             {

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -207,6 +207,12 @@ namespace Microsoft.Graph
             writer.WriteStartObject();
             foreach (var propertyInfo in value.GetType().GetProperties())
             {
+                var ignoreConverterAttribute = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>();
+                if(ignoreConverterAttribute != null)
+                {
+                    continue;// Don't serialize a property we are asked to ignore
+                }
+
                 string propertyName;
                 // Try to get the property name off the JsonAttribute otherwise camel case the property name
                 var jsonProperty = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonPropertyNameAttribute>();

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -354,6 +354,25 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void DerivedTypeConverterIgnoresPropertyWithJsonIgnore()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            var expectedSerializedString = string.Format("{{\"nullableDate\":\"{0}\"}}", now.ToString("yyyy-MM-dd"));
+
+            var date = new DateTestClass
+            {
+                NullableDate = new Date(now.Year, now.Month, now.Day),
+                IgnoredNumber = 230 // we shouldn't see this value
+            };
+
+            var serializedString = this.serializer.SerializeObject(date);
+
+            Assert.Equal(expectedSerializedString, serializedString);
+            Assert.DoesNotContain("230", serializedString);
+        }
+
+        [Fact]
         public void SerializeObjectWithAdditionalDataWithDerivedTypeConverter()
         {
             // This example class uses the derived type converter

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DateTestClass.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DateTestClass.cs
@@ -27,5 +27,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
 
         [JsonPropertyName("invalidType")]
         public int? InvalidType { get; set; }
+
+        [JsonIgnore]
+        public int IgnoredNumber { get; set; }
     }
 }


### PR DESCRIPTION
This PR is aimed at improved performance of the DerivedTypeConverter. 

Instead of catching the KeyNotFoundException when the "odata.type" is missing from the payload, we can use the TryGetProperty method to avoid the extra overhead of exception handling.

It also adds support to the DerivedTypeConverter to ignore properties with the JsonIgnore Attribute which will be useful in the event our public models are extended but still use the converter. This will enable the prevention of serializing new public properties added.

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/955

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/243)