### PR TITLE
Update kiota dependencies

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,9 +22,10 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <PackageReleaseNotes>
-      - Initial release with support for clients generated with Kiota
+        - Added support for vendor specific content types
+        - Added support for 204 no content responses
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -101,10 +102,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.1" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.2" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0-preview.1" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0-preview.1" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0-preview.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.2" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the Kiota core library references to support the following changes;

- Added support for vendor specific content types
- Added support for 204 no content responses
- Fixes a bug where converting `RequestInformation` to `HttpRequestMessage` would sometimes fail 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/401)