### PR TITLE
Fix for batch request urls with the string beta

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.4</VersionPrefix>
+    <VersionPrefix>2.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for DeltaResponseHandler not adding empty collection properties to the changes list
+- Fix for incorrect building of batch requests when the url contains the string 'beta'
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -308,10 +308,10 @@ namespace Microsoft.Graph
         private string GetRelativeUrl(Uri requestUri)
         {
             string version = "v1.0";
-            if (requestUri.AbsoluteUri.Contains("beta"))
+            if (requestUri.AbsoluteUri.Contains("/beta/"))//use the url segment to search.
                 version = "beta";
 
-            return requestUri.AbsoluteUri.Substring(requestUri.AbsoluteUri.IndexOf(version) + version.ToCharArray().Count());
+            return requestUri.AbsoluteUri.Substring(requestUri.AbsoluteUri.IndexOf(version, StringComparison.OrdinalIgnoreCase) + version.ToCharArray().Length);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -307,11 +307,10 @@ namespace Microsoft.Graph
 
         private string GetRelativeUrl(Uri requestUri)
         {
-            string version = "v1.0";
-            if (requestUri.AbsoluteUri.Contains("/beta/"))//use the url segment to search.
-                version = "beta";
+            if (requestUri == null)
+                throw new ArgumentNullException(nameof(requestUri));
 
-            return requestUri.AbsoluteUri.Substring(requestUri.AbsoluteUri.IndexOf(version, StringComparison.OrdinalIgnoreCase) + version.ToCharArray().Length);
+            return requestUri.PathAndQuery.Substring(5);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Graph
             if (requestUri == null)
                 throw new ArgumentNullException(nameof(requestUri));
 
-            return requestUri.PathAndQuery.Substring(5);
+            return requestUri.PathAndQuery.Substring(5); // `v1.0/` and `beta/` are both 5 characters
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -420,5 +420,35 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(CoreConstants.BatchRequest.MaxNumberOfRequests));
         }
 
+        [Theory]
+        [InlineData("https://graph.microsoft.com/v1.0/me", "/me")]
+        [InlineData("https://graph.microsoft.com/beta/me", "/me")]
+        [InlineData("https://graph.microsoft.com/v1.0/users/abcbeta123@wonderemail.com/events", "/users/abcbeta123@wonderemail.com/events")]
+        [InlineData("https://graph.microsoft.com/beta/users/abcbeta123@wonderemail.com/events", "/users/abcbeta123@wonderemail.com/events")]
+        [InlineData("https://graph.microsoft.com/v1.0/users?$filter=identities/any(id:id/issuer%20eq%20'$74707853-18b3-411f-ad57-2ef65f6fdeb0'%20and%20id/issuerAssignedId%20eq%20'**bobbetancourt@fakeemail.com**')", "/users?$filter=identities/any(id:id/issuer%20eq%20'$74707853-18b3-411f-ad57-2ef65f6fdeb0'%20and%20id/issuerAssignedId%20eq%20'**bobbetancourt@fakeemail.com**')")]
+        [InlineData("https://graph.microsoft.com/beta/users?$filter=identities/any(id:id/issuer%20eq%20'$74707853-18b3-411f-ad57-2ef65f6fdeb0'%20and%20id/issuerAssignedId%20eq%20'**bobbetancourt@fakeemail.com**')&$top=1", "/users?$filter=identities/any(id:id/issuer%20eq%20'$74707853-18b3-411f-ad57-2ef65f6fdeb0'%20and%20id/issuerAssignedId%20eq%20'**bobbetancourt@fakeemail.com**')&$top=1")]
+        public async Task BatchRequestContent_AddBatchRequestStepWithBaseRequestProperlySetsVersion(string requestUrl, string expectedUrl)
+        {
+            // Arrange
+            BatchRequestStep batchRequestStep = new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, requestUrl));
+            BatchRequestContent batchRequestContent = new BatchRequestContent();
+            Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
+
+            // Act
+            batchRequestContent.AddBatchRequestStep(batchRequestStep);
+            var requestContentStream = await batchRequestContent.GetBatchRequestContentAsync();
+            string requestContent;
+            using (StreamReader reader = new StreamReader(requestContentStream))
+            {
+                requestContent = await reader.ReadToEndAsync();
+            }
+
+            var expectedContent = "{\"requests\":[{\"id\":\"1\",\"url\":\""+ expectedUrl +"\",\"method\":\"GET\"}]}";
+
+
+            // Assert we added successfully and contents are as expected
+            Assert.Equal(expectedContent, System.Text.RegularExpressions.Regex.Unescape(requestContent));
+        }
+
     }
 }


### PR DESCRIPTION
This PR closes #310 

It involves fixing the incorrect building of batch requests when the url contains the string 'beta'. 
As the code simply searched for the string `beta` rather than the url segment `\beta\` this would result in queries being truncated if they contained the string beta in another part of the url.

This PR also adds unit tests to validate that this is resolved. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/312)