### PR TITLE
Add support for accessing stream contents in batch requests.

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>netstandard2.0;net462;MonoAndroid80;Xamarin.iOS10;Xamarin.Mac20;</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
     <PackageId>Microsoft.Graph.Core</PackageId>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -46,6 +46,7 @@
 - Fix for Batch function not sending the ImmutableID header
 - Fix NullReference Exception on null property in Error payload
 - Include US Government L5 (DOD) national cloud endpoint in cloud list
+- Add support for retrieving stream responses in Batch requests.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Graph
             });
 
             this.Serializer = serializer ?? new Serializer();
-            this.ResponseHandler = new ResponseHandler(this.Serializer);
+            this.ResponseHandler = responseHandler ?? new ResponseHandler(this.Serializer);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Microsoft.Graph
             using (var httpResponseMessage = await GetResponseByIdAsync(requestId)) 
             {
                 await ValidateSuccessfulResponse(httpResponseMessage);
-                var stream = await httpResponseMessage.Content.ReadAsStreamAsync();
+                using var stream = await httpResponseMessage.Content.ReadAsStreamAsync();
                 var memoryStream = new MemoryStream();
                 await stream.CopyToAsync(memoryStream);
                 return memoryStream;
@@ -183,7 +183,7 @@ namespace Microsoft.Graph
 
             if (jBatchResponseObject.RootElement.TryGetProperty(CoreConstants.Serialization.ODataNextLink, out JsonElement nextLink))
             {
-                return nextLink.ToString();
+                return nextLink.GetString();
             }
 
             return null;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -165,15 +165,15 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                         "]" +
                                     "}";
 
-            HttpContent content = new StringContent(responseJSON);
-            HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            using HttpContent content = new StringContent(responseJSON);
+            using HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = content
             };
 
             BatchResponseContent batchResponseContent = new BatchResponseContent(httpResponseMessage);
 
-            Stream responseStream = await batchResponseContent.GetResponseStreamByIdAsync("1");
+            using Stream responseStream = await batchResponseContent.GetResponseStreamByIdAsync("1");
 
             Assert.NotNull(responseStream);
             Assert.True(responseStream.Length > 0);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
     using Xunit;
     using System.Threading.Tasks;
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
+    using System.IO;
 
     public class BatchResponseContentTests
     {
@@ -123,6 +124,59 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
             Assert.True(response.Headers.CacheControl.NoCache);
+        }
+
+        [Fact]
+        public async Task BatchResponseContent_GetResponseStreamByIdAsync()
+        {
+            // This is an example response from /me/photo/$value
+            string responseJSON = @"{"+
+                                        "\"responses\": [" +
+                                            "{" +
+                                                "\"id\": \"1\"," +
+                                                "\"status\": 200," +
+                                                "\"headers\": {" +
+                                                    "\"Cache-Control\": \"private\"," +
+                                                    "\"Content-Type\": \"image/jpeg\"," +
+                                                    "\"ETag\": \"BEB9D79C\"" +
+                                              "}," +
+                                              "\"body\": \"iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZ" +
+                                                  "SBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77" +
+                                                  "u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM" +
+                                                  "6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0x" +
+                                                  "NDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyL" +
+                                                  "zIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodH" +
+                                                  "RwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXA" +
+                                                  "vMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJj" +
+                                                  "ZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc" +
+                                                  "3RhbmNlSUQ9InhtcC5paWQ6MEVBMTczNDg3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiIHhtcE1NOkRvY3VtZW" +
+                                                  "50SUQ9InhtcC5kaWQ6MEVBMTczNDk3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiPiA8eG1wTU06RGVyaXZlZEZ" +
+                                                  "yb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowRUExNzM0NjdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIg" +
+                                                  "c3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowRUExNzM0NzdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIvPiA8L" +
+                                                  "3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PjjUms" +
+                                                  "sAAAGASURBVHjatJaxTsMwEIbpIzDA6FaMMPYJkDKzVYU+QFeEGPIKfYU8AETkCYI6wANkZQwIKRNDB1hA0Jr" +
+                                                  "f0rk6WXZ8BvWkb4kv99vn89kDrfVexBSYgVNwDA7AN+jAK3gEd+AlGMGIBFDgFvzouK3JV/lihQTOwLtOtw9w" +
+                                                  "IRG5pJn91Tbgqk9kSk7GViADrTD4HCyZ0NQnomi51sb0fUyCMQEbp2WpU67IjfNjwcYyoUDhjJVcZBjYBy40j" +
+                                                  "4wXgaobWoe8Z6Y80CJBwFpunepIzt2AUgFjtXXshNXjVmMh+K+zzp/CMs0CqeuzrxSRpbOKfdCkiMTS1VBQ41" +
+                                                  "uxMyQR2qbrXiiwYN3ACh1FDmsdK2Eu4J6Tlo31dYVtCY88h5ELZIJJ+IRMzBHfyJINrigNkt5VsRiub9nXICd" +
+                                                  "sYyVd2NcVvA3ScE5t2rb5JuEeyZnAhmLt9NK63vX1O5Pe8XaPSuGq1uTrfUgMEp9EJ+CQvr+BJ/AAKvAcCiAR" +
+                                                  "+bf9CjAAluzmdX4AEIIAAAAASUVORK5CYII=\"" +
+                                            "}" +
+                                        "]" +
+                                    "}";
+
+            HttpContent content = new StringContent(responseJSON);
+            HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = content
+            };
+
+            BatchResponseContent batchResponseContent = new BatchResponseContent(httpResponseMessage);
+
+            Stream responseStream = await batchResponseContent.GetResponseStreamByIdAsync("1");
+
+            Assert.NotNull(responseStream);
+            Assert.True(responseStream.Length > 0);
         }
 
 


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/728

Currently, SDK users are not able to access stream contents of batch responses with the following call because the stream to the deserializer thus causing a JsonSerializationException. Furthermore, the parent HttpResponseMessage will already have been cleaned up/disposed.

```cs
/// this is incorrect and should not be used as the response is passed to the deserializer.
using var responseUserPhotoFile = batchResponse.GetResponseByIdAsync<Stream>("1");
```

This PR therefore adds the ability for the SDK user to access stream responses with proper cleanup of the parent HttpResponseMessage being performed using the following call together with the relevant checks for error responses.

```cs
using var responseStream = await batchResponseContent.GetResponseStreamByIdAsync("1");
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/262)