### PR TITLE
Fix null reference exception on delta paging

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,10 +22,9 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.7</VersionSuffix>
+    <VersionSuffix>preview.8</VersionSuffix>
     <PackageReleaseNotes>
-        - Dependency updates
-        - Fix errors on payload deserialization (https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/461)
+        - Fixes paging for models in delta requests generated without NextLink property.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Graph
         /// <exception cref="ArgumentException">Thrown when the object doesn't contain a collection inside it</exception>
         private static List<TEntity> ExtractEntityListFromParsable(TCollectionPage parsableCollection)
         {
-            return parsableCollection.GetType().GetProperty("Value").GetValue(parsableCollection, null) as List<TEntity> ?? throw new ArgumentException("The Parsable does not contain a collection property");
+            return parsableCollection.GetType().GetProperty("Value")?.GetValue(parsableCollection, null) as List<TEntity> ?? throw new ArgumentException("The Parsable does not contain a collection property");
         }
 
         /// <summary>
@@ -258,7 +258,13 @@ namespace Microsoft.Graph
         /// <returns></returns>
         private static string ExtractNextLinkFromParsable(TCollectionPage parsableCollection, string nextLinkPropertyName = "NextLink")
         {
-            return parsableCollection.GetType().GetProperty(nextLinkPropertyName).GetValue(parsableCollection, null) as string ?? string.Empty;
+            var nextLinkProperty = parsableCollection.GetType().GetProperty(nextLinkPropertyName);
+            if (nextLinkProperty != null)
+            {
+                return nextLinkProperty.GetValue(parsableCollection, null) as string ?? string.Empty;
+            }
+            // the next link property may not be defined in the response schema so we also check its presence in the additional data bag
+            return parsableCollection.AdditionalData.TryGetValue(CoreConstants.OdataInstanceAnnotations.NextLink,out var nextLink) ? nextLink.ToString() : string.Empty;
         }
     }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsDeltaResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsDeltaResponse.cs
@@ -1,0 +1,53 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Kiota.Abstractions.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
+{
+    public class TestEventsDeltaResponse : IParsable,IAdditionalDataHolder
+    {
+        /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
+        public IDictionary<string, object> AdditionalData { get; set; }
+        public List<TestEventItem> Value { get; set; }
+        /// <summary>
+        /// Instantiates a new eventsResponse and sets the default values.
+        /// </summary>
+        public TestEventsDeltaResponse()
+        {
+            AdditionalData = new Dictionary<string, object>();
+        }
+        /// <summary>
+        /// The deserialization information for the current model
+        /// </summary>
+        public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
+        {
+            return new Dictionary<string, Action<IParseNode>> {
+                {"value", (n) => { Value = n.GetCollectionOfObjectValues<TestEventItem>(TestEventItem.CreateFromDiscriminatorValue).ToList(); } },
+            };
+        }
+        /// <summary>
+        /// Serializes information the current object
+        /// <param name="writer">Serialization writer to use to serialize this model</param>
+        /// </summary>
+        public void Serialize(ISerializationWriter writer)
+        {
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteCollectionOfObjectValues<TestEventItem>("value", Value);
+            writer.WriteAdditionalData(AdditionalData);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the appropriate class based on discriminator value
+        /// <param name="parseNode">The parse node to use to read the discriminator value and create the object</param>
+        /// </summary>
+        public static TestEventsDeltaResponse CreateFromDiscriminatorValue(IParseNode parseNode)
+        {
+            _ = parseNode ?? throw new ArgumentNullException(nameof(parseNode));
+            return new TestEventsDeltaResponse();
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1376

Due to the shape of some of the collection models returned by actions/functions, some of the collection models may not necessarily contain the `NextLink` property. Related to https://github.com/microsoft/OpenAPI.NET.OData/issues/231

Changes include : -
- Fix paging for instances where the nextLink is present in the `AdditionalData` bag.
- Added tests to validate the changes.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/441)