### PR TITLE
Performance improvements on Derived Type converter

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -157,14 +157,17 @@ namespace Microsoft.Graph
         /// Replaces the default response handler with a custom response handler for this request.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
+        /// <param name="baseRequest">The <see cref="IBaseRequest"/> for the request.</param>
         /// <param name="responseHandler">The <see cref="IResponseHandler"/> for the request.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">If responseHandler is null.</exception>
-        public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : BaseRequest
+        public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : IBaseRequest
         {
-            baseRequest.ResponseHandler = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
-
+            _ = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
+            if(baseRequest is BaseRequest request)
+            {
+                request.ResponseHandler = responseHandler;
+            }
             return baseRequest;
         }
 

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -163,11 +163,7 @@ namespace Microsoft.Graph
         /// <exception cref="System.ArgumentNullException">If responseHandler is null.</exception>
         public static T WithResponseHandler<T>(this T baseRequest, IResponseHandler responseHandler) where T : IBaseRequest
         {
-            _ = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
-            if(baseRequest is BaseRequest request)
-            {
-                request.ResponseHandler = responseHandler;
-            }
+            baseRequest.ResponseHandler = responseHandler ?? throw new ArgumentNullException(nameof(responseHandler));
             return baseRequest;
         }
 

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,14 +21,11 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.8</VersionPrefix>
+    <VersionPrefix>2.0.9</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Adds missing ConfigureAwait calls to resolve issues with blocking calls
-- Change default http request message version to http/2
-- Change default handler to WinHttpHandler for NetFramework clients to support http/2
-- Fix null reference exception on deserializing batch request items for non existent object
-- Fix for incorrect content type headers set for batch response content when the reponse type is not application/json
+        - Improves performance of DerivedTypeConverter on deserialization of large payloads
+        - Fixes WithResponseHandler extension method to target Interface not Base class
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseRequest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the <see cref="IResponseHandler"/> for the request.
         /// </summary>
-        IResponseHandler ResponseHandler { get; }
+        IResponseHandler ResponseHandler { get; set; }
 
         /// <summary>
         /// Gets the <see cref="HttpRequestMessage"/> representation of the request.


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1252 and closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/436 and closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/114

Changes include : - 
- Using the new `JsonProperty.Deserialize` method from dotnet 6 to avoid unnecessary string allocations
- Improve the custom `PopulateObject` function to cache the `PropertyInfo` instances in a dictionary to reduce calls to `PropertyInfo.GetCustomAttribute` which is expensive according to https://github.com/dotnet/runtime/issues/44713
- Fix the `WithResponseHandler` extension method to target interface not class.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/438)