### PR TITLE
Url decode nextLink url string.

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -13,17 +13,17 @@
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <RepositoryUrl>https://github.com/microsoftgraph/msgraph-sdk-dotnet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/microsoftgraph/msgraph-sdk-dotnet-core</RepositoryUrl>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for serialization of interface properties not using global serializer options
+- Fix for initialization of the @odata.nextLink property through the NextLinkConverter
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    using System.Net;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    public class NextLinkConverter : JsonConverter<string>
+    {
+        /// <summary>
+        /// Checks if the given object can be converted into a next link url.
+        /// </summary>
+        /// <param name="objectType">The object type.</param>
+        /// <returns>True if the object is of type Duration.</returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+
+        /// <summary>
+        /// Deserialize the JSON data into a decoded nextLink url string.
+        /// </summary>
+        /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
+        /// <param name="typeToConvert">The object type.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> for conversion.</param>
+        /// <returns>A TimeOfDay object.</returns>
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return WebUtility.UrlDecode(reader.GetString());
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write to.</param>
+        /// <param name="value">The nextLink url value.</param>
+        /// <param name="options">The calling serializer options</param>
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Graph
         /// <returns>A TimeOfDay object.</returns>
         public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (typeToConvert == null)
+                throw new ArgumentNullException(nameof(typeToConvert));
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
             return WebUtility.UrlDecode(reader.GetString());
         }
 
@@ -41,6 +46,11 @@ namespace Microsoft.Graph
         /// <param name="options">The calling serializer options</param>
         public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
         {
+            if (writer == null)
+                throw new ArgumentNullException(nameof(writer));
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
             writer.WriteStringValue(value);
         }
     }

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Graph
         {
             if (typeToConvert == null)
                 throw new ArgumentNullException(nameof(typeToConvert));
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
 
             return WebUtility.UrlDecode(reader.GetString());
         }
@@ -48,8 +46,6 @@ namespace Microsoft.Graph
         {
             if (writer == null)
                 throw new ArgumentNullException(nameof(writer));
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
 
             writer.WriteStringValue(value);
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public ITestEventDeltaCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
+        public string NextLink { get; set; }
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]


### PR DESCRIPTION
**Background**
https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/255 added support for the encoding of the query parameters in urls to fix issues arising from the use of special characters in QueryOptions. However, during paging, the `@odata.NextLink` property is returned from the api endpoint with space characters replaced with `+` which causes it to be encoded and result to errors. 

**Fix**
To fix this, the PR adds the new `NextLinkConverter` to the core library to fix the initialization of the nextLink property in collectionResponse objects by first decoding the relevant url(which will result in a url safe to encode like changing `+` to space representation).
The PR adds tests to validate that this is mitigated appropiately.

This PR should be followed by https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/570 which annotates the relevant property with the relevant converter so that we may encode the url safely.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/299)