### PR TITLE
Release 2.0.8

### DIFF
--- a/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
+++ b/src/Microsoft.Graph.Core/Authentication/TokenCredentials/IntegratedWindowsTokenCredential.cs
@@ -62,19 +62,19 @@ namespace Microsoft.Graph
             try
             {
                 // Try to get the account from the cache
-                IEnumerable<IAccount> accounts = await _clientApplication.GetAccountsAsync();
+                IEnumerable<IAccount> accounts = await _clientApplication.GetAccountsAsync().ConfigureAwait(false);
                 IAccount account = accounts.FirstOrDefault();
 
                 // Try to get the token silently
                 AcquireTokenSilentParameterBuilder tokenSilentBuilder =
                     _clientApplication.AcquireTokenSilent(requestContext.Scopes, account);
 
-                result = await tokenSilentBuilder.ExecuteAsync(cancellationToken);
+                result = await tokenSilentBuilder.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (MsalException)
             {
                 // We can't get the token silently so get a new one
-                result = await GetNewAccessTokenAsync(requestContext);
+                result = await GetNewAccessTokenAsync(requestContext).ConfigureAwait(false);
             }
 
             return new AccessToken(result.AccessToken, result.ExpiresOn);
@@ -94,7 +94,7 @@ namespace Microsoft.Graph
                 try
                 {
                     authenticationResult = await _clientApplication.AcquireTokenByIntegratedWindowsAuth(requestContext.Scopes)
-                                .ExecuteAsync();
+                                .ExecuteAsync().ConfigureAwait(false);
                     break;
                 }
                 catch (MsalServiceException serviceException)
@@ -105,7 +105,7 @@ namespace Microsoft.Graph
                         TimeSpan delay = this.GetRetryAfter(serviceException);
                         retryCount++;
                         // pause execution
-                        await Task.Delay(delay);
+                        await Task.Delay(delay).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
                         t.Result.Seek(0, SeekOrigin.Begin);
 
                     newRequest.Content = new StreamContent(t.Result);
-                });
+                }).ConfigureAwait(false);
 
                 // Copy content headers.
                 if (originalRequest.Content.Headers != null)

--- a/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Graph
             if (certificateProvider == null)
                 throw new ArgumentNullException(nameof(certificateProvider));
 
-            return JsonSerializer.Deserialize<T>(await encryptedContent.DecryptAsync(certificateProvider));
+            return JsonSerializer.Deserialize<T>(await encryptedContent.DecryptAsync(certificateProvider).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.Graph
             if (certificateProvider == null)
                 throw new ArgumentNullException(nameof(certificateProvider));
 
-            using var certificate = await certificateProvider(encryptedContent.EncryptionCertificateId, encryptedContent.EncryptionCertificateThumbprint);
+            using var certificate = await certificateProvider(encryptedContent.EncryptionCertificateId, encryptedContent.EncryptionCertificateThumbprint).ConfigureAwait(false);
             using var rsaPrivateKey = certificate.GetRSAPrivateKey();
             var decryptedSymmetricKey = rsaPrivateKey.Decrypt(Convert.FromBase64String(encryptedContent.DataKey), RSAEncryptionPadding.OaepSHA1);
             using var hashAlg = new HMACSHA256(decryptedSymmetricKey);

--- a/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
+++ b/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(appIds));
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(wellKnownUri, new OpenIdConnectConfigurationRetriever());
-            var openIdConfig = await configurationManager.GetConfigurationAsync();
+            var openIdConfig = await configurationManager.GetConfigurationAsync().ConfigureAwait(false);
             var handler = new JwtSecurityTokenHandler();
             var issuersToValidate = tenantIds.Select(x => $"{issuerPrefix}{x}/");
             var appIdsToValidate = appIds.Select(x => x.ToString());

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -110,7 +110,7 @@
     <PackageReference Include="Azure.Core" Version="1.22.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Azure.Core" Version="1.20.0" />
+    <PackageReference Include="Azure.Core" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -106,7 +106,7 @@
   </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.6</VersionPrefix>
+    <VersionPrefix>2.0.7</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for paging when nextLink url contains encoded special url characters.
+- Fix for incorrect url building in .NetFramework environments
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -111,7 +111,7 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
     <PackageReference Include="Azure.Core" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.41.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
