### PR TITLE
Always ConfiguteAwait false on awaited tasks

### DIFF
--- a/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
+++ b/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
@@ -62,19 +62,19 @@ namespace Microsoft.Graph
             try
             {
                 // Try to get the account from the cache
-                IEnumerable<IAccount> accounts = await _clientApplication.GetAccountsAsync();
+                IEnumerable<IAccount> accounts = await _clientApplication.GetAccountsAsync().ConfigureAwait(false);
                 IAccount account = accounts.FirstOrDefault();
 
                 // Try to get the token silently
                 AcquireTokenSilentParameterBuilder tokenSilentBuilder =
                     _clientApplication.AcquireTokenSilent(requestContext.Scopes, account);
 
-                result = await tokenSilentBuilder.ExecuteAsync(cancellationToken);
+                result = await tokenSilentBuilder.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (MsalException)
             {
                 // We can't get the token silently so get a new one
-                result = await GetNewAccessTokenAsync(requestContext);
+                result = await GetNewAccessTokenAsync(requestContext).ConfigureAwait(false);
             }
 
             return new AccessToken(result.AccessToken, result.ExpiresOn);
@@ -94,7 +94,7 @@ namespace Microsoft.Graph
                 try
                 {
                     authenticationResult = await _clientApplication.AcquireTokenByIntegratedWindowsAuth(requestContext.Scopes)
-                                .ExecuteAsync();
+                                .ExecuteAsync().ConfigureAwait(false);
                     break;
                 }
                 catch (MsalServiceException serviceException)
@@ -105,7 +105,7 @@ namespace Microsoft.Graph
                         TimeSpan delay = this.GetRetryAfter(serviceException);
                         retryCount++;
                         // pause execution
-                        await Task.Delay(delay);
+                        await Task.Delay(delay).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
                         t.Result.Seek(0, SeekOrigin.Begin);
 
                     newRequest.Content = new StreamContent(t.Result);
-                });
+                }).ConfigureAwait(false);
 
                 // Copy content headers.
                 if (originalRequest.Content.Headers != null)

--- a/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Graph
             if (certificateProvider == null)
                 throw new ArgumentNullException(nameof(certificateProvider));
 
-            return JsonSerializer.Deserialize<T>(await encryptedContent.DecryptAsync(certificateProvider));
+            return JsonSerializer.Deserialize<T>(await encryptedContent.DecryptAsync(certificateProvider).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.Graph
             if (certificateProvider == null)
                 throw new ArgumentNullException(nameof(certificateProvider));
 
-            using var certificate = await certificateProvider(encryptedContent.EncryptionCertificateId, encryptedContent.EncryptionCertificateThumbprint);
+            using var certificate = await certificateProvider(encryptedContent.EncryptionCertificateId, encryptedContent.EncryptionCertificateThumbprint).ConfigureAwait(false);
             using var rsaPrivateKey = certificate.GetRSAPrivateKey();
             var decryptedSymmetricKey = rsaPrivateKey.Decrypt(Convert.FromBase64String(encryptedContent.DataKey), RSAEncryptionPadding.OaepSHA1);
             using var hashAlg = new HMACSHA256(decryptedSymmetricKey);

--- a/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
+++ b/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(appIds));
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(wellKnownUri, new OpenIdConnectConfigurationRetriever());
-            var openIdConfig = await configurationManager.GetConfigurationAsync();
+            var openIdConfig = await configurationManager.GetConfigurationAsync().ConfigureAwait(false);
             var handler = new JwtSecurityTokenHandler();
             var issuersToValidate = tenantIds.Select(x => $"{issuerPrefix}{x}/");
             var appIdsToValidate = appIds.Select(x => x.ToString());

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendRequestAsync(serializableObject, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
         
@@ -152,7 +152,7 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendMultiPartRequestAsync(multipartContent, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
 
@@ -416,7 +416,7 @@ namespace Microsoft.Graph
                     });
             }
 
-            await Client.AuthenticationProvider.AuthenticateRequestAsync(request);
+            await Client.AuthenticationProvider.AuthenticateRequestAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -192,12 +192,12 @@ namespace Microsoft.Graph
                 writer.WriteStartArray();
                 foreach (KeyValuePair<string, BatchRequestStep> batchRequestStep in BatchRequestSteps)
                 {
-                    await WriteBatchRequestStepAsync(batchRequestStep.Value, writer);
+                    await WriteBatchRequestStepAsync(batchRequestStep.Value, writer).ConfigureAwait(false);
                 }
                 writer.WriteEndArray();
 
                 writer.WriteEndObject();//close the root object
-                await writer.FlushAsync();
+                await writer.FlushAsync().ConfigureAwait(false);
 
                 //Reset the position since we want the caller to use this stream
                 stream.Position = 0;
