### PR TITLE
Include type assembly info in the TypeMappingCache key

### DIFF
--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestResourceData.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestResourceData.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The type ResourceData.
+    /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<TestResourceData>))]
+    public partial class TestResourceData
+    {
+
+        /// <summary>
+        /// Gets or sets additional data.
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonPropertyName("@odata.type")]
+        public string ODataType { get; set; }
+
+    }
+}


### PR DESCRIPTION
This PR updates the DerivedTypeConverter to include the type assembly info in the TypeMappingCache key. This is in order to prevent collisions in lookups in the cache when a sdk user has both v1 and beta service libraries installed in their projects.
In this case since the two types, (e.g Team from V1 and Team from beta) will have different entries since the key will be differentiated from the assembly name.

- [ ] Closes #139 

Furthermore, this PR fixes the occurrences of InvalidCastException thrown when the api returns a value in the "@odata.type" that cannot be assigned to the type defined in the metadata as the two types are not related. The converter will now default to the type defined in the metadata and not try to create the type defined in the "@odata.type". Extra properties will then be found in the additionalData.
A good example is the ResourceData type which is not a base of ChatMessage as shown [here](https://docs.microsoft.com/en-us/graph/api/resources/resourcedata?view=graph-rest-1.0#json-representation).

- [ ] Closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/107
- [ ] Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/998