### PR TITLE
Fix inconsistent serialization of interface properties

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -20,34 +20,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Adds support for TokenCredential from Azure.Core
-- [Breaking Change] Adds support for System.Text,Json and drops Newtonsoft.Json dependency
-- [Breaking Change] Fix for incorrect task cancellation #28
-- Added GraphResponse object for wrapping responses
-- [Breaking Change] IBaseRequest now takes IResponseHandler as a member
-- Support Mac Http handlers(v1.0 feature)
-- Compression header handling(v1.0 feature)
-- Fix DefaultMaxSliceSize in LargeFileUpload task(v1.0 feature)
-- Fix for NullReference exception thrown when contentType is empty(v1.0 feature)
-- Add support for content with parameters(v1.0 feature)
-- Add continuous access evaluation(CAE) support(v1.0 feature)
-- Fix deserialization of odata primitives(v1.0 feature)
-- Support composable functions.(v1.0 feature)
-- Fixes setting of response headers in ServiceException so that customers have access to correlation ids #193 (v1.0 feature)
-- Prevents potential deadlock from occurring when AuthenticateRequestAsync(request) is called. #188 (v1.0 feature)
-- [Breaking Change] Remove serialization of headers and statusCode into AdditionalData #206
-- Fix deserialization of empty streams to be consistent with empty strings
-- [Breaking Change] Method type in IBaseRequest changes from string to enum 
-- Fix InvalidOperationException when Location header is relative #214
-- Include symbols
-- Change debug type to portable
-- Fix for Batch function not sending the ImmutableID header
-- Fix NullReference Exception on null property in Error payload
-- Include US Government L5 (DOD) national cloud endpoint in cloud list
-- Add support for retrieving stream responses in Batch requests.
+- Fix for serialization of interface properties not using global serializer options
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -134,6 +110,6 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.35.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -241,7 +241,17 @@ namespace Microsoft.Graph
                     foreach (var item in additionalData)
                     {
                         writer.WritePropertyName(item.Key);
-                        JsonSerializer.Serialize(writer, item.Value, item.Value.GetType(), options);
+                        // Check if value is null to choose the JsonSerializer.Serialize overload as System.Text.Json no longer supports 
+                        // the type parameter being null. 
+                        // Ref: https://docs.microsoft.com/en-us/dotnet/core/compatibility/serialization/5.0/jsonserializer-serialize-throws-argumentnullexception-for-null-type
+                        if (item.Value == null)
+                        {
+                            JsonSerializer.Serialize(writer, item.Value, options);
+                        }
+                        else
+                        {
+                            JsonSerializer.Serialize(writer, item.Value, item.Value.GetType(), options);
+                        }
                     }
                 }
                 else

--- a/src/Microsoft.Graph.Core/Serialization/InterfaceConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/InterfaceConverter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// <param name="options">The serializer options to use.</param>
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
-            JsonSerializer.Serialize(writer, value, typeof(T));
+            JsonSerializer.Serialize(writer, value, typeof(T), options);
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -431,13 +431,15 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
                 ContentType = TestBodyType.Text,
                 AdditionalData = new Dictionary<string, object>
                 {
-                    { "length" , "100" }
+                    { "length" , "100" },
+                    { "extraProperty", null }
                 }
             };
             var expectedSerializedString = "{" +
                                                "\"contentType\":\"text\"," +
                                                "\"content\":\"Example Content\"," +
                                                "\"length\":\"100\"," + // should be at the same level as other properties
+                                               "\"extraProperty\":null," +
                                                "\"@odata.type\":\"microsoft.graph.itemBody\"" +
                                            "}";
 
@@ -445,6 +447,27 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
             var serializedString = this.serializer.SerializeObject(testItemBody);
 
             //Assert
+            Assert.Equal(expectedSerializedString, serializedString);
+        }
+
+        [Fact]
+        public void SerializeInterfaceProperty()
+        {
+            // Arrange
+            var user = new TestUser()
+            {
+                EventDeltas = new TestEventDeltaCollectionPage()
+                {
+                    new TestEvent() { Id = "id" }
+
+                }
+            };
+            var expectedSerializedString = "{\"@odata.type\":\"microsoft.graph.user\",\"eventDeltas\":[{\"id\":\"id\",\"@odata.type\":\"microsoft.graph.event\"}]}";
+
+            // Act
+            var serializedString = this.serializer.SerializeObject(user);
+
+            // Assert that the interface properties respect the json serializer options
             Assert.Equal(expectedSerializedString, serializedString);
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestUser.cs
@@ -68,5 +68,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         [JsonPropertyName("surname")]
         public string Surname { get; set; }
 
+        /// <summary>
+        /// Gets or sets eventDeltas.
+        /// The user's event deltas. This property is just a testing value.
+        /// </summary>
+        [JsonPropertyName("eventDeltas")]
+        public ITestEventDeltaCollectionPage EventDeltas { get; set; }
+
     }
 }


### PR DESCRIPTION
The changes proposed in this PR involve

- Fixing the serialization of Interface properties by ensuring the JsonSerializerOptions intance is passed over to ensure consistent serialization with all types. 
- Fixing the DerivedTypeConverter to call the right  `JsonSerializer.Serialize` overload as the previous overload no longer supports a null `Type` parameter(See [here](https://docs.microsoft.com/en-us/dotnet/core/compatibility/serialization/5.0/jsonserializer-serialize-throws-argumentnullexception-for-null-type)).
- Adding/Updating tests to validate the above


Related issues.

- https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1084
- https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/329

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/296)