### PR TITLE
Include header options on sending batch request

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -43,6 +43,7 @@
 - Fix InvalidOperationException when Location header is relative #214
 - Include symbols
 - Change debug type to portable
+- Fix for Batch function not sending the ImmutableID header
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -231,8 +231,8 @@ namespace Microsoft.Graph
             }
 
             // write any headers if the step contains any request headers or content headers
-            if (   (batchRequestStep.Request.Headers != null && batchRequestStep.Request.Headers.Any()) 
-                || (batchRequestStep.Request.Content?.Headers != null && batchRequestStep.Request.Content.Headers.Any()))
+            if ((batchRequestStep.Request.Headers?.Any() ?? false) 
+                || (batchRequestStep.Request.Content?.Headers?.Any() ?? false))
             {
                 // write the Headers property name for the batch object
                 writer.WritePropertyName(CoreConstants.BatchRequest.Headers);

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -230,15 +230,32 @@ namespace Microsoft.Graph
                 writer.WriteEndArray();
             }
 
-            // write any headers the step contains
-            if (batchRequestStep.Request.Content?.Headers != null && batchRequestStep.Request.Content.Headers.Any())
+            // write any headers if the step contains any request headers or content headers
+            if (   (batchRequestStep.Request.Headers != null && batchRequestStep.Request.Headers.Any()) 
+                || (batchRequestStep.Request.Content?.Headers != null && batchRequestStep.Request.Content.Headers.Any()))
             {
+                // write the Headers property name for the batch object
                 writer.WritePropertyName(CoreConstants.BatchRequest.Headers);
                 writer.WriteStartObject();
-                foreach (var header in batchRequestStep.Request.Content.Headers)
+
+                // write any request headers
+                if (batchRequestStep.Request.Headers != null)
                 {
-                    writer.WriteString(header.Key, GetHeaderValuesAsString(header.Value));
+                    foreach (var header in batchRequestStep.Request.Headers)
+                    {
+                        writer.WriteString(header.Key, GetHeaderValuesAsString(header.Value));
+                    }
                 }
+
+                // write any content headers
+                if (batchRequestStep.Request.Content?.Headers != null)
+                {
+                    foreach (var header in batchRequestStep.Request.Content.Headers)
+                    {
+                        writer.WriteString(header.Key, GetHeaderValuesAsString(header.Value));
+                    }
+                }
+
                 writer.WriteEndObject();
             }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -381,12 +381,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.True(batchRequestContent.BatchRequestSteps[batchRequestStepId].Request.Content.Headers.Any());
 
             // we do this to get a version of the json payload that is indented 
-            string requestContentString;
-            await using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
-            using (JsonDocument jsonDocument = await JsonDocument.ParseAsync(requestStream))
-            {
-                requestContentString = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
-            }
+            await using var requestStream = await batchRequestContent.GetBatchRequestContentAsync();
+            using var jsonDocument = await JsonDocument.ParseAsync(requestStream);
+            string requestContentString = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
 
             // Ensure the headers section is added
             string expectedJsonSection = "      \"url\": \"/me\",\r\n" +

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
     using System.Linq;
     using System.Net.Http;
     using System.IO;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
     using System.Text.Json;
     using Xunit;
 
@@ -355,6 +357,45 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.RequestUri.OriginalString, baseRequest.RequestUrl);
             Assert.Equal(batchRequestContent.BatchRequestSteps.First().Value.Request.Method.Method, baseRequest.Method.ToString());
+        }
+
+        [Fact]
+        public async Task BatchRequestContent_AddBatchRequestStepWithBaseRequestWithHeaderOptions()
+        {
+            // Create a BatchRequestContent from a BaseRequest object
+            BatchRequestContent batchRequestContent = new BatchRequestContent();
+
+            // Create a BatchRequestContent from a HttpRequestMessage object
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, REQUEST_URL)
+            {
+                Content = new StringContent("{}")
+            };
+            requestMessage.Headers.Add("ConsistencyLevel", "eventual");
+            requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(CoreConstants.MimeTypeNames.Application.Json);
+            string batchRequestStepId = batchRequestContent.AddBatchRequestStep(requestMessage);
+
+            // Assert we added successfully and contents are as expected
+            Assert.NotNull(batchRequestContent.BatchRequestSteps);
+            Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
+            Assert.True(batchRequestContent.BatchRequestSteps[batchRequestStepId].Request.Headers.Any());
+            Assert.True(batchRequestContent.BatchRequestSteps[batchRequestStepId].Request.Content.Headers.Any());
+
+            // we do this to get a version of the json payload that is indented 
+            string requestContentString;
+            await using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
+            using (JsonDocument jsonDocument = await JsonDocument.ParseAsync(requestStream))
+            {
+                requestContentString = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
+            }
+
+            // Ensure the headers section is added
+            string expectedJsonSection = "      \"url\": \"/me\",\r\n" +
+                                         "      \"method\": \"POST\",\r\n" +
+                                         "      \"headers\": {\r\n" +
+                                         "        \"ConsistencyLevel\": \"eventual\",\r\n" + // Ensure the requestMessage headers are present
+                                         "        \"Content-Type\": \"application/json\"\r\n" + // Ensure the content headers are present
+                                         "      }";
+            Assert.Contains(expectedJsonSection, requestContentString);
         }
 
         [Fact]


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/258

Currently, using the `HeaderOption` sets the headers of the HttpRequestMessage rather than what the batch code currently expects i.e. the `ContentHeaders`. 
This PR therefore updates the batch code to read the headers from the HttpRequestMessage itself as well so that headers in the HttpRequestMessage are also included in the sending of the batch request.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/257)