@@ -263,7 +263,7 @@ namespace Microsoft.Graph
             if (batchRequestStep.Request != null && batchRequestStep.Request.Content != null)
             {
                 writer.WritePropertyName(CoreConstants.BatchRequest.Body);
-                using (JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request))
+                using (JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request).ConfigureAwait(false))
                 {
                     content.WriteTo(writer);
                 }
@@ -275,8 +275,8 @@ namespace Microsoft.Graph
         {
             try
             {
-                HttpRequestMessage clonedRequest = await request.CloneAsync();
-                using (Stream streamContent = await clonedRequest.Content.ReadAsStreamAsync())
+                HttpRequestMessage clonedRequest = await request.CloneAsync().ConfigureAwait(false);
+                using (Stream streamContent = await clonedRequest.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     return JsonDocument.Parse(streamContent);
                 }
@@ -321,9 +321,9 @@ namespace Microsoft.Graph
         /// <returns></returns>
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            using (Stream batchContent = await GetBatchRequestContentAsync())
+            using (Stream batchContent = await GetBatchRequestContentAsync().ConfigureAwait(false))
             {
-                await batchContent.CopyToAsync(stream);
+                await batchContent.CopyToAsync(stream).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Graph
         public async Task<Dictionary<string, HttpResponseMessage>> GetResponsesAsync()
         {
             Dictionary<string, HttpResponseMessage> responseMessages = new Dictionary<string, HttpResponseMessage>();
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return responseMessages;
 
@@ -76,7 +76,7 @@ namespace Microsoft.Graph
         /// <returns>A <see cref="HttpResponseMessage"/> response object for a batch request.</returns>
         public async Task<HttpResponseMessage> GetResponseByIdAsync(string requestId)
         {
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return null;
 
@@ -101,11 +101,11 @@ namespace Microsoft.Graph
         /// <returns>A deserialized object of type T<see cref="HttpResponseMessage"/>.</returns>
         public async Task<T> GetResponseByIdAsync<T>(string requestId)
         {
-            using (var httpResponseMessage = await GetResponseByIdAsync(requestId))
+            using (var httpResponseMessage = await GetResponseByIdAsync(requestId).ConfigureAwait(false))
             {
-                await ValidateSuccessfulResponse(httpResponseMessage);
+                await ValidateSuccessfulResponse(httpResponseMessage).ConfigureAwait(false);
                 // return the deserialized object
-                return await ResponseHandler.HandleResponse<T>(httpResponseMessage);
+                return await ResponseHandler.HandleResponse<T>(httpResponseMessage).ConfigureAwait(false);
             }
         }
 
@@ -117,12 +117,12 @@ namespace Microsoft.Graph
         /// <remarks> Stream should be dispose once done with.</remarks>
         public async Task<Stream> GetResponseStreamByIdAsync(string requestId)
         {
-            using (var httpResponseMessage = await GetResponseByIdAsync(requestId)) 
+            using (var httpResponseMessage = await GetResponseByIdAsync(requestId).ConfigureAwait(false)) 
             {
-                await ValidateSuccessfulResponse(httpResponseMessage);
-                using var stream = await httpResponseMessage.Content.ReadAsStreamAsync();
+                await ValidateSuccessfulResponse(httpResponseMessage).ConfigureAwait(false);
+                using var stream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memoryStream = new MemoryStream();
-                await stream.CopyToAsync(memoryStream);
+                await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
                 return memoryStream;
             }
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Graph
                 string rawResponseBody = null;
 
                 //deserialize into an ErrorResponse as the result is not a success.
-                ErrorResponse errorResponse = await ResponseHandler.HandleResponse<ErrorResponse>(httpResponseMessage);
+                ErrorResponse errorResponse = await ResponseHandler.HandleResponse<ErrorResponse>(httpResponseMessage).ConfigureAwait(false);
 
                 if (errorResponse?.Error == null)
                 {
@@ -177,7 +177,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public async Task<string> GetNextLinkAsync()
         {
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return null;
 
@@ -229,9 +229,9 @@ namespace Microsoft.Graph
 
             try
             {
-                using (Stream streamContent = await this.batchResponseMessage.Content.ReadAsStreamAsync())
+                using (Stream streamContent = await this.batchResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
-                    return await JsonDocument.ParseAsync(streamContent);
+                    return await JsonDocument.ParseAsync(streamContent).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Graph
             {
                 // Gets the response string with response headers and status code
                 // set on the response body object.
-                var responseString = await GetResponseString(response);
+                var responseString = await GetResponseString(response).ConfigureAwait(false);
 
                 // Get the response body object with the change list 
                 // set on each response item.
-                var responseWithChangelist = await GetResponseBodyWithChangelist(responseString);
+                var responseWithChangelist = await GetResponseBodyWithChangelist(responseString).ConfigureAwait(false);
 
                 return this.serializer.DeserializeObject<T>(responseWithChangelist);
             }
@@ -106,7 +106,7 @@ namespace Microsoft.Graph
 
                 foreach (var deltaObject in pageOfDeltaObjects.EnumerateArray())
                 {
-                    var updatedObjectJsonDocument = await DiscoverChangedProperties(deltaObject);
+                    var updatedObjectJsonDocument = await DiscoverChangedProperties(deltaObject).ConfigureAwait(false);
                     updatedObjectsWithChangeList.Add(updatedObjectJsonDocument.RootElement);
                 }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Graph
             var changes = new List<string>();
 
             // Get the list of changed properties on the item.
-            await GetObjectProperties(responseItem, changes);
+            await GetObjectProperties(responseItem, changes).ConfigureAwait(false);
 
             // Add the changes object to the response item.
             var response = AddOrReplacePropertyToObject(responseItem, "changes", changes);
@@ -159,7 +159,7 @@ namespace Microsoft.Graph
                     case JsonValueKind.Object:
                     {
                         string parent = parentName + property.Name;
-                        await GetObjectProperties(property.Value, changes, parent);
+                        await GetObjectProperties(property.Value, changes, parent).ConfigureAwait(false);
                         break;
                     }
                     case JsonValueKind.Array:
@@ -182,7 +182,7 @@ namespace Microsoft.Graph
 
                             if (arrayItem.ValueKind == JsonValueKind.Object)
                             {
-                                await GetObjectProperties(arrayItem, changes, parentWithIndex);
+                                await GetObjectProperties(arrayItem, changes, parentWithIndex).ConfigureAwait(false);
                             }
                             else // Assuming that this is a Value item.
                             {

--- a/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Graph
         /// </summary>
         public async Task<T> GetResponseObjectAsync()
         {
-            return await this.BaseRequest.ResponseHandler.HandleResponse<T>(this.ToHttpResponseMessage());
+            return await this.BaseRequest.ResponseHandler.HandleResponse<T>(this.ToHttpResponseMessage()).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
             while (retryAttempt < MaxRetry)
             {
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
+                var newRequest = await httpResponseMessage.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                 // extract the www-authenticate header and add claims to the request context
                 if (httpResponseMessage.Headers.WwwAuthenticate.Any())
@@ -89,8 +89,8 @@ namespace Microsoft.Graph
                 }
 
                 // Authenticate request using AuthenticationProvider
-                await authProvider.AuthenticateRequestAsync(newRequest);
-                httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
+                await authProvider.AuthenticateRequestAsync(newRequest).ConfigureAwait(false);
+                httpResponseMessage = await base.SendAsync(newRequest, cancellationToken).ConfigureAwait(false);
 
                 retryAttempt++;
 
@@ -121,15 +121,15 @@ namespace Microsoft.Graph
             // Authenticate request using AuthenticationProvider
             if (authProvider != null)
             {
-                await authProvider.AuthenticateRequestAsync(httpRequestMessage);
+                await authProvider.AuthenticateRequestAsync(httpRequestMessage).ConfigureAwait(false);
 
-                HttpResponseMessage response = await base.SendAsync(httpRequestMessage, cancellationToken);
+                HttpResponseMessage response = await base.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 
                 // Check if response is a 401 & is not a streamed body (is buffered)
                 if (IsUnauthorized(response) && httpRequestMessage.IsBuffered())
                 {
                     // re-issue the request to get a new access token
-                    response = await SendRetryAsync(response, authProvider, cancellationToken);
+                    response = await SendRetryAsync(response, authProvider, cancellationToken).ConfigureAwait(false);
                 }
 
                 return response;
@@ -138,7 +138,7 @@ namespace Microsoft.Graph
             {
                 // NOTE: In order to support HttpProvider, we'll skip authentication if no provider is set.
                 // We will add this check once we re-write a new HttpProvider.
-                return await base.SendAsync(httpRequestMessage, cancellationToken);
+                return await base.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Graph
 
             if (response == null)
             {
-                response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             return response;
         }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Graph
                 httpRequest.Headers.AcceptEncoding.Add(gzipQHeaderValue);
             }
 
-            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken);
+            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             // Decompress response content when Content-Encoding: gzip header is present.
             if (ShouldDecompressContent(response))
             {
-                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), CompressionMode.Decompress));
                 // Copy Content Headers to the destination stream content
                 foreach (var httpContentHeader in response.Content.Headers)
                 {

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Graph
             RedirectOption = request.GetMiddlewareOption<RedirectHandlerOption>() ?? RedirectOption;
 
             // send request first time to get response
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // check response status code and redirect handler option
             if (IsRedirect(response.StatusCode) && RedirectOption.ShouldRedirect(response) && RedirectOption.MaxRedirect > 0)
@@ -75,11 +75,11 @@ namespace Microsoft.Graph
                     // Drain response content to free responses.
                     if (response.Content != null)
                     {
-                        await response.Content.ReadAsByteArrayAsync();
+                        await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                     }
 
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                    var newRequest = await response.RequestMessage.CloneAsync();
+                    var newRequest = await response.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                     // status code == 303: change request method from post to get and content to be null
                     if (response.StatusCode == HttpStatusCode.SeeOther)
@@ -109,7 +109,7 @@ namespace Microsoft.Graph
                     }
 
                     // Send redirect request to get reponse      
-                    response = await base.SendAsync(newRequest, cancellationToken);
+                    response = await base.SendAsync(newRequest, cancellationToken).ConfigureAwait(false);
 
                     // Check response status code
                     if (!IsRedirect(response.StatusCode))

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Graph
         {
             RetryOption = httpRequest.GetMiddlewareOption<RetryHandlerOption>() ?? RetryOption;
 
-            var response = await base.SendAsync(httpRequest, cancellationToken);
+            var response = await base.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             // Check whether retries are permitted and that the MaxRetry value is a non - negative, non - zero value
             if (httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && (ShouldRetry(response) || RetryOption.ShouldRetry(RetryOption.Delay, 0, response)))
             {
-                response = await SendRetryAsync(response, cancellationToken);
+                response = await SendRetryAsync(response, cancellationToken).ConfigureAwait(false);
             }
 
             return response;
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
                 // before retry attempt and before the TooManyRetries ServiceException.
                 if (response.Content != null)
                 {
-                    await response.Content.ReadAsByteArrayAsync();
+                    await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 }
 
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
@@ -104,17 +104,17 @@ namespace Microsoft.Graph
                 }
 
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                var request = await response.RequestMessage.CloneAsync();
+                var request = await response.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                 // Increase retryCount and then update Retry-Attempt in request header
                 retryCount++;
                 AddOrUpdateRetryAttempt(request, retryCount);
 
                 // Delay time
-                await delay;
+                await delay.ConfigureAwait(false);
 
                 // Call base.SendAsync to send the request
-                response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
                 if (!(request.IsBuffered() && (ShouldRetry(response) || RetryOption.ShouldRetry(RetryOption.Delay, retryCount, response))))
                 {
@@ -126,7 +126,7 @@ namespace Microsoft.Graph
             // before retry attempt and before the TooManyRetries ServiceException.
             if (response.Content != null)
             {
-                await response.Content.ReadAsByteArrayAsync();
+                await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
             
             throw new ServiceException (

--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         {
             if (response.Content != null)
             {
-                using (var responseStream = await response.Content.ReadAsStreamAsync())
+                using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     return serializer.DeserializeObject<T>(responseStream);
                 }

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Graph
 
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {
-                var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(response);
+                var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(response).ConfigureAwait(false);
                 return uploadResult.UploadSession;
             }
         }

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
             this.ContentType = CoreConstants.MimeTypeNames.Application.Stream;
             using (var response = await this.SendRequestAsync(stream, cancellationToken).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Graph
         /// a request.</exception>
         public async Task IterateAsync()
         {
-            await IterateAsync(new CancellationToken());
+            await IterateAsync(new CancellationToken()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Microsoft.Graph
             if (State == PagingState.Delta)
             {
                 // Make a call to get the next page of results and add items to queue. 
-                await InterpageIterateAsync(token);
+                await InterpageIterateAsync(token).ConfigureAwait(false);
             }
 
             // Iterate over the contents of queue. The queue could be from the initial page
@@ -205,7 +205,7 @@ namespace Microsoft.Graph
             while (shouldContinueInterpageIteration && !token.IsCancellationRequested)
             {
                 // Make a call to get the next page of results and add items to queue. 
-                await InterpageIterateAsync(token);
+                await InterpageIterateAsync(token).ConfigureAwait(false);
 
                 // Iterate over items added to the queue by InterpageIterateAsync and
                 // determine whether there are more pages to request.
@@ -221,7 +221,7 @@ namespace Microsoft.Graph
         /// is provided to the PageIterator</exception>
         public async Task ResumeAsync()
         {
-            await ResumeAsync(new CancellationToken());
+            await ResumeAsync(new CancellationToken()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Microsoft.Graph
         /// a request.</exception>
         public async Task ResumeAsync(CancellationToken token)
         {
-            await IterateAsync(token);
+            await IterateAsync(token).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
### Changes proposed in this pull request
Some awaited tasks included ConfigureAwait(false) but many did not. One of these continuations that was missing the ConfigureAwait(false) seemed to be causing deadlocks in our use of the Graph API (when acquiring a token). This pull request adds ConfigureAwait(false) to _all_ awaited tasks.

### Other links

https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/267
https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/188


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/363)