### PR TITLE
Fix pipeline after image update

### DIFF
--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -58,6 +58,11 @@ steps:
   inputs:
     command: 'restore'
 
+# windows-latest image removes this from windows 2022
+- pwsh: .\sdkmanager "platforms;android-26"
+  displayName: 'Install Xamarin dependencies'
+  workingDirectory: $(ANDROID_HOME)\tools\bin\
+
 - task: MSBuild@1
   displayName: 'Build solution to run unit test'
   inputs:


### PR DESCRIPTION
Following updates to the `windows-latest` vmImage, to window server 2022 as detailed [here](https://github.com/actions/virtual-environments/issues/4856), the breaking changes come with the side effect of some of the build depenedencies missing to build the repository.

This PR installs the missing dependency in order to unblock updates to the dev branch witnessed in #378 and #379 by installing the missing android SDK tools to meet the Xamarin dependencies in the build process.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/380)