### PR TITLE
Require AuthProvider param for all BaseClient constructor and  LargeFileUpload spec alignment

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,9 +22,10 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.9</VersionSuffix>
+    <VersionSuffix>preview.10</VersionSuffix>
     <PackageReleaseNotes>
-        - Adds support for async callback in the PageIterator.
+        - Require AuthProvider param for all BaseClient constructor [#450]
+        - Adds support for cancellation token in LargeFileUploadTask to fully align to spec [#215] [#132]
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -36,17 +36,6 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Constructs a new <see cref="BaseClient"/>.
-        /// </summary>
-        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
-        /// <param name="httpClient">The customized <see cref="HttpClient"/> to be used for making requests</param>
-        internal BaseClient(
-            string baseUrl,
-            HttpClient httpClient):this(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient) { BaseUrl = baseUrl })
-        {
-        }
-
-        /// <summary>
         /// Gets the <see cref="IRequestAdapter"/> for sending requests.
         /// </summary>
         public IRequestAdapter RequestAdapter { get; set; }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BatchRequestBuilderTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using Moq;
     using Xunit;
     using Microsoft.Graph.Core.Requests;
-    using Microsoft.Kiota.Abstractions;
+    using Microsoft.Kiota.Abstractions.Authentication;
     using System.Threading.Tasks;
     using System.Net.Http;
     using System.Collections.Generic;
@@ -18,7 +18,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task BatchRequestBuilderAsync()
         {
             // Arrange
-            IBaseClient baseClient = new BaseClient("https://localhost", GraphClientFactory.Create());
+            IBaseClient baseClient = new BaseClient("https://localhost", new AnonymousAuthenticationProvider());
 
             // Act
             var batchRequestBuilder = new BatchRequestBuilder(baseClient.RequestAdapter);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Upload/UploadSliceRequestTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using Microsoft.Kiota.Abstractions.Serialization;
-    using Microsoft.Kiota.Http.HttpClientLibrary;
+    using Microsoft.Kiota.Abstractions.Authentication;
     using Microsoft.Kiota.Serialization.Json;
     using Xunit;
 
@@ -50,7 +50,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
                 // 3. Create a batch request object to be tested
                 IBaseClient client = new BaseClient(requestUrl, authenticationProvider.Object);
-                IBaseClient baseClient = new BaseClient(this.baseUrl, GraphClientFactory.Create(finalHandler: testHttpMessageHandler));
+                IBaseClient baseClient = new BaseClient(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(),httpClient: GraphClientFactory.Create(finalHandler: testHttpMessageHandler)));
                 UploadSliceRequestBuilder<TestDriveItem> uploadSliceRequestBuilder = new UploadSliceRequestBuilder<TestDriveItem>(requestUrl, baseClient.RequestAdapter, 0, 200, 1000);
                 Stream stream = new MemoryStream(new byte[300]);
 


### PR DESCRIPTION
This PR closes #450, closes #215 and closes #132

Changes include:
- Ensure all BaseClient constructors take an AuthProvider
- Add support for passing a cancellationToken to the LargeFileUploadTask to fully align with the spec.
- Adds tests to capture cancelled cancellationTokens

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/457)