### PR TITLE
Release 2.0.4

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
   <PropertyGroup>
     <Description>Microsoft Graph Core Client Library implements core functionality used by Microsoft Graph client libraries.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -20,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for DerivedTypeConverter emitting null values in conjunction with the NextLinkConverter
+- Fix for DeltaResponseHandler not adding empty collection properties to the changes list
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -106,7 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Azure.Core" Version="1.17.0" />
+    <PackageReference Include="Azure.Core" Version="1.18.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.35.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -109,7 +109,7 @@
     <PackageReference Include="Azure.Core" Version="1.17.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.35.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -165,9 +165,18 @@ namespace Microsoft.Graph
                     case JsonValueKind.Array:
                     {
                         string parent = parentName + property.Name;
+                        var arrayEnumerator = property.Value.EnumerateArray();
+                        if (!arrayEnumerator.Any())
+                        {
+                            // Handle the edge case when the change involves changing to an empty array 
+                            // as we can't observe elements in an empty collection in the foreach loop below
+                            changes.Add(parent); 
+                            break;
+                        }
 
                         int index = 0;
-                        foreach ( var arrayItem in property.Value.EnumerateArray())
+                        // Extract change elements from the array collection
+                        foreach ( var arrayItem in arrayEnumerator)
                         {
                             string parentWithIndex = $"{parent}[{index}]";
 

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Graph
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
+    /// <summary>
+    /// The converter for deserializing/serializing next link urls
+    /// </summary>
     public class NextLinkConverter : JsonConverter<string>
     {
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -47,7 +47,7 @@
 	<PackageReference Include="System.Reflection.Emit" Version="4.7.0">
 	  <ExcludeAssets>all</ExcludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 	<PackageReference Include="Moq" Version="4.16.1" />
 	<PackageReference Include="xunit" Version="2.4.1" />
 	<ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />


### PR DESCRIPTION
This PR merges dev to master to for the 2.0.2 release

Changes include: -

- Dependabot update bumping Azure.Core from 1.17.0 to 1.18.0
- Fix for deltaResponseHandler leaving out empty arrays via #307 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/308)