### PR TITLE
Fixes claims parsing of WWWAuthenticate header in some scenarios.

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -149,14 +149,15 @@ namespace Microsoft.Graph
         /// <param name="newRequest">Request message to add claims to</param>
         private void AddClaimsToRequestContext(HttpRequestMessage newRequest, string wwwAuthenticateHeader)
         {
-            int claimsStart = wwwAuthenticateHeader.IndexOf("claims=", StringComparison.OrdinalIgnoreCase);
-            if (claimsStart < 0) 
+            var claimsHeaderString = wwwAuthenticateHeader.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault( header => header.Contains("claims="));
+            if (string.IsNullOrEmpty(claimsHeaderString)) 
                 return; // do nothing as there is no claims in www Authenticate Header
 
-            claimsStart += 8; // jump to the index after the opening quotation mark
+            claimsHeaderString = claimsHeaderString.Trim();// remove any potential whitespace
+            int claimsStart = 8; // jump to the index after the opening quotation mark
 
             // extract and decode the Base 64 encoded claims property
-            byte[] bytes = Convert.FromBase64String(wwwAuthenticateHeader.Substring(claimsStart, wwwAuthenticateHeader.Length - claimsStart - 1));
+            byte[] bytes = Convert.FromBase64String(claimsHeaderString.Substring(claimsStart, claimsHeaderString.Length - claimsStart - 1));
             string claimsChallenge = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 
             // Try to get the current options otherwise create new ones

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequest.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Graph
                 request.Content = new StreamContent(stream);
                 request.Content.Headers.ContentRange = new ContentRangeHeaderValue(this.RangeBegin, this.RangeEnd, this.TotalSessionLength);
                 request.Content.Headers.ContentLength = this.RangeLength;
+                request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(this.ContentType);
 
                 return await this.Client.HttpProvider.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1416 and closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/458

Changes include
- Fix the parsing of the `WWWAuthenticateHeader` to avoid passing extra characters to the base64 decode function.
- Ensure the `ContentType` header is set in `UploadSliceRequest.cs`
- Updates tests to cater for these scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/459)