### PR TITLE
Use updated nextLink property for pageIterator

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -22,10 +22,9 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.10</VersionSuffix>
+    <VersionSuffix>preview.11</VersionSuffix>
     <PackageReleaseNotes>
-        - Require AuthProvider param for all BaseClient constructor [#450]
-        - Adds support for cancellation token in LargeFileUploadTask to fully align to spec [#215] [#132]
+        - Refactor pageiterator to use updated nextLink property.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Graph
         /// <param name="parsableCollection">The <see cref="IParsable"/> to extract the nextLink from</param>
         /// <param name="nextLinkPropertyName">The property name of the nextLink string</param>
         /// <returns></returns>
-        private static string ExtractNextLinkFromParsable(TCollectionPage parsableCollection, string nextLinkPropertyName = "NextLink")
+        private static string ExtractNextLinkFromParsable(TCollectionPage parsableCollection, string nextLinkPropertyName = "OdataNextLink")
         {
             var nextLinkProperty = parsableCollection.GetType().GetProperty(nextLinkPropertyName);
             if (nextLinkProperty != null)

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         public async Task Given_CollectionPage_It_Iterates_Across_Pages_With_Async_Delegate()
         {
             // // Arrange the sample first page of 17 events to initialize the original collection page.
-            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), NextLink = "http://localhost/events?$skip=11" };
+            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
             var inputEventCount = 17;
             for (int i = 0; i < inputEventCount; i++)
             {
@@ -265,7 +265,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         public async Task Given_CollectionPage_It_Iterates_Across_Pages()
         {
             // // Arrange the sample first page of 17 events to initialize the original collection page.
-            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), NextLink = "http://localhost/events?$skip=11" };
+            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
             var inputEventCount = 17;
             for (int i = 0; i < inputEventCount; i++)
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         public async Task Given_CollectionPage_It_Detects_Next_Link_Loop()
         {
             // Create the 17 events to initialize the original collection page.
-            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), NextLink = "http://localhost/events?$skip=11" };
+            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
             var inputEventCount = 5;
             for (int i = 0; i < inputEventCount; i++)
             {
@@ -320,7 +320,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
             }
 
             // Create the 5 events to initialize the next collection page.
-            var nextPage = new TestEventsResponse() { Value = new List<TestEventItem>() , NextLink = "http://localhost/events?$skip=11" };//same next link url
+            var nextPage = new TestEventsResponse() { Value = new List<TestEventItem>() , OdataNextLink = "http://localhost/events?$skip=11" };//same next link url
             var nextPageEventCount = 5;
             for (int i = 0; i < nextPageEventCount; i++)
             {
@@ -350,7 +350,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
             try
             {
                 // Create the 17 events to initialize the original collection page.
-                var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), NextLink = "http://localhost/events?$skip=11" };
+                var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
                 var inputEventCount = 17;
                 for (int i = 0; i < inputEventCount; i++)
                 {
@@ -398,7 +398,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         public async Task Given_RequestConfigurator_It_Is_Invoked()
         {
             // Create the 17 events to initialize the original collection page.
-            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), NextLink = "http://localhost/events?$skip=11" };
+            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
             var inputEventCount = 17;
             for (int i = 0; i < inputEventCount; i++)
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventDeltaCollectionResponse.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public List<TestEvent> Value { get; set; }
 
         /// <summary>
-        /// Gets or sets the nextLink string value.
+        /// Gets or sets the OdataNextLink string value.
         /// </summary>
-        public string NextLink { get; set; }
+        public string OdataNextLink { get; set; }
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
@@ -37,7 +37,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                {"@odata.nextLink", (n) => { NextLink = n.GetStringValue(); } },
+                {"@odata.nextLink", (n) => { OdataNextLink = n.GetStringValue(); } },
                 {"value", (n) => { Value = n.GetCollectionOfObjectValues<TestEvent>(TestEvent.CreateFromDiscriminatorValue).ToList(); } },
             };
         }
@@ -50,7 +50,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("@odata.nextLink", NextLink);
+            writer.WriteStringValue("@odata.nextLink", OdataNextLink);
             writer.WriteCollectionOfObjectValues("value", Value);
             writer.WriteAdditionalData(AdditionalData);
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsResponse.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
     {
         /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
         public IDictionary<string, object> AdditionalData { get; set; }
-        public string NextLink { get; set; }
+        public string OdataNextLink { get; set; }
         public List<TestEventItem> Value { get; set; }
         /// <summary>
         /// Instantiates a new eventsResponse and sets the default values.
@@ -27,7 +27,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
         {
             return new Dictionary<string, Action<IParseNode>> {
-                {"@odata.nextLink", (n) => { NextLink = n.GetStringValue(); } },
+                {"@odata.nextLink", (n) => { OdataNextLink = n.GetStringValue(); } },
                 {"value", (n) => { Value = n.GetCollectionOfObjectValues<TestEventItem>(TestEventItem.CreateFromDiscriminatorValue).ToList(); } },
             };
         }
@@ -38,7 +38,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("@odata.nextLink", NextLink);
+            writer.WriteStringValue("@odata.nextLink", OdataNextLink);
             writer.WriteCollectionOfObjectValues<TestEventItem>("value", Value);
             writer.WriteAdditionalData(AdditionalData);
         }


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/460

It refactors the PageIterator to cater for the updated NextLinkProperty name due to changes made in https://github.com/microsoft/kiota/pull/1739

https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/d2802c613bca9a5620542d86df469e4a277ae124/src/Microsoft.Graph/Generated/Models/ContactCollectionResponse.cs#L17

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/461)