### PR TITLE
Use nuget dependencies for Kiota

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,7 @@
 version: 2
-registries:
-  nuget-github:
-    type: nuget-feed
-    url: https://nuget.pkg.github.com/microsoft/index.json
-    username: ${{secrets.PUBLISH_GH_USERNAME}}
-    password: ${{secrets.PUBLISH_GH_TOKEN}}
 updates:
 - package-ecosystem: nuget
   directory: "/"
-  registries:
-    - nuget-github
   target-branch: feature/3.0
   schedule:
     interval: daily

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Setup VSTest
         uses: darenm/Setup-VSTest@v1
 
-      - run: ./scripts/UpdateNugetCredentials.ps1 -username "${{ secrets.PUBLISH_GH_USERNAME }}" -apiToken "${{ secrets.PUBLISH_GH_TOKEN }}" -nugetFileAbsolutePath "./nuget.config"
-        shell: pwsh
-
       - name : Nuget Restore
         run: msbuild -t:restore -m
 
@@ -47,30 +44,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
 
-      - name: Build Nuget Package
-        run: msbuild .\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj -t:pack /p:Configuration=Release /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg -m
-
-      - name: Upload Nuget Package
-        uses: actions/upload-artifact@v2
-        with:
-          name: drop
-          path: |
-            ${{ env.relativePath }}/bin/Release/*.nupkg
-            ${{ env.relativePath }}/bin/Release/*.snupkg
-
-  deploy:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/feature/3.0' }}
-    environment:
-      name: staging_feeds
-    runs-on: windows-latest
-    needs: [build]
-    steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1.9.0
-        with:
-          dotnet-version: 6.0.x
-      - uses: actions/download-artifact@v2
-        with:
-          name: drop
-      - run: dotnet nuget push "*.nupkg" --skip-duplicate -s https://nuget.pkg.github.com/microsoftgraph/index.json -k ${{ secrets.PUBLISH_GH_TOKEN }}
 

--- a/scripts/UpdateNugetCredentials.ps1
+++ b/scripts/UpdateNugetCredentials.ps1
@@ -1,9 +1,0 @@
-# This file is sourced from https://github.com/microsoft/kiota/blob/main/scripts/updateNugetCredentials.ps1 and any updates there should be synced here as well.
-param([Parameter(Mandatory=$true)][string]$username, [Parameter(Mandatory=$true)][string]$apiToken, [Parameter(Mandatory=$true)][string]$nugetFileAbsolutePath)
-$template = "<?xml version=`"1.0`" encoding=`"utf-8`"?><configuration><packageSources><add key=`"GitHub`" value=`"https://nuget.pkg.github.com/microsoft/index.json`" /></packageSources><packageSourceCredentials><GitHub><add key=`"Username`" value=`"`" /><add key=`"ClearTextPassword`" value=`"`" /></GitHub></packageSourceCredentials></configuration>"
-[xml]$nugetConfigFileContent = [xml]$template
-$userEntry = $nugetConfigFileContent.configuration.packageSourceCredentials.GitHub.add | Where-Object {$_.key -eq "Username"} | Select-Object -First 1
-$userEntry.value = $username
-$tokenEntry = $nugetConfigFileContent.configuration.packageSourceCredentials.GitHub.add | Where-Object {$_.key -eq "ClearTextPassword"} | Select-Object -First 1
-$tokenEntry.value = $apiToken
-Set-Content -Path $nugetFileAbsolutePath -Value $nugetConfigFileContent.InnerXml -Encoding UTF8

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,7 +22,7 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -100,9 +100,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.33" />
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.8" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.22" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.16" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR changes the dependencies of the project to point to the dependencies on Nuget now that we have the Kiota packages published.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/393)