### PR TITLE
Fix DerivedTypeConverter emitting null values with NextLinkConverter attribute

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -20,10 +20,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.0.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for initialization of the @odata.nextLink property through the NextLinkConverter
+- Fix for DerivedTypeConverter emitting null values in conjunction with the NextLinkConverter
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -258,9 +258,10 @@ namespace Microsoft.Graph
                 {
                     // Check to see if the property has a special converter specified
                     var jsonConverter = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonConverterAttribute>();
-                    if (propertyInfo.GetValue(value) == null && jsonConverter == null)
+                    if ((propertyInfo.GetValue(value) == null && 
+                         (jsonConverter == null || jsonConverter.ConverterType == typeof(NextLinkConverter))))
                     {
-                        continue; //Don't do anything if we don't have a special converter or the value is null
+                        continue; //Don't emit null values unless we have a special converter. Unless its a converter for a primitive like the NextLinkConverter
                     }
 
                     writer.WritePropertyName(propertyName);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         }
 
         [Fact]
-        public void SerializeObjectWithEmptyAdditionalDataWithDerivedTypeConverter()
+        public void DerivedTypeConverterSerializeObjectWithEmptyAdditionalDataWithDerivedTypeConverterAndIgnoresNullNextLinkConverter()
         {
             // This example class uses the derived type converter with an empty/unset AdditionalData
             // Arrange
@@ -494,6 +494,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
 
             //Assert
             Assert.Equal(expectedSerializedString, serializedString);
+            Assert.DoesNotContain("@odata.nextLink", serializedString);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestItemBody.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestItemBody.cs
@@ -37,6 +37,13 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public string Content { get; set; }
 
         /// <summary>
+        /// Gets or sets instancesNextLink.
+        /// </summary>
+        [JsonPropertyName("instances@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
+        public string InstancesNextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]


### PR DESCRIPTION
This PR fixes an issue reported with the emitting of null values during serialization when the `NextLinkConverter` attribute is added to a model using the `DerivedTypeConveter`.

This leads to Api side errors as some values are not allowed to be set as null.

Existing tests have been enriched to capture this edge case.

Related to https://stackoverflow.com/questions/68768713/odata-nextlink-error-in-sendmail-via-graph-library

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/301)