-    <PackageReference Include="Azure.Core" Version="1.21.0" />
+    <PackageReference Include="Azure.Core" Version="1.22.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.0" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -106,7 +106,7 @@
   </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -108,7 +108,7 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -108,7 +108,7 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.38.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -109,7 +109,7 @@
   </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
     <PackageReference Include="Azure.Core" Version="1.22.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.5</VersionPrefix>
+    <VersionPrefix>2.0.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for incorrect building of batch requests when the url contains the string 'beta'
+- Fix for paging when nextLink url contains encoded special url characters.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -111,6 +111,6 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -108,7 +108,7 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Azure.Core" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.38.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -110,7 +110,7 @@
     <PackageReference Include="Azure.Core" Version="1.21.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -27,6 +27,8 @@
 - Adds missing ConfigureAwait calls to resolve issues with blocking calls
 - Change default http request message version to http/2
 - Change default handler to WinHttpHandler for NetFramework clients to support http/2
+- Fix null reference exception on deserializing batch request items for non existent object
+- Fix for incorrect content type headers set for batch response content when the reponse type is not application/json
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,12 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.7</VersionPrefix>
+    <VersionPrefix>2.0.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fix for incorrect url building in .NetFramework environments
+- Adds missing ConfigureAwait calls to resolve issues with blocking calls
+- Change default http request message version to http/2
+- Change default handler to WinHttpHandler for NetFramework clients to support http/2
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -73,6 +75,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -111,6 +111,6 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendRequestAsync(serializableObject, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
         
@@ -152,7 +152,7 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendMultiPartRequestAsync(multipartContent, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
 
@@ -416,7 +416,7 @@ namespace Microsoft.Graph
                     });
             }
 
