### PR TITLE
Fix for incorrect URL building in .Net Framework

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.6</VersionPrefix>
+    <VersionPrefix>2.0.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for paging when nextLink url contains encoded special url characters.
+- Fix for incorrect url building in .NetFramework environments
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -37,7 +37,12 @@ namespace Microsoft.Graph
 
             var nextLinkUri = new Uri(reader.GetString());
             // Replace any '+' in the query as it signifies a space character the SDK does url encoding on the query parameter
-            return new UriBuilder(nextLinkUri) { Query = nextLinkUri.Query.Replace("+", "%20") }.ToString();
+            // Strip the ? character as .NetFramework may incorrectly build the url by adding a second '?' character
+            var queryString = string.Empty;
+            if (nextLinkUri.Query != null && nextLinkUri.Query.Length > 1)
+                queryString = nextLinkUri.Query.Replace("+", "%20").Substring(1);
+
+            return new UriBuilder(nextLinkUri) { Query = queryString }.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR closes #345 

It resolves an issue with .Net Framework clients that may add a second '?` character to the url query due to the question mark being always prepended to the string, even if the string already starts with a question mark.


**Reference**
- https://docs.microsoft.com/en-us/dotnet/api/system.uribuilder.query?view=net-6.0#remarks

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/346)