### PR TITLE
Rename HttpMethod to Method

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -98,14 +98,14 @@
   </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.25" />
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.16" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.17" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.7" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Graph
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var requestInformation = new RequestInformation() { HttpMethod = Kiota.Abstractions.HttpMethod.GET , UrlTemplate = this.monitorUrl};
+                var requestInformation = new RequestInformation() { HttpMethod = Method.GET , UrlTemplate = this.monitorUrl};
                 var nativeResponseHandler = new NativeResponseHandler();
                 await this.client.RequestAdapter.SendNoContentAsync(requestInformation, nativeResponseHandler, cancellationToken).ConfigureAwait(false);
                 using var responseMessage = nativeResponseHandler.Value as HttpResponseMessage;

--- a/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
@@ -60,10 +60,9 @@ namespace Microsoft.Graph.Core.Requests
             _ = batchRequestContent ?? throw new ArgumentNullException(nameof(batchRequestContent));
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Kiota.Abstractions.HttpMethod.POST,
+                HttpMethod = Method.POST,
                 UrlTemplate = UrlTemplate,
             };
-            requestInfo.PathParameters.Add("baseurl", RequestAdapter.BaseUrl);
             requestInfo.Content = await batchRequestContent.GetBatchRequestContentAsync();
             requestInfo.Headers.Add("Content-Type", "application/json");
             return requestInfo;

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequestBuilder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Graph
         {
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Kiota.Abstractions.HttpMethod.DELETE,
+                HttpMethod = Method.DELETE,
                 UrlTemplate = urlTemplate,
             };
             return requestInfo;
@@ -75,7 +75,7 @@ namespace Microsoft.Graph
         {
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Kiota.Abstractions.HttpMethod.GET,
+                HttpMethod = Method.GET,
                 UrlTemplate = urlTemplate,
             };
             return requestInfo;

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequestBuilder.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Graph
             _ = stream ?? throw new ArgumentNullException(nameof(stream));
             var requestInfo = new RequestInformation
             {
-                HttpMethod = Kiota.Abstractions.HttpMethod.PUT,
+                HttpMethod = Method.PUT,
                 UrlTemplate = UrlTemplate,
             };
             requestInfo.SetStreamContent(stream);

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Graph
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using HttpMethod = Kiota.Abstractions.HttpMethod;
 
     /*
      Spec https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/tasks/PageIteratorTask.md
@@ -147,7 +146,7 @@ namespace Microsoft.Graph
                 // Call the MSGraph API to get the next page of results and set that page as the currentPage.
                 var nextPageRequestInformation = new RequestInformation
                 {
-                    HttpMethod = HttpMethod.GET,
+                    HttpMethod = Method.GET,
                     UrlTemplate = string.IsNullOrEmpty(Nextlink) ? Deltalink : Nextlink,
                 };
                 // if we have a request configurator, modify the request as desired then execute it to get the next page
@@ -223,7 +222,6 @@ namespace Microsoft.Graph
         /// Resumes iterating through each page of items and processes it according to the Func&lt;TEntity, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
-        /// is provided to the PageIterator</exception>
         public async Task ResumeAsync()
         {
             await ResumeAsync(new CancellationToken());

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var requestInformation = await batchRequestBuilder.CreatePostRequestInformationAsync(batchRequestContent);
 
             // Assert
-            Assert.Equal("https://localhost/$batch", requestInformation.URI.AbsoluteUri);
+            Assert.Equal("{+baseurl}/$batch", requestInformation.UrlTemplate);
             Assert.Equal(baseClient.RequestAdapter, batchRequestBuilder.RequestAdapter);
         }
     }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
         public void BatchRequestContent_AddBatchRequestStepWithBaseRequest()
         {
             // Arrange
-            RequestInformation requestInformation = new RequestInformation() { HttpMethod = Kiota.Abstractions.HttpMethod.GET, UrlTemplate = REQUEST_URL };
+            RequestInformation requestInformation = new RequestInformation() { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
             BatchRequestContent batchRequestContent = new BatchRequestContent(client);
             Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
 
@@ -403,14 +403,14 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             // Add MaxNumberOfRequests number of steps
             for (var i = 0; i < CoreConstants.BatchRequest.MaxNumberOfRequests; i++)
             {
-                RequestInformation requestInformation = new RequestInformation() { HttpMethod = Kiota.Abstractions.HttpMethod.GET, UrlTemplate = REQUEST_URL };
+                RequestInformation requestInformation = new RequestInformation() { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
                 string batchRequestStepId = batchRequestContent.AddBatchRequestStep(requestInformation);
                 Assert.NotNull(batchRequestStepId);
                 Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(i + 1));//Assert we can add steps up to the max
             }
 
             // Act
-            RequestInformation extraRequestInformation = new RequestInformation() { HttpMethod = Kiota.Abstractions.HttpMethod.GET, UrlTemplate = REQUEST_URL };
+            RequestInformation extraRequestInformation = new RequestInformation() { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
             var exception = Assert.Throws<ClientException>(() => batchRequestContent.AddBatchRequestStep(extraRequestInformation));
             
             // Assert


### PR DESCRIPTION
This PR updates the Kiota core dependencies and refactors the project to bring in the latest changes to rename HttpMethod to Method.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/348)