### PR TITLE
JsonPropertyName attribute to match property names

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -123,8 +123,12 @@ namespace Microsoft.Graph
                     // iterate through the object properties
                     foreach (var property in json.EnumerateObject())
                     {
-                        // look up the property in the object definition
-                        var propertyInfo = objectType.GetProperty(property.Name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                        // look up the property in the object definition using the mapping provided in the model attribute
+                        var propertyInfo = objectType.GetProperties().FirstOrDefault((mappedProperty) =>
+                        {
+                            var attribute = mappedProperty.GetCustomAttribute<JsonPropertyNameAttribute>();
+                            return attribute?.Name == property.Name;
+                        });
                         if (propertyInfo == null)
                         {
                             //Add the property to AdditionalData as it doesn't exist as a member of the object

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -91,6 +91,28 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
+        public void DerivedTypeConverterFollowsNamingProperty()
+        {
+            var id = "id";
+            var givenName = "name";
+            var link = "localhost.com"; // this property name does not match the object name
+
+            var stringToDeserialize = string.Format(
+                "{{\"id\":\"{0}\", \"givenName\":\"{1}\", \"link\":\"{2}\"}}",
+                id,
+                givenName,
+                link);
+
+            var instance = this.serializer.DeserializeObject<DerivedTypeClass>(stringToDeserialize);
+
+            Assert.NotNull(instance);
+            Assert.Equal(id, instance.Id);
+            Assert.Equal(link, instance.WebUrl);
+            Assert.NotNull(instance.AdditionalData);
+            Assert.Equal(givenName, instance.AdditionalData["givenName"].ToString());
+        }
+
+        [Fact]
         public void DeserializeStream()
         {
             var id = "id";

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DerivedTypeClass.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DerivedTypeClass.cs
@@ -30,5 +30,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
         /// </summary>
         [JsonPropertyName("memorableDates")]
         public IEnumerable<DateTestClass> MemorableDates { get; set; }
+
+        /// <summary>
+        /// Gets or sets link.
+        /// </summary>
+        [JsonPropertyName("link")]
+        public string WebUrl { get; set; }
     }
 }


### PR DESCRIPTION
This PR modifies the DerivedTypeConverter to use the string value provided in the `JsonPropertyName` attribute to match properties during deserialization. 
This was initially done using the Property name in the object and therefore properties would sometimes be put into the additional Data rather than being put into the property since the names would not match.

Related issue:
https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/291

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/249)