### PR TITLE
Specify System.Net.Http version in .Net45

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -72,9 +72,9 @@
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
   <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR Specifies the System.Net.Http version in .Net45 in the Microsoft.Graph.Core.csproj.

This is meant to address warnings raised by dependabot.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/247)