### PR TITLE
Fix deserialization of timeofday with leading zeros

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/TimeOfDayConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/TimeOfDayConverter.cs
@@ -39,11 +39,10 @@ namespace Microsoft.Graph
         {
             try
             {
-                var dateTime = (DateTime)JsonSerializer.Deserialize(reader.GetString(), typeof(DateTime));
-
+                var dateTime = DateTime.Parse(reader.GetString());
                 return new TimeOfDay(dateTime);
             }
-            catch (JsonException serializationException)
+            catch (FormatException formatException)
             {
                 throw new ServiceException(
                     new Error
@@ -51,7 +50,7 @@ namespace Microsoft.Graph
                         Code = ErrorConstants.Codes.GeneralException,
                         Message = "Unable to deserialize time of day"
                     },
-                    serializationException);
+                    formatException);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Serialization/TimeOfDayConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/TimeOfDayConverter.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Graph
         {
             try
             {
+                // Use the datetime class to parse since Utf8JsonReader/System.Text.Json serializer will 
+                // throw FormatException on json that is not ISO 8601-1:2019 date format compliant.
                 var dateTime = DateTime.Parse(reader.GetString());
                 return new TimeOfDay(dateTime);
             }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/TimeOfDayConverterTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/TimeOfDayConverterTests.cs
@@ -27,5 +27,23 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         {
             Assert.False(this.converter.CanConvert(typeof(DateTime)));
         }
+
+        [Fact]
+        public void CanSerializeAndDeserializeTimeOfDay()
+        {
+            // Arrange
+            var serializer = new Serializer();
+            var stringToDeserialize = "\"06:00:00\"";
+            var expectedTimeDate = new TimeOfDay(6, 0, 0);
+            
+            // Act
+            var timeOfDay = serializer.DeserializeObject<TimeOfDay>(stringToDeserialize);
+
+            var timeOfDayString = serializer.SerializeObject(timeOfDay);
+
+            // Assert
+            Assert.Equal(expectedTimeDate.ToString(), timeOfDay.ToString());
+            Assert.Equal(timeOfDayString, stringToDeserialize);
+        }
     }
 }


### PR DESCRIPTION
This PR closes #244

It involves the updating of the TimeOfDayConverter to more lenient deserialization by using .NETs `DateTime.Parse` method rather than System.Text.Json underlying serializer which strictly expects ISO 8601-1:2019 date format by default

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/245)