### PR TITLE
Include US Government L5 (DOD) national cloud endpoint

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -44,6 +44,7 @@
 - Include symbols
 - Change debug type to portable
 - Fix for Batch function not sending the ImmutableID header
+- Include US Government L5 (DOD) national cloud endpoint in cloud list
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -38,13 +38,16 @@ namespace Microsoft.Graph
                 { Global_Cloud, "https://graph.microsoft.com" },
                 { USGOV_Cloud, "https://graph.microsoft.us" },
                 { China_Cloud, "https://microsoftgraph.chinacloudapi.cn" },
-                { Germany_Cloud, "https://graph.microsoft.de" }
+                { Germany_Cloud, "https://graph.microsoft.de" },
+                { USGOV_DOD_Cloud, "https://dod-graph.microsoft.us" },
             };
 
         /// Global endpoint
         public const string Global_Cloud = "Global";
         /// US_GOV endpoint
         public const string USGOV_Cloud = "US_GOV";
+        /// US_GOV endpoint
+        public const string USGOV_DOD_Cloud = "US_GOV_DOD";
         /// China endpoint
         public const string China_Cloud = "China";
         /// Germany endpoint


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/253

It includes the US Government L5 (DOD) national cloud endpoint to the cloud list in GraphClientFactory.

Reference: -
https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/259)