### PR TITLE
Fix for deltaResponseHandler leaving out empty arrays

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
   <PropertyGroup>
     <Description>Microsoft Graph Core Client Library implements core functionality used by Microsoft Graph client libraries.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -20,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for DerivedTypeConverter emitting null values in conjunction with the NextLinkConverter
+- Fix for DeltaResponseHandler not adding empty collection properties to the changes list
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -165,9 +165,18 @@ namespace Microsoft.Graph
                     case JsonValueKind.Array:
                     {
                         string parent = parentName + property.Name;
+                        var arrayEnumerator = property.Value.EnumerateArray();
+                        if (!arrayEnumerator.Any())
+                        {
+                            // Handle the edge case when the change involves changing to an empty array 
+                            // as we can't observe elements in an empty collection in the foreach loop below
+                            changes.Add(parent); 
+                            break;
+                        }
 
                         int index = 0;
-                        foreach ( var arrayItem in property.Value.EnumerateArray())
+                        // Extract change elements from the array collection
+                        foreach ( var arrayItem in arrayEnumerator)
                         {
                             string parentWithIndex = $"{parent}[{index}]";
 

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Graph
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
+    /// <summary>
+    /// The converter for deserializing/serializing next link urls
+    /// </summary>
     public class NextLinkConverter : JsonConverter<string>
     {
         /// <summary>


### PR DESCRIPTION
This PR fixes an issue with the DeltaResponseHandler where in the event a property in the delta query response is an empty array, the property would be left out of the list of change properties as the loop does not get the chance to iterate through an empty list.

This PR also 
- Adds a valid test to validate this change
- Fixes a missing XML comment for the public NextLink converter class

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/307)