### PR TITLE
Adds IBaseClient for extensibility

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,7 +22,7 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.4</VersionSuffix>
+    <VersionSuffix>preview.5</VersionSuffix>
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Graph
     public class AsyncMonitor<T> : IAsyncMonitor<T>
     {
         private AsyncOperationStatus asyncOperationStatus;
-        private BaseClient client;
+        private IBaseClient client;
 
         internal string monitorUrl;
 
@@ -28,7 +28,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="client">The client to monitor.</param>
         /// <param name="monitorUrl">The URL to monitor.</param>
-        public AsyncMonitor(BaseClient client, string monitorUrl)
+        public AsyncMonitor(IBaseClient client, string monitorUrl)
         {
             this.client = client;
             this.monitorUrl = monitorUrl;

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// A default client implementation.
     /// </summary>
-    public class BaseClient
+    public class BaseClient: IBaseClient
     {
         /// <summary>
         /// Constructs a new <see cref="BaseClient"/> for use by derived instances.
@@ -58,7 +58,7 @@ namespace Microsoft.Graph
             string baseUrl,
             TokenCredential tokenCredential,
             IEnumerable<string> scopes = null
-            ):this(baseUrl, new AzureIdentityAuthenticationProvider(tokenCredential, scopes?.ToArray() ?? Array.Empty<string>()))
+            ):this(baseUrl, new AzureIdentityAuthenticationProvider(tokenCredential, null,scopes?.ToArray() ?? Array.Empty<string>()))
         {
         }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the <see cref="IRequestAdapter"/> for sending requests.
         /// </summary>
-        protected internal virtual IRequestAdapter RequestAdapter { get; set; }
+        public IRequestAdapter RequestAdapter { get; set; }
 
         /// <summary>
         /// Gets the <see cref="BatchRequestBuilder"/> for building batch Requests

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -4,34 +4,21 @@
 
 namespace Microsoft.Graph
 {
-    using System;
     using System.Net.Http;
     using Microsoft.Graph.Core.Requests;
-    using System.Collections.Generic;
-    using Azure.Core;
     using Microsoft.Kiota.Abstractions.Authentication;
-    using Microsoft.Kiota.Authentication.Azure;
-    using System.Linq;
     using Microsoft.Kiota.Abstractions;
 
     /// <summary>
     /// A default client implementation.
     /// </summary>
-    public class BaseClient: IBaseClient
+    internal class BaseClient: IBaseClient
     {
-        /// <summary>
-        /// Constructs a new <see cref="BaseClient"/> for use by derived instances.
-        /// </summary>
-        protected BaseClient()
-        {
-        }
-
         /// <summary>
         /// Constructs a new <see cref="BaseClient"/>.
         /// </summary>
         /// <param name="requestAdapter">The custom <see cref="IRequestAdapter"/> to be used for making requests</param>
-        public BaseClient(
-            IRequestAdapter requestAdapter)
+        internal BaseClient(IRequestAdapter requestAdapter)
         {
             this.RequestAdapter = requestAdapter;
         }
@@ -41,7 +28,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
         /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.</param>
-        public BaseClient(
+        internal BaseClient(
             string baseUrl,
             IAuthenticationProvider authenticationProvider
             ): this(new BaseGraphRequestAdapter(authenticationProvider){ BaseUrl = baseUrl })
@@ -52,22 +39,8 @@ namespace Microsoft.Graph
         /// Constructs a new <see cref="BaseClient"/>.
         /// </summary>
         /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
-        /// <param name="tokenCredential">The <see cref="TokenCredential"/> for authenticating request messages.</param>
-        /// <param name="scopes">List of scopes for the authentication context.</param>
-        public BaseClient(
-            string baseUrl,
-            TokenCredential tokenCredential,
-            IEnumerable<string> scopes = null
-            ):this(baseUrl, new AzureIdentityAuthenticationProvider(tokenCredential, null,scopes?.ToArray() ?? Array.Empty<string>()))
-        {
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="BaseClient"/>.
-        /// </summary>
-        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
         /// <param name="httpClient">The customized <see cref="HttpClient"/> to be used for making requests</param>
-        public BaseClient(
+        internal BaseClient(
             string baseUrl,
             HttpClient httpClient):this(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient) { BaseUrl = baseUrl })
         {

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Graph
         /// <summary>
         /// Constructs a new <see cref="BatchRequestContent"/>.
         /// </summary>
-        /// <param name="baseClient">The <see cref="BaseClient"/> for making requests</param>
-        public BatchRequestContent(BaseClient baseClient)
+        /// <param name="baseClient">The <see cref="IBaseClient"/> for making requests</param>
+        public BatchRequestContent(IBaseClient baseClient)
             :this(baseClient, new BatchRequestStep[] { })
         {
         }
@@ -44,9 +44,9 @@ namespace Microsoft.Graph
         /// <summary>
         /// Constructs a new <see cref="BatchRequestContent"/>.
         /// </summary>
-        /// <param name="baseClient">The <see cref="BaseClient"/> for making requests</param>
+        /// <param name="baseClient">The <see cref="IBaseClient"/> for making requests</param>
         /// <param name="batchRequestSteps">A list of <see cref="BatchRequestStep"/> to add to the batch request content.</param>
-        public BatchRequestContent(BaseClient baseClient, params BatchRequestStep[] batchRequestSteps)
+        public BatchRequestContent(IBaseClient baseClient, params BatchRequestStep[] batchRequestSteps)
         {
             if (batchRequestSteps == null)
                 throw new ClientException(new Error

--- a/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using Microsoft.Graph.Core.Requests;
+    using Microsoft.Kiota.Abstractions;
+
+    /// <summary>
+    /// A default client interface.
+    /// </summary>
+    public interface IBaseClient
+    {
+        /// <summary>
+        /// Gets the <see cref="IRequestAdapter"/> for sending requests.
+        /// </summary>
+        IRequestAdapter RequestAdapter { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="BatchRequestBuilder"/> for building batch Requests
+        /// </summary>
+        public BatchRequestBuilder Batch
+        {
+            get
+            {
+                return new BatchRequestBuilder(this.RequestAdapter);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Graph
     /// <typeparam name="TCollectionPage">The Microsoft Graph collection response type returned in the collection response.</typeparam>
     public class PageIterator<TEntity, TCollectionPage> where TCollectionPage : IParsable,IAdditionalDataHolder,new()
     {
-        private BaseClient _client;
+        private IBaseClient _client;
         private TCollectionPage _currentPage;
         private Queue<TEntity> _pageItemQueue;
         private Func<TEntity, bool> _processPageItemCallback;
@@ -50,7 +50,7 @@ namespace Microsoft.Graph
         /// <param name="callback">A Func delegate that processes type TEntity in the result set and should return false if the iterator should cancel processing.</param>
         /// <param name="requestConfigurator">A Func delegate that configures the NextPageRequest</param>
         /// <returns>A PageIterator&lt;TEntity&gt; that will process additional result pages based on the rules specified in Func&lt;TEntity,bool&gt; processPageItems</returns>
-        public static PageIterator<TEntity, TCollectionPage> CreatePageIterator(BaseClient client, TCollectionPage page, Func<TEntity, bool> callback, Func<RequestInformation, RequestInformation> requestConfigurator = null)
+        public static PageIterator<TEntity, TCollectionPage> CreatePageIterator(IBaseClient client, TCollectionPage page, Func<TEntity, bool> callback, Func<RequestInformation, RequestInformation> requestConfigurator = null)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client));

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
@@ -26,17 +26,5 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             Assert.Equal(expectedBaseUrl, baseClient.RequestAdapter.BaseUrl);
         }
-
-        [Fact]
-        public void BaseClient_InitializeWithTokenCredential()
-        {
-            var expectedBaseUrl = "https://localhost";
-
-            var baseClient = new BaseClient(expectedBaseUrl, this.tokenCredential.Object);
-
-            Assert.Equal(expectedBaseUrl, baseClient.RequestAdapter.BaseUrl);
-            Assert.IsType<BaseGraphRequestAdapter>(baseClient.RequestAdapter);
-
-        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task BatchRequestBuilderAsync()
         {
             // Arrange
-            BaseClient baseClient = new BaseClient("https://localhost", GraphClientFactory.Create());
+            IBaseClient baseClient = new BaseClient("https://localhost", GraphClientFactory.Create());
 
             // Act
             var batchRequestBuilder = new BatchRequestBuilder(baseClient.RequestAdapter);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
     public class BatchRequestContentTests
     {
         private const string REQUEST_URL = "https://graph.microsoft.com/v1.0/me";
-        private readonly BaseClient client = new BaseClient(REQUEST_URL, new MockAuthenticationProvider().Object);
+        private readonly IBaseClient client = new BaseClient(REQUEST_URL, new MockAuthenticationProvider().Object);
 
         [Fact]
         public void BatchRequestContent_DefaultInitialize()

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RequestTestBase.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RequestTestBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
         protected MockAuthenticationProvider authenticationProvider;
         protected HttpResponseMessage httpResponseMessage;
-        protected BaseClient baseClient;
+        protected IBaseClient baseClient;
 
         public RequestTestBase()
         {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 testHttpMessageHandler.AddResponseMapping(requestUrl, responseMessage);
 
                 // 3. Create a batch request object to be tested
-                BaseClient client = new BaseClient(requestUrl, authenticationProvider.Object);
-                BaseClient baseClient = new BaseClient(this.baseUrl, GraphClientFactory.Create(finalHandler: testHttpMessageHandler));
+                IBaseClient client = new BaseClient(requestUrl, authenticationProvider.Object);
+                IBaseClient baseClient = new BaseClient(this.baseUrl, GraphClientFactory.Create(finalHandler: testHttpMessageHandler));
                 UploadSliceRequestBuilder<TestDriveItem> uploadSliceRequestBuilder = new UploadSliceRequestBuilder<TestDriveItem>(requestUrl, baseClient.RequestAdapter, 0, 200, 1000);
                 Stream stream = new MemoryStream(new byte[300]);
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
     {
         private PageIterator<TestEventItem, TestEventsResponse> eventPageIterator;
         private Mock<IRequestAdapter> mockRequestAdapter;
-        private BaseClient baseClient;
+        private IBaseClient baseClient;
 
         public PageIteratorTests()
         {
             this.mockRequestAdapter = new Mock<IRequestAdapter>(MockBehavior.Strict);
-            var mockClient = new Mock<BaseClient>(this.mockRequestAdapter.Object);
+            var mockClient = new Mock<IBaseClient>();
             mockClient.SetupGet((client) => client.RequestAdapter).Returns(mockRequestAdapter.Object);
             this.baseClient = mockClient.Object;
             


### PR DESCRIPTION
This includes the following changes;

- Adds an IBaseClient for extensibility with the service library
- Adds back the `ExtractSessionFromParsable` method for handling upload sessions for the LargeFileUploadTask to accept an IParsable for now. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/392)