### PR TITLE
Odata query handler

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Graph
         public static IList<DelegatingHandler> CreateDefaultHandlers()
         {
             return new List<DelegatingHandler> {
+                new OdataQueryHandler(),
                 new CompressionHandler(),
                 new RetryHandler(),
                 new RedirectHandler()

--- a/src/Microsoft.Graph.Core/Requests/Middleware/OdataQueryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/OdataQueryHandler.cs
@@ -1,0 +1,61 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
+    using System;
+    using System.Net.Http;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation that handles compression.
+    /// </summary>
+    public class OdataQueryHandler : DelegatingHandler
+    {
+        private readonly ODataQueryHandlerOption odataQueryHandlerOption;
+        private readonly Regex odataQueryRegex = new Regex("(?i)([^$])(count|deltatoken|expand|filter|format|orderby|search|select|skip|skiptoken|top)=",RegexOptions.Compiled);
+
+        /// <summary>
+        /// The <see cref="OdataQueryHandler"/> constructor
+        /// </summary>
+        /// <param name="handlerOption">The <see cref="ODataQueryHandlerOption"/> to use</param>
+        public OdataQueryHandler(ODataQueryHandlerOption handlerOption = null) 
+        {
+            this.odataQueryHandlerOption = handlerOption ?? new ODataQueryHandlerOption();
+        }
+
+        /// <summary>
+        /// Sends a HTTP request.
+        /// </summary>
+        /// <param name="httpRequest">The <see cref="HttpRequestMessage"/> to be sent.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        {
+            if (httpRequest == null)
+                throw new ArgumentNullException(nameof(httpRequest));
+
+            // Check if the request has a preconfigured option otherwise use the one provided in this instance
+            var odataQueryOption = httpRequest.GetRequestOption<ODataQueryHandlerOption>() ?? odataQueryHandlerOption;
+            // If the request is replacable, just do it
+            if (odataQueryOption.ShouldReplace(httpRequest))
+            {
+                var queryString = string.Empty;
+                if (httpRequest.RequestUri.Query != null && httpRequest.RequestUri.Query.Length > 1)
+                    // We insert and remove the ? sign so we can make no dollar mandatory and avoid adding a second dollar when already here
+                    queryString = odataQueryRegex.Replace("?" + httpRequest.RequestUri.Query, "$1$$$2=")[1..];
+
+                // replace the uri with the new query options
+                httpRequest.RequestUri = new UriBuilder(httpRequest.RequestUri) { Query = queryString }.Uri;
+            }
+
+            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken);
+
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Middleware/OdataQueryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/OdataQueryHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Graph
     public class OdataQueryHandler : DelegatingHandler
     {
         private readonly ODataQueryHandlerOption odataQueryHandlerOption;
-        private readonly Regex odataQueryRegex = new Regex("(?i)([^$])(count|deltatoken|expand|filter|format|orderby|search|select|skip|skiptoken|top)=",RegexOptions.Compiled);
+        private readonly Regex odataQueryRegex = new Regex("([^$])(count|deltatoken|expand|filter|format|orderby|search|select|skip|skiptoken|top)=",RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// The <see cref="OdataQueryHandler"/> constructor
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <param name="httpRequest">The <see cref="HttpRequestMessage"/> to be sent.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns></returns>
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequest, CancellationToken cancellationToken)
         {
             if (httpRequest == null)
                 throw new ArgumentNullException(nameof(httpRequest));
@@ -53,9 +53,7 @@ namespace Microsoft.Graph
                 httpRequest.RequestUri = new UriBuilder(httpRequest.RequestUri) { Query = queryString }.Uri;
             }
 
-            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken);
-
-            return response;
+            return base.SendAsync(httpRequest, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/Options/ODataQueryHandlerOption.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/Options/ODataQueryHandlerOption.cs
@@ -1,0 +1,20 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Kiota.Abstractions;
+    using System;
+    using System.Net.Http;
+
+    public class ODataQueryHandlerOption : IRequestOption
+    {
+        /// <summary>
+        /// Function to determine whether a request should be modified. Defaults to returning true.
+        /// </summary>
+        public Func<HttpRequestMessage, bool> ShouldReplace { get; set; } = (requestMessage) => true;
+    }
+}
+
+

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -68,40 +68,44 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void Should_CreatePipeline_Without_HttpMessageHandlerInput()
         {
-            using (CompressionHandler compressionHandler = (CompressionHandler)GraphClientFactory.CreatePipeline(handlers))
-            using (RetryHandler retryHandler = (RetryHandler)compressionHandler.InnerHandler)
-            using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
-            using (HttpMessageHandler innerMost = redirectHandler.InnerHandler)
-            {
-                Assert.NotNull(compressionHandler);
-                Assert.NotNull(retryHandler);
-                Assert.NotNull(redirectHandler);
-                Assert.NotNull(innerMost);
-                Assert.IsType<CompressionHandler>(compressionHandler);
-                Assert.IsType<RetryHandler>(retryHandler);
-                Assert.IsType<RedirectHandler>(redirectHandler);
-                Assert.True(innerMost is HttpMessageHandler);
-            }
+            using OdataQueryHandler odataQueryHandler = (OdataQueryHandler)GraphClientFactory.CreatePipeline(handlers);
+            using CompressionHandler compressionHandler = (CompressionHandler)odataQueryHandler.InnerHandler;
+            using RetryHandler retryHandler = (RetryHandler)compressionHandler.InnerHandler;
+            using RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler;
+            using HttpMessageHandler innerMost = redirectHandler.InnerHandler;
+
+            Assert.NotNull(odataQueryHandler);
+            Assert.NotNull(compressionHandler);
+            Assert.NotNull(retryHandler);
+            Assert.NotNull(redirectHandler);
+            Assert.NotNull(innerMost);
+            Assert.IsType<OdataQueryHandler>(odataQueryHandler);
+            Assert.IsType<CompressionHandler>(compressionHandler);
+            Assert.IsType<RetryHandler>(retryHandler);
+            Assert.IsType<RedirectHandler>(redirectHandler);
+            Assert.True(innerMost is HttpMessageHandler);
         }
 #endif
 
         [Fact]
         public void CreatePipelineWithHttpMessageHandlerInput()
         {
-            using (CompressionHandler compressionHandler = (CompressionHandler)GraphClientFactory.CreatePipeline(handlers, new MockRedirectHandler()))
-            using (RetryHandler retryHandler = (RetryHandler)compressionHandler.InnerHandler)
-            using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
-            using (MockRedirectHandler innerMost = (MockRedirectHandler)redirectHandler.InnerHandler)
-            {
-                Assert.NotNull(compressionHandler);
-                Assert.NotNull(retryHandler);
-                Assert.NotNull(redirectHandler);
-                Assert.NotNull(innerMost);
-                Assert.IsType<CompressionHandler>(compressionHandler);
-                Assert.IsType<RetryHandler>(retryHandler);
-                Assert.IsType<RedirectHandler>(redirectHandler);
-                Assert.IsType<MockRedirectHandler>(innerMost);
-            }
+            using OdataQueryHandler odataQueryHandler = (OdataQueryHandler)GraphClientFactory.CreatePipeline(handlers, new MockRedirectHandler());
+            using CompressionHandler compressionHandler = (CompressionHandler)odataQueryHandler.InnerHandler;
+            using RetryHandler retryHandler = (RetryHandler)compressionHandler.InnerHandler;
+            using RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler;
+            using MockRedirectHandler innerMost = (MockRedirectHandler)redirectHandler.InnerHandler;
+            
+            Assert.NotNull(odataQueryHandler);
+            Assert.NotNull(compressionHandler);
+            Assert.NotNull(retryHandler);
+            Assert.NotNull(redirectHandler);
+            Assert.NotNull(innerMost);
+            Assert.IsType<OdataQueryHandler>(odataQueryHandler);
+            Assert.IsType<CompressionHandler>(compressionHandler);
+            Assert.IsType<RetryHandler>(retryHandler);
+            Assert.IsType<RedirectHandler>(redirectHandler);
+            Assert.IsType<MockRedirectHandler>(innerMost);
         }
 
         [Fact]
@@ -291,7 +295,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         {
             FeatureFlag expectedFlag = FeatureFlag.CompressionHandler | FeatureFlag.RetryHandler;
             var handlers = GraphClientFactory.CreateDefaultHandlers();
-            handlers.RemoveAt(2);
+            //Exclude the redirect handler for this test
+            handlers = handlers.Where(handler => !handler.GetType().Equals(typeof(RedirectHandler))).ToList();
             var pipelineWithHandlers = GraphClientFactory.CreatePipelineWithFeatureFlags(handlers);
 
             Assert.NotNull(pipelineWithHandlers.Pipeline);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/OdataQueryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/OdataQueryHandlerTests.cs
@@ -1,0 +1,106 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Middleware
+{
+    using Microsoft.Kiota.Abstractions;
+    using Microsoft.Kiota.Abstractions.Authentication;
+    using Microsoft.Kiota.Http.HttpClientLibrary;
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class OdataQueryHandlerTests
+    {
+        private readonly HttpMessageInvoker _invoker;
+        private readonly HttpClientRequestAdapter requestAdapter;
+
+        public OdataQueryHandlerTests()
+        {
+            var odataQueryHandler = new OdataQueryHandler
+            {
+                InnerHandler = new FakeSuccessHandler()
+            };
+            this._invoker = new HttpMessageInvoker(odataQueryHandler);
+            requestAdapter = new HttpClientRequestAdapter(new AnonymousAuthenticationProvider());
+        }
+
+        [Fact]
+        public async Task ItReplacesOdataQueryParametersByDefaultAsync()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                URI = new Uri("http://localhost?Select=something&exPand=somethingElse(select=nested)&$top=10")
+            };
+
+            // Act and get a request message
+            var requestMessage = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
+            Assert.Empty(requestMessage.Headers);
+
+            // Act
+            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+
+            var queryString = response.RequestMessage.RequestUri.Query;
+
+            // Assert the request was enriched as expected
+            Assert.Contains("$Select=something", queryString);
+            Assert.Contains("$exPand=somethingElse", queryString);
+            Assert.Contains("$select=nested", queryString);
+            Assert.Contains("&$top=10", queryString); // No doulble $ for already existing ones
+        }
+
+        [Fact]
+        public async Task ItDoesNotReplaceOdataQueryParametersUsingConsfigurator()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                URI = new Uri("http://localhost?Select=something&exPand=somethingElse(select=nested)&$top=10")
+            };
+            var requestOption = new ODataQueryHandlerOption
+            {
+                ShouldReplace = (request) => false // do not change the query options
+            };
+
+
+            // Act and get a request message
+            requestInfo.AddRequestOptions(requestOption);
+            var requestMessage = requestAdapter.GetRequestMessageFromRequestInformation(requestInfo);
+            Assert.Empty(requestMessage.Headers);
+
+            // Act
+            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+
+            var queryString = response.RequestMessage.RequestUri.Query;
+
+            // Assert the request was enriched as expected
+            Assert.Contains("Select=something", queryString);
+            Assert.DoesNotContain("$Select=something", queryString);
+            Assert.Contains("exPand=somethingElse", queryString);
+            Assert.DoesNotContain("$exPand=somethingElse", queryString);
+            Assert.Contains("select=nested", queryString);
+            Assert.DoesNotContain("$select=nested", queryString);
+            Assert.Contains("&$top=10", queryString); // No doulble $ for already existing ones
+        }
+    }
+
+    internal class FakeSuccessHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                RequestMessage = request
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an OData query handler to the middleware pipeline as the generated query parameters from Kiota lack the `$` sign when requests are sent out.

As much as this should not be a problem in OData 4.0 which no longer requires the `$` prefix some workloads on graph still do not support this and this middleware alleviates the errors that may arise from a missing `$` prefix by reinserting based on whether the query parameter is an OData query parameter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/356)