### PR TITLE
Encode url query data parameters

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -375,13 +375,21 @@ namespace Microsoft.Graph
 
                 foreach (var queryOption in this.QueryOptions)
                 {
+                    // no need to add empty query option
+                    if(string.IsNullOrEmpty(queryOption.Value)) 
+                        continue;
+
+                    // Escape any special uri characters in the queryOption data 
+                    // We first decode/escape the string in case the user has already encoded it to prevent double encoding
+                    var unescapedData = Uri.UnescapeDataString(queryOption.Value);
+                    var escapedOptionValue = Uri.EscapeDataString(unescapedData);
                     if (stringBuilder.Length == 0)
                     {
-                        stringBuilder.AppendFormat("?{0}={1}", queryOption.Name, queryOption.Value);
+                        stringBuilder.AppendFormat("?{0}={1}", queryOption.Name, escapedOptionValue);
                     }
                     else
                     {
-                        stringBuilder.AppendFormat("&{0}={1}", queryOption.Name, queryOption.Value);
+                        stringBuilder.AppendFormat("&{0}={1}", queryOption.Name, escapedOptionValue);
                     }
                 }
 


### PR DESCRIPTION
This PR involves adding the functionality to encode the query parameters of requests made through BaseRequest.
This is to ensure that special characters that appear in this section of the URL(such as ?,#,+) are URL encoded as they do not carry a special functions and therefore need to be encoded.

This PR also fixes the unnecessary addition of the query parameters with no data as outlined in #248 

- [x] closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/248
- [x] closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/196
- [x] closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/914
- [x] closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/700
- [x] closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/881



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/255)