### PR TITLE
[Kiota] LargeFileUpload task refactoring 

### DIFF
--- a/src/Microsoft.Graph.Core/Models/IUploadSession.cs
+++ b/src/Microsoft.Graph.Core/Models/IUploadSession.cs
@@ -4,13 +4,14 @@
 
 namespace Microsoft.Graph
 {
+    using Microsoft.Kiota.Abstractions.Serialization;
     using System;
     using System.Collections.Generic;
 
     /// <summary>
     /// The IUploadSession interface
     /// </summary>
-    public interface IUploadSession
+    public interface IUploadSession: IParsable
     {
         /// <summary>
         /// Expiration date of the upload session

--- a/src/Microsoft.Graph.Core/Models/UploadSession.cs
+++ b/src/Microsoft.Graph.Core/Models/UploadSession.cs
@@ -4,14 +4,24 @@
 
 namespace Microsoft.Graph.Core.Models
 {
+    using Microsoft.Kiota.Abstractions.Serialization;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Concrete implementation of the IUploadSession interface
     /// </summary>
-    internal class UploadSession : IUploadSession
+    internal class UploadSession : IUploadSession,IParsable
     {
+        /// <summary>
+        /// Instantiates a new uploadSession and sets the default values.
+        /// </summary>
+        public UploadSession()
+        {
+            AdditionalData = new Dictionary<string, object>();
+        }
+
         /// <summary>
         /// Expiration date of the upload session
         /// </summary>
@@ -26,5 +36,36 @@ namespace Microsoft.Graph.Core.Models
         /// The URL for upload
         /// </summary>
         public string UploadUrl { get; set; }
+
+        /// <summary>
+        /// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+        /// </summary>
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// The deserialization information for the current model
+        /// </summary>
+        public IDictionary<string, Action<T, IParseNode>> GetFieldDeserializers<T>()
+        {
+            return new Dictionary<string, Action<T, IParseNode>> 
+            {
+                {"expirationDateTime", (o,n) => { (o as UploadSession).ExpirationDateTime = n.GetDateTimeOffsetValue(); } },
+                {"nextExpectedRanges", (o,n) => { (o as UploadSession).NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },
+                {"uploadUrl", (o,n) => { (o as UploadSession).UploadUrl = n.GetStringValue(); } },
+            };
+        }
+
+        /// <summary>
+        /// Serializes information the current object
+        /// <param name="writer">Serialization writer to use to serialize this model</param>
+        /// </summary>
+        public void Serialize(ISerializationWriter writer)
+        {
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteDateTimeOffsetValue("expirationDateTime", ExpirationDateTime);
+            writer.WriteCollectionOfPrimitiveValues<string>("nextExpectedRanges", NextExpectedRanges);
+            writer.WriteStringValue("uploadUrl", UploadUrl);
+            writer.WriteAdditionalData(AdditionalData);
+        }
     }
 }

--- a/src/Microsoft.Graph.Core/Models/UploadSession.cs
+++ b/src/Microsoft.Graph.Core/Models/UploadSession.cs
@@ -12,16 +12,8 @@ namespace Microsoft.Graph.Core.Models
     /// <summary>
     /// Concrete implementation of the IUploadSession interface
     /// </summary>
-    internal class UploadSession : IUploadSession,IParsable
+    internal class UploadSession : IUploadSession
     {
-        /// <summary>
-        /// Instantiates a new uploadSession and sets the default values.
-        /// </summary>
-        public UploadSession()
-        {
-            AdditionalData = new Dictionary<string, object>();
-        }
-
         /// <summary>
         /// Expiration date of the upload session
         /// </summary>
@@ -40,7 +32,7 @@ namespace Microsoft.Graph.Core.Models
         /// <summary>
         /// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
         /// </summary>
-        public IDictionary<string, object> AdditionalData { get; set; }
+        public IDictionary<string, object> AdditionalData { get; set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// The deserialization information for the current model

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Graph
         /// Task to help with resume able large file uploads. Generates slices based on <paramref name="uploadSession"/>
         /// information, and can control uploading of requests/>
         /// </summary>
-        /// <param name="uploadSession">Session information of type <see cref="IUploadSession"/>></param>
+        /// <param name="uploadSession">Session information of type <see cref="IParsable"/> that has a similar structure to <see cref="IUploadSession"/></param>
         /// <param name="uploadStream">Readable, seekable stream to be uploaded. Length of session is determined via uploadStream.Length</param>
         /// <param name="maxSliceSize">Max size of each slice to be uploaded. Multiple of 320 KiB (320 * 1024) is required.</param>
         /// <param name="baseClient"><see cref="BaseClient"/> to use for making upload requests. The client should not set Auth headers as upload urls do not need them.

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.Graph
 {
+    using Microsoft.Graph.Core.Models;
+    using Microsoft.Kiota.Abstractions.Serialization;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -33,22 +35,46 @@ namespace Microsoft.Graph
         /// <param name="maxSliceSize">Max size of each slice to be uploaded. Multiple of 320 KiB (320 * 1024) is required.</param>
         /// <param name="baseClient"><see cref="BaseClient"/> to use for making upload requests. The client should not set Auth headers as upload urls do not need them.
         /// If less than 0, default value of 5 MiB is used. .</param>
-        public LargeFileUploadTask(IUploadSession uploadSession, Stream uploadStream,  int maxSliceSize = -1, BaseClient baseClient = null)
+        public LargeFileUploadTask(IParsable uploadSession, Stream uploadStream,  int maxSliceSize = -1, BaseClient baseClient = null)
         {
             if (!uploadStream.CanRead || !uploadStream.CanSeek)
             {
                 throw new ArgumentException("Must provide stream that can read and seek");
             }
-
-            this.Session = uploadSession;
-            this._client = baseClient ?? this.InitializeClient(uploadSession.UploadUrl);
+            this.Session = this.ExtractSessionFromParsable(uploadSession);
+            this._client = baseClient ?? this.InitializeClient(Session.UploadUrl);
             this._uploadStream = uploadStream;
-            this._rangesRemaining = this.GetRangesRemaining(uploadSession);
+            this._rangesRemaining = this.GetRangesRemaining(Session);
             this._maxSliceSize = maxSliceSize < 0 ? DefaultMaxSliceSize : maxSliceSize;
             if (this._maxSliceSize % RequiredSliceSizeIncrement != 0)
             {
                 throw new ArgumentException("Max slice size must be a multiple of 320 KiB", nameof(maxSliceSize));
             }
+        }
+
+        /// <summary>
+        /// Extract an <see cref="IUploadSession"/> from an <see cref="IParsable"/>
+        /// </summary>
+        /// <param name="uploadSession"><see cref="IParsable"/> to initiaze an <see cref="IUploadSession"/> from</param>
+        /// <returns>A <see cref="IUploadSession"/> instance</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        private IUploadSession ExtractSessionFromParsable(IParsable uploadSession)
+        {
+            if (!uploadSession.GetFieldDeserializers<IParsable>().ContainsKey("expirationDateTime"))
+                throw new ArgumentException("The Parsable does not contain the 'expirationDateTime' property");
+            if (!uploadSession.GetFieldDeserializers<IParsable>().ContainsKey("nextExpectedRanges"))
+                throw new ArgumentException("The Parsable does not contain the 'nextExpectedRanges' property");
+            if (!uploadSession.GetFieldDeserializers<IParsable>().ContainsKey("uploadUrl"))
+                throw new ArgumentException("The Parsable does not contain the 'uploadUrl' property");
+
+            var uploadSessionType = uploadSession.GetType();
+
+            return new UploadSession() 
+            {
+                ExpirationDateTime = uploadSessionType.GetProperty("ExpirationDateTime").GetValue(uploadSession, null) as DateTimeOffset?,
+                NextExpectedRanges = uploadSessionType.GetProperty("NextExpectedRanges").GetValue(uploadSession, null) as IEnumerable<string>,
+                UploadUrl = uploadSessionType.GetProperty("UploadUrl").GetValue(uploadSession, null) as string
+            };
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels;
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using Microsoft.Kiota.Abstractions;
+    using Microsoft.Kiota.Serialization.Json;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -527,12 +528,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
                 UploadUrl = "http://localhost",
                 NextExpectedRanges = new List<string> { "0 - 1000" }
             };
+            using var jsonSerializerWriter = new JsonSerializationWriter();
             var expectedString = @"{""expirationDateTime"":""2016-11-20T18:23:45.9356913+00:00"",""nextExpectedRanges"":[""0 - 1000""],""uploadUrl"":""http://localhost""}";
             // Act
-            var serializedString = this.serializer.SerializeObject(uploadSession);
+            jsonSerializerWriter.WriteObjectValue(string.Empty, uploadSession);
             // Assert
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
             // Expect the string to be ISO 8601-1:2019 format
-            Assert.Equal(expectedString, serializedString);
+            Assert.Equal(expectedString, serializedJsonString);
         }
 
         [Fact]


### PR DESCRIPTION
This PR refactors the LargeFileUploadTask to be work with the kiota core libraries in conjuction with refactoring made in previous PRs. 

Changes include
- Refactoring the  LargeFileUploadTask constructor to take an IParsable that is verified to be an uploadSession
- Refactoring relevant models
- Refactoring tests

**Notes**
- There is an open issue with regards to creating an uploadSession with the generated request builders [here](https://github.com/microsoft/kiota/issues/990). 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/350)