### PR TITLE
Replace typeof(T).ToString() with nameof()

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         internal static T WithDefaultAuthProvider<T>(this T baseRequest) where T : IBaseRequest
         {
-            string authOptionKey = typeof(AuthenticationHandlerOption).ToString();
+            string authOptionKey = nameof(AuthenticationHandlerOption);
             if (baseRequest.MiddlewareOptions.ContainsKey(authOptionKey))
             {
                 (baseRequest.MiddlewareOptions[authOptionKey] as AuthenticationHandlerOption).AuthenticationProvider = baseRequest.Client.AuthenticationProvider;
@@ -48,7 +48,7 @@ namespace Microsoft.Graph
         {
             if (baseRequest.Client.PerRequestAuthProvider != null)
             {
-                string authOptionKey = typeof(AuthenticationHandlerOption).ToString();
+                string authOptionKey = nameof(AuthenticationHandlerOption);
                 if (baseRequest.MiddlewareOptions.ContainsKey(authOptionKey))
                 {
                     (baseRequest.MiddlewareOptions[authOptionKey] as AuthenticationHandlerOption).AuthenticationProvider = baseRequest.Client.PerRequestAuthProvider();
@@ -72,7 +72,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public static T WithShouldRetry<T>(this T baseRequest, Func<int, int, HttpResponseMessage, bool> shouldRetry) where T : IBaseRequest
         {
-            string retryOptionKey = typeof(RetryHandlerOption).ToString();
+            string retryOptionKey = nameof(RetryHandlerOption);
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
                 (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).ShouldRetry = shouldRetry;
@@ -95,7 +95,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public static T WithMaxRetry<T>(this T baseRequest, int maxRetry) where T : IBaseRequest
         {
-            string retryOptionKey = typeof(RetryHandlerOption).ToString();
+            string retryOptionKey = nameof(RetryHandlerOption);
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
                 (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).MaxRetry = maxRetry;
@@ -118,7 +118,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public static T WithMaxRetry<T>(this T baseRequest, TimeSpan retriesTimeLimit) where T : IBaseRequest
         {
-            string retryOptionKey = typeof(RetryHandlerOption).ToString();
+            string retryOptionKey = nameof(RetryHandlerOption);
             if (baseRequest.MiddlewareOptions.ContainsKey(retryOptionKey))
             {
                 (baseRequest.MiddlewareOptions[retryOptionKey] as RetryHandlerOption).RetriesTimeLimit = retriesTimeLimit;
@@ -141,7 +141,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public static T WithMaxRedirects<T>(this T baseRequest, int maxRedirects) where T : IBaseRequest
         {
-            string redirectOptionKey = typeof(RedirectHandlerOption).ToString();
+            string redirectOptionKey = nameof(RedirectHandlerOption);
             if (baseRequest.MiddlewareOptions.ContainsKey(redirectOptionKey))
             {
                 (baseRequest.MiddlewareOptions[redirectOptionKey] as RedirectHandlerOption).MaxRedirect = maxRedirects;
@@ -178,7 +178,7 @@ namespace Microsoft.Graph
         /// <param name="scopes">Microsoft graph scopes used to authenticate this request.</param>
         public static T WithScopes<T>(this T baseRequest, string[] scopes) where T : IBaseRequest
         {
-            string authHandlerOptionKey = typeof(AuthenticationHandlerOption).ToString();
+            string authHandlerOptionKey = nameof(AuthenticationHandlerOption);
             AuthenticationHandlerOption authHandlerOptions; 
 
             // make sure that the options exist in the middleware otherwise create it

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ namespace Microsoft.Graph
         public static GraphRequestContext GetRequestContext(this HttpRequestMessage httpRequestMessage)
         {
             GraphRequestContext requestContext = new GraphRequestContext();
-            if (httpRequestMessage.Properties.TryGetValue(typeof(GraphRequestContext).ToString(), out var requestContextObject))
+            if (httpRequestMessage.Properties.TryGetValue(nameof(GraphRequestContext), out var requestContextObject))
             {
                 requestContext = (GraphRequestContext)requestContextObject;
             }
@@ -117,7 +117,7 @@ namespace Microsoft.Graph
             GraphRequestContext requestContext = httpRequestMessage.GetRequestContext();
             if (requestContext.MiddlewareOptions != null)
             {
-                requestContext.MiddlewareOptions.TryGetValue(typeof(T).ToString(), out option);
+                requestContext.MiddlewareOptions.TryGetValue(typeof(T).Name, out option);
             }
             return (T)option;
         }

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Graph
                 FeatureUsage = httpRequestMessage.GetFeatureFlags()
             };
 
-            httpRequestMessage.Properties.Add(typeof(GraphRequestContext).ToString(), requestContext);
+            httpRequestMessage.Properties.Add(nameof(GraphRequestContext), requestContext);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -180,8 +180,8 @@ namespace Microsoft.Graph
 
             // update the request context with the updated options
             GraphRequestContext requestContext = newRequest.GetRequestContext();
-            requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
-            newRequest.Properties[typeof(GraphRequestContext).ToString()] = requestContext;
+            requestContext.MiddlewareOptions[nameof(AuthenticationHandlerOption)] = authenticationHandlerOption;
+            newRequest.Properties[nameof(GraphRequestContext)] = requestContext;
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
                 var baseRequest = new BaseRequest(requestUrl, baseClient);
                 baseRequest.WithShouldRetry((d, a, r) => false);
 
-                Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+                Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[nameof(GraphRequestContext)]);
                 Assert.False(baseRequest.GetHttpRequestMessage().GetMiddlewareOption<RetryHandlerOption>().ShouldRetry(delay, attempt, httpResponseMessage));
             }
         }
@@ -53,7 +53,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
             var baseRequest = new BaseRequest(requestUrl, baseClient);
             baseRequest.WithMaxRetry(3);
 
-            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[nameof(GraphRequestContext)]);
             Assert.Equal(3, baseRequest.GetHttpRequestMessage().GetMiddlewareOption<RetryHandlerOption>().MaxRetry);
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
             var baseRequest = new BaseRequest(requestUrl, baseClient);
             baseRequest.WithMaxRedirects(4);
 
-            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[nameof(GraphRequestContext)]);
             Assert.Equal(4, baseRequest.GetHttpRequestMessage().GetMiddlewareOption<RedirectHandlerOption>().MaxRedirect);
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
             baseRequest.WithPerRequestAuthProvider();
             var httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
-            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[nameof(GraphRequestContext)]);
             Assert.NotSame(baseClient.AuthenticationProvider, httpRequestMessage.GetMiddlewareOption<AuthenticationHandlerOption>().AuthenticationProvider);
             Assert.Same(requestMockAuthProvider.Object, httpRequestMessage.GetMiddlewareOption<AuthenticationHandlerOption>().AuthenticationProvider);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
             baseRequest.WithScopes(scopes);
 
             // Assert
-            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[typeof(GraphRequestContext).ToString()]);
+            Assert.IsType<GraphRequestContext>(baseRequest.GetHttpRequestMessage().Properties[nameof(GraphRequestContext)]);
             var messageScopes = baseRequest.GetHttpRequestMessage().GetMiddlewareOption<AuthenticationHandlerOption>()
                 .AuthenticationProviderOption.Scopes;
             Assert.Equal(2, messageScopes.Length);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -410,13 +410,13 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 MiddlewareOptions = new Dictionary<string, IMiddlewareOption>() {
                     {
-                        typeof(AuthenticationHandlerOption).ToString(),
+                        nameof(AuthenticationHandlerOption),
                         new AuthenticationHandlerOption { AuthenticationProvider = authProvider .Object }
                     }
                 },
                 ClientRequestId = "client-request-id"
             };
-            httpRequestMessage.Properties.Add(typeof(GraphRequestContext).ToString(), requestContext);
+            httpRequestMessage.Properties.Add(nameof(GraphRequestContext), requestContext);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
@@ -116,11 +116,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             using (var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized))
             using (var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK))
             {
-                httpRequestMessage.Properties.Add(typeof(GraphRequestContext).ToString(), new GraphRequestContext
+                httpRequestMessage.Properties.Add(nameof(GraphRequestContext), new GraphRequestContext
                 {
                     MiddlewareOptions = new Dictionary<string, IMiddlewareOption>() {
                         {
-                            typeof(AuthenticationHandlerOption).ToString(),
+                            nameof(AuthenticationHandlerOption),
                             new AuthenticationHandlerOption { AuthenticationProvider = mockAuthenticationProvider.Object }
                         }
                     }
@@ -290,7 +290,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var requestContext = response.RequestMessage.GetRequestContext();
 
-            var middleWareOption = requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] as AuthenticationHandlerOption;
+            var middleWareOption = requestContext.MiddlewareOptions[nameof(AuthenticationHandlerOption)] as AuthenticationHandlerOption;
             Assert.NotNull(middleWareOption);
 
             var authProviderOption = middleWareOption.AuthenticationProviderOption as ICaeAuthenticationProviderOption;
@@ -317,8 +317,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             // set the original AuthenticationProviderOptionTest as the auth provider
             var originalRequestContext = httpRequestMessage.GetRequestContext();
-            originalRequestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
-            httpRequestMessage.Properties[typeof(GraphRequestContext).ToString()] = originalRequestContext;
+            originalRequestContext.MiddlewareOptions[nameof(AuthenticationHandlerOption)] = authenticationHandlerOption;
+            httpRequestMessage.Properties[nameof(GraphRequestContext)] = originalRequestContext;
 
             var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             unauthorizedResponse.Headers.WwwAuthenticate.Add(
@@ -335,7 +335,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var requestContext = response.RequestMessage.GetRequestContext();
 
             // Assert
-            var middleWareOption = requestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] as AuthenticationHandlerOption;
+            var middleWareOption = requestContext.MiddlewareOptions[nameof(AuthenticationHandlerOption)] as AuthenticationHandlerOption;
             Assert.NotNull(middleWareOption);
 
             var authProviderOption = middleWareOption.AuthenticationProviderOption as ICaeAuthenticationProviderOption;


### PR DESCRIPTION
This PR resolves feedback from https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/271

Currently we use `typeof(T).ToString()` to add/retrieve values from the `Middlewares` collection which introduces a performance penalty. This PR replaces those calls with `nameof` to alleviate that.

References
- https://www.erikschierboom.com/2015/12/31/csharp6-under-the-hood-nameof
- https://stackoverflow.com/questions/6417763/efficiency-of-cs-typeof-operator-or-whatever-its-representation-is-in-msil/6417977#6417977

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/275)