### PR TITLE
- adds code owner configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @andrueastman @michaelmainer @peombwa @zengin


### PR DESCRIPTION
I noticed that dependabot PRs didn't have any reviewers. Adding the people I think should be default reviewers on any PR in this repo.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/289)