### PR TITLE
Configure dependabot for feature/3.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
+registries:
+  nuget-github:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/microsoft/index.json
+    username: ${{secrets.PUBLISH_GH_USERNAME}}
+    password: ${{secrets.PUBLISH_GH_TOKEN}}
 updates:
+- package-ecosystem: nuget
+  directory: "/"
+  registries:
+    - nuget-github
+  target-branch: feature/3.0
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
 - package-ecosystem: nuget
   directory: "/"
   schedule:


### PR DESCRIPTION
This Pr configures the feature/3.0 branch for automatic dependabot update from a private registry.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/375)