-            await Client.AuthenticationProvider.AuthenticateRequestAsync(request);
+            await Client.AuthenticationProvider.AuthenticateRequestAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -304,7 +304,10 @@ namespace Microsoft.Graph
         public HttpRequestMessage GetHttpRequestMessage(CancellationToken cancellationToken)
         {
             var queryString = this.BuildQueryString();
-            var request = new HttpRequestMessage(new HttpMethod(this.Method.ToString()), string.Concat(this.RequestUrl, queryString));
+            var request = new HttpRequestMessage(new HttpMethod(this.Method.ToString()), string.Concat(this.RequestUrl, queryString))
+            {
+                Version = new Version(2, 0) // default to Http/2. The http client should use the lower version in case of any issues.
+            };
             this.AddHeadersToRequest(request);
             this.AddRequestContextToRequest(request, cancellationToken);
             return request;

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -192,12 +192,12 @@ namespace Microsoft.Graph
                 writer.WriteStartArray();
                 foreach (KeyValuePair<string, BatchRequestStep> batchRequestStep in BatchRequestSteps)
                 {
-                    await WriteBatchRequestStepAsync(batchRequestStep.Value, writer);
+                    await WriteBatchRequestStepAsync(batchRequestStep.Value, writer).ConfigureAwait(false);
                 }
                 writer.WriteEndArray();
 
                 writer.WriteEndObject();//close the root object
-                await writer.FlushAsync();
+                await writer.FlushAsync().ConfigureAwait(false);
 
                 //Reset the position since we want the caller to use this stream
                 stream.Position = 0;
@@ -263,7 +263,7 @@ namespace Microsoft.Graph
             if (batchRequestStep.Request != null && batchRequestStep.Request.Content != null)
             {
                 writer.WritePropertyName(CoreConstants.BatchRequest.Body);
-                using (JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request))
+                using (JsonDocument content = await GetRequestContentAsync(batchRequestStep.Request).ConfigureAwait(false))
                 {
                     content.WriteTo(writer);
                 }
@@ -275,8 +275,8 @@ namespace Microsoft.Graph
         {
             try
             {
-                HttpRequestMessage clonedRequest = await request.CloneAsync();
-                using (Stream streamContent = await clonedRequest.Content.ReadAsStreamAsync())
+                HttpRequestMessage clonedRequest = await request.CloneAsync().ConfigureAwait(false);
+                using (Stream streamContent = await clonedRequest.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     return JsonDocument.Parse(streamContent);
                 }
@@ -321,9 +321,9 @@ namespace Microsoft.Graph
         /// <returns></returns>
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            using (Stream batchContent = await GetBatchRequestContentAsync())
+            using (Stream batchContent = await GetBatchRequestContentAsync().ConfigureAwait(false))
             {
-                await batchContent.CopyToAsync(stream);
+                await batchContent.CopyToAsync(stream).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Graph
         public async Task<Dictionary<string, HttpResponseMessage>> GetResponsesAsync()
         {
             Dictionary<string, HttpResponseMessage> responseMessages = new Dictionary<string, HttpResponseMessage>();
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return responseMessages;
 
@@ -76,7 +76,7 @@ namespace Microsoft.Graph
         /// <returns>A <see cref="HttpResponseMessage"/> response object for a batch request.</returns>
         public async Task<HttpResponseMessage> GetResponseByIdAsync(string requestId)
         {
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return null;
 
@@ -101,11 +101,11 @@ namespace Microsoft.Graph
         /// <returns>A deserialized object of type T<see cref="HttpResponseMessage"/>.</returns>
         public async Task<T> GetResponseByIdAsync<T>(string requestId)
         {
-            using (var httpResponseMessage = await GetResponseByIdAsync(requestId))
+            using (var httpResponseMessage = await GetResponseByIdAsync(requestId).ConfigureAwait(false))
             {
-                await ValidateSuccessfulResponse(httpResponseMessage);
+                await ValidateSuccessfulResponse(httpResponseMessage).ConfigureAwait(false);
                 // return the deserialized object
-                return await ResponseHandler.HandleResponse<T>(httpResponseMessage);
+                return await ResponseHandler.HandleResponse<T>(httpResponseMessage).ConfigureAwait(false);
             }
         }
 
@@ -117,12 +117,12 @@ namespace Microsoft.Graph
         /// <remarks> Stream should be dispose once done with.</remarks>
         public async Task<Stream> GetResponseStreamByIdAsync(string requestId)
         {
-            using (var httpResponseMessage = await GetResponseByIdAsync(requestId)) 
+            using (var httpResponseMessage = await GetResponseByIdAsync(requestId).ConfigureAwait(false)) 
             {
-                await ValidateSuccessfulResponse(httpResponseMessage);
-                using var stream = await httpResponseMessage.Content.ReadAsStreamAsync();
+                await ValidateSuccessfulResponse(httpResponseMessage).ConfigureAwait(false);
+                using var stream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 var memoryStream = new MemoryStream();
-                await stream.CopyToAsync(memoryStream);
+                await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
                 return memoryStream;
             }
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Graph
                 string rawResponseBody = null;
 
                 //deserialize into an ErrorResponse as the result is not a success.
-                ErrorResponse errorResponse = await ResponseHandler.HandleResponse<ErrorResponse>(httpResponseMessage);
+                ErrorResponse errorResponse = await ResponseHandler.HandleResponse<ErrorResponse>(httpResponseMessage).ConfigureAwait(false);
 
                 if (errorResponse?.Error == null)
                 {
@@ -177,7 +177,7 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public async Task<string> GetNextLinkAsync()
         {
-            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync();
+            jBatchResponseObject = jBatchResponseObject ?? await GetBatchResponseContentAsync().ConfigureAwait(false);
             if (jBatchResponseObject == null)
                 return null;
 
@@ -229,9 +229,9 @@ namespace Microsoft.Graph
 
             try
             {
-                using (Stream streamContent = await this.batchResponseMessage.Content.ReadAsStreamAsync())
+                using (Stream streamContent = await this.batchResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
-                    return await JsonDocument.ParseAsync(streamContent);
+                    return await JsonDocument.ParseAsync(streamContent).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Graph
             {
                 // Gets the response string with response headers and status code
                 // set on the response body object.
-                var responseString = await GetResponseString(response);
+                var responseString = await GetResponseString(response).ConfigureAwait(false);
 
                 // Get the response body object with the change list 
                 // set on each response item.
-                var responseWithChangelist = await GetResponseBodyWithChangelist(responseString);
+                var responseWithChangelist = await GetResponseBodyWithChangelist(responseString).ConfigureAwait(false);
 
                 return this.serializer.DeserializeObject<T>(responseWithChangelist);
             }
@@ -106,7 +106,7 @@ namespace Microsoft.Graph
 
                 foreach (var deltaObject in pageOfDeltaObjects.EnumerateArray())
                 {
-                    var updatedObjectJsonDocument = await DiscoverChangedProperties(deltaObject);
+                    var updatedObjectJsonDocument = await DiscoverChangedProperties(deltaObject).ConfigureAwait(false);
                     updatedObjectsWithChangeList.Add(updatedObjectJsonDocument.RootElement);
                 }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Graph
             var changes = new List<string>();
 
             // Get the list of changed properties on the item.
-            await GetObjectProperties(responseItem, changes);
+            await GetObjectProperties(responseItem, changes).ConfigureAwait(false);
 
             // Add the changes object to the response item.
             var response = AddOrReplacePropertyToObject(responseItem, "changes", changes);
@@ -159,7 +159,7 @@ namespace Microsoft.Graph
                     case JsonValueKind.Object:
                     {
                         string parent = parentName + property.Name;
-                        await GetObjectProperties(property.Value, changes, parent);
+                        await GetObjectProperties(property.Value, changes, parent).ConfigureAwait(false);
                         break;
                     }
                     case JsonValueKind.Array:
@@ -182,7 +182,7 @@ namespace Microsoft.Graph
 
                             if (arrayItem.ValueKind == JsonValueKind.Object)
                             {
-                                await GetObjectProperties(arrayItem, changes, parentWithIndex);
+                                await GetObjectProperties(arrayItem, changes, parentWithIndex).ConfigureAwait(false);
                             }
                             else // Assuming that this is a Value item.
                             {

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -230,6 +230,8 @@ namespace Microsoft.Graph
             return new Foundation.NSUrlSessionHandler { AllowAutoRedirect = false };
 #elif ANDROID
             return new Xamarin.Android.Net.AndroidClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
+#elif NETFRAMEWORK
+            return new WinHttpHandler() { Proxy = proxy, AutomaticRedirection = false, AutomaticDecompression = DecompressionMethods.None };
 #else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
 #endif

--- a/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Graph
         /// </summary>
         public async Task<T> GetResponseObjectAsync()
         {
-            return await this.BaseRequest.ResponseHandler.HandleResponse<T>(this.ToHttpResponseMessage());
+            return await this.BaseRequest.ResponseHandler.HandleResponse<T>(this.ToHttpResponseMessage()).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
             while (retryAttempt < MaxRetry)
             {
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
+                var newRequest = await httpResponseMessage.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                 // extract the www-authenticate header and add claims to the request context
                 if (httpResponseMessage.Headers.WwwAuthenticate.Any())
@@ -89,8 +89,8 @@ namespace Microsoft.Graph
                 }
 
                 // Authenticate request using AuthenticationProvider
-                await authProvider.AuthenticateRequestAsync(newRequest);
-                httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
+                await authProvider.AuthenticateRequestAsync(newRequest).ConfigureAwait(false);
+                httpResponseMessage = await base.SendAsync(newRequest, cancellationToken).ConfigureAwait(false);
 
                 retryAttempt++;
 
@@ -121,15 +121,15 @@ namespace Microsoft.Graph
             // Authenticate request using AuthenticationProvider
             if (authProvider != null)
             {
-                await authProvider.AuthenticateRequestAsync(httpRequestMessage);
+                await authProvider.AuthenticateRequestAsync(httpRequestMessage).ConfigureAwait(false);
 
-                HttpResponseMessage response = await base.SendAsync(httpRequestMessage, cancellationToken);
+                HttpResponseMessage response = await base.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 
                 // Check if response is a 401 & is not a streamed body (is buffered)
                 if (IsUnauthorized(response) && httpRequestMessage.IsBuffered())
                 {
                     // re-issue the request to get a new access token
-                    response = await SendRetryAsync(response, authProvider, cancellationToken);
+                    response = await SendRetryAsync(response, authProvider, cancellationToken).ConfigureAwait(false);
                 }
 
                 return response;
@@ -138,7 +138,7 @@ namespace Microsoft.Graph
             {
                 // NOTE: In order to support HttpProvider, we'll skip authentication if no provider is set.
                 // We will add this check once we re-write a new HttpProvider.
-                return await base.SendAsync(httpRequestMessage, cancellationToken);
+                return await base.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/ChaosHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Graph
 
             if (response == null)
             {
-                response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             return response;
         }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/CompressionHandler.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Graph
                 httpRequest.Headers.AcceptEncoding.Add(gzipQHeaderValue);
             }
 
-            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken);
+            HttpResponseMessage response = await base.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             // Decompress response content when Content-Encoding: gzip header is present.
             if (ShouldDecompressContent(response))
             {
-                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync(), CompressionMode.Decompress));
+                StreamContent streamContent = new StreamContent(new GZipStream(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), CompressionMode.Decompress));
                 // Copy Content Headers to the destination stream content
                 foreach (var httpContentHeader in response.Content.Headers)
                 {

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Graph
             RedirectOption = request.GetMiddlewareOption<RedirectHandlerOption>() ?? RedirectOption;
 
             // send request first time to get response
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // check response status code and redirect handler option
             if (IsRedirect(response.StatusCode) && RedirectOption.ShouldRedirect(response) && RedirectOption.MaxRedirect > 0)
@@ -75,11 +75,11 @@ namespace Microsoft.Graph
                     // Drain response content to free responses.
                     if (response.Content != null)
                     {
-                        await response.Content.ReadAsByteArrayAsync();
+                        await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                     }
 
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                    var newRequest = await response.RequestMessage.CloneAsync();
+                    var newRequest = await response.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                     // status code == 303: change request method from post to get and content to be null
                     if (response.StatusCode == HttpStatusCode.SeeOther)
@@ -109,7 +109,7 @@ namespace Microsoft.Graph
                     }
 
                     // Send redirect request to get reponse      
-                    response = await base.SendAsync(newRequest, cancellationToken);
+                    response = await base.SendAsync(newRequest, cancellationToken).ConfigureAwait(false);
 
                     // Check response status code
                     if (!IsRedirect(response.StatusCode))

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Graph
         {
             RetryOption = httpRequest.GetMiddlewareOption<RetryHandlerOption>() ?? RetryOption;
 
-            var response = await base.SendAsync(httpRequest, cancellationToken);
+            var response = await base.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
             // Check whether retries are permitted and that the MaxRetry value is a non - negative, non - zero value
             if (httpRequest.IsBuffered() && RetryOption.MaxRetry > 0 && (ShouldRetry(response) || RetryOption.ShouldRetry(RetryOption.Delay, 0, response)))
             {
-                response = await SendRetryAsync(response, cancellationToken);
+                response = await SendRetryAsync(response, cancellationToken).ConfigureAwait(false);
             }
 
             return response;
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
                 // before retry attempt and before the TooManyRetries ServiceException.
                 if (response.Content != null)
                 {
-                    await response.Content.ReadAsByteArrayAsync();
+                    await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 }
 
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
@@ -104,17 +104,17 @@ namespace Microsoft.Graph
                 }
 
                 // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
-                var request = await response.RequestMessage.CloneAsync();
+                var request = await response.RequestMessage.CloneAsync().ConfigureAwait(false);
 
                 // Increase retryCount and then update Retry-Attempt in request header
                 retryCount++;
                 AddOrUpdateRetryAttempt(request, retryCount);
 
                 // Delay time
-                await delay;
+                await delay.ConfigureAwait(false);
 
                 // Call base.SendAsync to send the request
-                response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
                 if (!(request.IsBuffered() && (ShouldRetry(response) || RetryOption.ShouldRetry(RetryOption.Delay, retryCount, response))))
                 {
@@ -126,7 +126,7 @@ namespace Microsoft.Graph
             // before retry attempt and before the TooManyRetries ServiceException.
             if (response.Content != null)
             {
-                await response.Content.ReadAsByteArrayAsync();
+                await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
             
             throw new ServiceException (

--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         {
             if (response.Content != null)
             {
-                using (var responseStream = await response.Content.ReadAsStreamAsync())
+                using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     return serializer.DeserializeObject<T>(responseStream);
                 }

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Graph
 
             using (var response = await this.SendRequestAsync(null, cancellationToken).ConfigureAwait(false))
             {
-                var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(response);
+                var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(response).ConfigureAwait(false);
                 return uploadResult.UploadSession;
             }
         }

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
             this.ContentType = CoreConstants.MimeTypeNames.Application.Stream;
             using (var response = await this.SendRequestAsync(stream, cancellationToken).ConfigureAwait(false))
             {
-                return await this.responseHandler.HandleResponse<T>(response);
+                return await this.responseHandler.HandleResponse<T>(response).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -37,7 +37,12 @@ namespace Microsoft.Graph
 
             var nextLinkUri = new Uri(reader.GetString());
             // Replace any '+' in the query as it signifies a space character the SDK does url encoding on the query parameter
-            return new UriBuilder(nextLinkUri) { Query = nextLinkUri.Query.Replace("+", "%20") }.ToString();
+            // Strip the ? character as .NetFramework may incorrectly build the url by adding a second '?' character
+            var queryString = string.Empty;
+            if (nextLinkUri.Query != null && nextLinkUri.Query.Length > 1)
+                queryString = nextLinkUri.Query.Replace("+", "%20").Substring(1);
+
+            return new UriBuilder(nextLinkUri) { Query = queryString }.ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/NextLinkConverter.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Graph
 {
     using System;
-    using System.Net;
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
@@ -30,13 +29,15 @@ namespace Microsoft.Graph
         /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
         /// <param name="typeToConvert">The object type.</param>
         /// <param name="options">The <see cref="JsonSerializerOptions"/> for conversion.</param>
-        /// <returns>A TimeOfDay object.</returns>
+        /// <returns>A nextLink string parsable by <see cref="BaseRequest"/>.</returns>
         public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (typeToConvert == null)
                 throw new ArgumentNullException(nameof(typeToConvert));
 
-            return WebUtility.UrlDecode(reader.GetString());
+            var nextLinkUri = new Uri(reader.GetString());
+            // Replace any '+' in the query as it signifies a space character the SDK does url encoding on the query parameter
+            return new UriBuilder(nextLinkUri) { Query = nextLinkUri.Query.Replace("+", "%20") }.ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Graph
         /// a request.</exception>
         public async Task IterateAsync()
         {
-            await IterateAsync(new CancellationToken());
+            await IterateAsync(new CancellationToken()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Microsoft.Graph
             if (State == PagingState.Delta)
             {
                 // Make a call to get the next page of results and add items to queue. 
-                await InterpageIterateAsync(token);
+                await InterpageIterateAsync(token).ConfigureAwait(false);
             }
 
             // Iterate over the contents of queue. The queue could be from the initial page
@@ -205,7 +205,7 @@ namespace Microsoft.Graph
             while (shouldContinueInterpageIteration && !token.IsCancellationRequested)
             {
                 // Make a call to get the next page of results and add items to queue. 
-                await InterpageIterateAsync(token);
+                await InterpageIterateAsync(token).ConfigureAwait(false);
 
                 // Iterate over items added to the queue by InterpageIterateAsync and
                 // determine whether there are more pages to request.
@@ -221,7 +221,7 @@ namespace Microsoft.Graph
         /// is provided to the PageIterator</exception>
         public async Task ResumeAsync()
         {
-            await ResumeAsync(new CancellationToken());
+            await ResumeAsync(new CancellationToken()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Microsoft.Graph
         /// a request.</exception>
         public async Task ResumeAsync(CancellationToken token)
         {
-            await IterateAsync(token);
+            await IterateAsync(token).ConfigureAwait(false);
         }
     }
 

--- a/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
+++ b/tests/Microsoft.Graph.Core.XamarinAndroid.Test/Microsoft.Graph.Core.XamarinAndroid.Test.csproj
@@ -102,7 +102,7 @@
       <Version>28.0.0.3</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.7.0</Version>
+      <Version>1.7.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.abstractions">
       <Version>2.0.3</Version>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -47,7 +47,7 @@
 	<PackageReference Include="System.Reflection.Emit" Version="4.7.0">
 	  <ExcludeAssets>all</ExcludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 	<PackageReference Include="Moq" Version="4.16.1" />
 	<PackageReference Include="xunit" Version="2.4.1" />
 	<ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchResponseContentTests.cs
@@ -111,7 +111,38 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                     + "\"status\":409,"
                     + "\"headers\" : {\"Cache-Control\":\"no-cache\"},"
                     + "\"body\":{\"error\": {\"code\": \"20117\",\"message\": \"An item with this name already exists in this location.\",\"innerError\":{\"request-id\": \"nothing1b13-45cd-new-92be873c5781\",\"date\": \"2019-03-22T23:17:50\"}}}"
-                +"}]}";
+                +"}," 
+                + "{" +
+                    "\"id\": \"3\"," +
+                    "\"status\": 200," +
+                    "\"headers\": {" +
+                        "\"Cache-Control\": \"private\"," +
+                        "\"Content-Type\": \"image/jpeg\"," +
+                        "\"ETag\": \"BEB9D79C\"" +
+                    "}," +
+                    "\"body\": \"iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZ" +
+                        "SBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77" +
+                        "u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM" +
+                        "6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0x" +
+                        "NDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyL" +
+                        "zIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodH" +
+                        "RwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXA" +
+                        "vMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJj" +
+                        "ZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc" +
+                        "3RhbmNlSUQ9InhtcC5paWQ6MEVBMTczNDg3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiIHhtcE1NOkRvY3VtZW" +
+                        "50SUQ9InhtcC5kaWQ6MEVBMTczNDk3QzA5MTFFNjk3ODM5NjQyRjE2RjA3QTkiPiA8eG1wTU06RGVyaXZlZEZ" +
+                        "yb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowRUExNzM0NjdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIg" +
+                        "c3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowRUExNzM0NzdDMDkxMUU2OTc4Mzk2NDJGMTZGMDdBOSIvPiA8L" +
+                        "3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PjjUms" +
+                        "sAAAGASURBVHjatJaxTsMwEIbpIzDA6FaMMPYJkDKzVYU+QFeEGPIKfYU8AETkCYI6wANkZQwIKRNDB1hA0Jr" +
+                        "f0rk6WXZ8BvWkb4kv99vn89kDrfVexBSYgVNwDA7AN+jAK3gEd+AlGMGIBFDgFvzouK3JV/lihQTOwLtOtw9w" +
+                        "IRG5pJn91Tbgqk9kSk7GViADrTD4HCyZ0NQnomi51sb0fUyCMQEbp2WpU67IjfNjwcYyoUDhjJVcZBjYBy40j" +
+                        "4wXgaobWoe8Z6Y80CJBwFpunepIzt2AUgFjtXXshNXjVmMh+K+zzp/CMs0CqeuzrxSRpbOKfdCkiMTS1VBQ41" +
+                        "uxMyQR2qbrXiiwYN3ACh1FDmsdK2Eu4J6Tlo31dYVtCY88h5ELZIJJ+IRMzBHfyJINrigNkt5VsRiub9nXICd" +
+                        "sYyVd2NcVvA3ScE5t2rb5JuEeyZnAhmLt9NK63vX1O5Pe8XaPSuGq1uTrfUgMEp9EJ+CQvr+BJ/AAKvAcCiAR" +
+                        "+bf9CjAAluzmdX4AEIIAAAAASUVORK5CYII=\"" +
+                    "}" +
+                "]}";
 
             HttpContent content = new StringContent(responseJSON);
             HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
@@ -124,6 +155,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
             Assert.True(response.Headers.CacheControl.NoCache);
+
+            // Read response object with different content type
+            HttpResponseMessage imageResponse = await batchResponseContent.GetResponseByIdAsync("3");
+
+            Assert.NotNull(imageResponse);
+            Assert.Equal(HttpStatusCode.OK, imageResponse.StatusCode);
+            Assert.Equal("image/jpeg", imageResponse.Content.Headers.ContentType.MediaType);
+
+            //try to get id that doesn't exist
+            var nonExistentMessage = await batchResponseContent.GetResponseByIdAsync("4");
+            Assert.Null(nonExistentMessage);
         }
 
         [Fact]
@@ -240,6 +282,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.Equal("20117", serviceException.Error.Code);
             Assert.Equal(HttpStatusCode.Conflict, serviceException.StatusCode);//status 409
             Assert.NotNull(serviceException.RawResponseBody);
+
+            // Act by trying to fetch notbook that doesn't exist
+            TestNoteBook nonExistentnotebook = await batchResponseContent.GetResponseByIdAsync<TestNoteBook>("7");
+            // Assert we have a valid notebook object
+            Assert.Null(nonExistentnotebook);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -707,8 +707,13 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
         ]
         [InlineData(
             "https://graph.microsoft.com/beta/deviceManagement/managedDevices?$filter=(deviceType+eq+%27android%27+or+deviceType+eq+%27androidEnterprise%27+or+deviceType+eq+%27androidForWork%27+or+deviceType+eq+%27iPad%27+or+deviceType+eq+%27iPhone%27)&$skiptoken=LastDeviceName%3d%27Andrew%25e2%2580%2599s%2520iPhone%27%2cLastDeviceId%3d%272dcc19dc-a2b9-434a-8013-ac85b69bece3%27", 
-            "filter", 
-            "(deviceType%20eq%20'android'%20or%20deviceType%20eq%20'androidEnterprise'%20or%20deviceType%20eq%20'androidForWork'%20or%20deviceType%20eq%20'iPad'%20or%20deviceType%20eq%20'iPhone')")
+            "filter",
+            "(deviceType%20eq%20%27android%27%20or%20deviceType%20eq%20%27androidEnterprise%27%20or%20deviceType%20eq%20%27androidForWork%27%20or%20deviceType%20eq%20%27iPad%27%20or%20deviceType%20eq%20%27iPhone%27)")
+        ]
+        [InlineData(
+            "https://graph.microsoft.com/v1.0/teams/c7a2f0a6-bb37-40f2-b908-2305650b03ce/channels/19:7yFDiTCIS1sYT-rZ46tTn8PfZFTafi7pyhe1ml0RmhI1@thread.tacv2/messages?$skiptoken=%5b%7B%22token%22%3a%22%2bRID%3a~vpsQAJ9uAC0sBo8AAAC8DQ%3d%3d%23RT%3a1%23TRC%3a20%23RTD%3aAyAER1ygxSHVHJBn2S99BTI6Ozh6R0VqVURKVDJ0WlUuc1s1NnVVbzlRZ1dHVWJnajhtemlmMm5tMVNuaUoyQXVpc2ZiZS91YmR3MzwyNzQ5Mzo6NjU2MzI2AA%3d%3d%23ISV%3a2%23IEO%3a65551%23QCF%3a4%23FPC%3aAgg8AgAA8DYAADwCAADwNgAAPAIAAPA2AAASAMODRQIAN2U3Km0DAMEVAQQkAA%3d%3d%22%2c%22range%22%3a%7B%22min%22%3a%2205C1DB7BBFBDC008323A3B67373962653567633866636235353A316362633A663537333667653333383762417569736662652F756264773300%22%2c%22max%22%3a%2205C1DB8525A774%22%7D%7D%5d",
+            "skiptoken",
+            "%5b%7B%22token%22%3a%22%2bRID%3a~vpsQAJ9uAC0sBo8AAAC8DQ%3d%3d%23RT%3a1%23TRC%3a20%23RTD%3aAyAER1ygxSHVHJBn2S99BTI6Ozh6R0VqVURKVDJ0WlUuc1s1NnVVbzlRZ1dHVWJnajhtemlmMm5tMVNuaUoyQXVpc2ZiZS91YmR3MzwyNzQ5Mzo6NjU2MzI2AA%3d%3d%23ISV%3a2%23IEO%3a65551%23QCF%3a4%23FPC%3aAgg8AgAA8DYAADwCAADwNgAAPAIAAPA2AAASAMODRQIAN2U3Km0DAMEVAQQkAA%3d%3d%22%2c%22range%22%3a%7B%22min%22%3a%2205C1DB7BBFBDC008323A3B67373962653567633866636235353A316362633A663537333667653333383762417569736662652F756264773300%22%2c%22max%22%3a%2205C1DB8525A774%22%7D%7D%5d")
         ]
         public void DeserializeNextLinkValues(string nextLink, string queryOptionKey, string expectedValue)
         {


### PR DESCRIPTION
This PR creates the 2.0.8 release

Changes include
- Fix for missing configureAwait in tasks via #363
- BatchContent fixes for incorrect headers and null reference exception via #369
- HTTP/2 support via #364 
- Dependabot updates via #352 , #354 , #358, #362, #365, #366 ,#370

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/371)