### PR TITLE
Fix for null reference on error property in some error payloads

### DIFF
--- a/src/Microsoft.Graph.Core/Exceptions/Error.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/Error.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Graph
                 errorStringBuilder.Append(Environment.NewLine);
                 foreach (var prop in this.AdditionalData)
                 {
-                    errorStringBuilder.AppendFormat("\t{0}: {1}", prop.Key, prop.Value == null ? "null" : prop.Value.ToString());
+                    errorStringBuilder.AppendFormat("\t{0}: {1}", prop.Key, prop.Value?.ToString() ?? "null");
                     errorStringBuilder.Append(Environment.NewLine);
                 }
             }

--- a/src/Microsoft.Graph.Core/Exceptions/Error.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/Error.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Graph
                 errorStringBuilder.Append(Environment.NewLine);
                 foreach (var prop in this.AdditionalData)
                 {
-                    errorStringBuilder.AppendFormat("\t{0}: {1}", prop.Key, prop.Value.ToString());
+                    errorStringBuilder.AppendFormat("\t{0}: {1}", prop.Key, prop.Value == null ? "null" : prop.Value.ToString());
                     errorStringBuilder.Append(Environment.NewLine);
                 }
             }

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -44,6 +44,7 @@
 - Include symbols
 - Change debug type to portable
 - Fix for Batch function not sending the ImmutableID header
+- Fix NullReference Exception on null property in Error payload
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/100

In the event that the error response from graph has an unexpected property set in the payload as null, this causes NullReferenceException as the code tries to call the ToString method on a null value. 

The change therefore ensures that the SDK user will get the full error information and not hindered by the null reference exception in this case.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/260)