### PR TITLE
Remove restriction on 320KB multiple restriction for the LargeFileUploadTask

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,11 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.10</VersionPrefix>
+    <VersionPrefix>2.0.11</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-        - Ensure Content-Type header is set in Large file uploads
-        - Fixes parsing of WWW authenticate header in some scenarios
+        - Remove 320KB multiple slice size restriction on LargeFileUploadTask
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Graph
     public class LargeFileUploadTask<T>
     {
         private const int DefaultMaxSliceSize = 5 * 1024 * 1024;
-        private const int RequiredSliceSizeIncrement = 320 * 1024;
         private IUploadSession Session { get; set; }
         private readonly IBaseClient _client;
         private readonly Stream _uploadStream;
@@ -30,7 +29,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="uploadSession">Session information of type <see cref="IUploadSession"/>></param>
         /// <param name="uploadStream">Readable, seekable stream to be uploaded. Length of session is determined via uploadStream.Length</param>
-        /// <param name="maxSliceSize">Max size of each slice to be uploaded. Multiple of 320 KiB (320 * 1024) is required.</param>
+        /// <param name="maxSliceSize">Max size(in bytes) of each slice to be uploaded. Defaults to 5MB</param>
         /// <param name="baseClient"><see cref="IBaseClient"/> to use for making upload requests. The client should not set Auth headers as upload urls do not need them.
         /// If less than 0, default value of 5 MiB is used. .</param>
         public LargeFileUploadTask(IUploadSession uploadSession, Stream uploadStream,  int maxSliceSize = -1, IBaseClient baseClient = null)
@@ -45,10 +44,6 @@ namespace Microsoft.Graph
             this._uploadStream = uploadStream;
             this._rangesRemaining = this.GetRangesRemaining(uploadSession);
             this._maxSliceSize = maxSliceSize < 0 ? DefaultMaxSliceSize : maxSliceSize;
-            if (this._maxSliceSize % RequiredSliceSizeIncrement != 0)
-            {
-                throw new ArgumentException("Max slice size must be a multiple of 320 KiB", nameof(maxSliceSize));
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="uploadSession">Session information of type <see cref="IUploadSession"/>></param>
         /// <param name="uploadStream">Readable, seekable stream to be uploaded. Length of session is determined via uploadStream.Length</param>
-        /// <param name="maxSliceSize">Max size(in bytes) of each slice to be uploaded. Defaults to 5MB</param>
+        /// <param name="maxSliceSize">Max size(in bytes) of each slice to be uploaded. Defaults to 5MB. When uploading to OneDrive or SharePoint, this value needs to be a multiple of 320 KiB (327,680 bytes).</param>
         /// <param name="baseClient"><see cref="IBaseClient"/> to use for making upload requests. The client should not set Auth headers as upload urls do not need them.
         /// If less than 0, default value of 5 MiB is used. .</param>
         public LargeFileUploadTask(IUploadSession uploadSession, Stream uploadStream,  int maxSliceSize = -1, IBaseClient baseClient = null)

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
     public class LargeFileUploadTests : RequestTestBase
     {
         [Fact]
-        public void ThrowsArgumentExceptionOnInvalidSliceSize()
+        public void AllowsVariableSliceSize()
         {
-            using (Stream stream = new MemoryStream())
+            byte[] mockData = new byte[1000000];
+            using (Stream stream = new MemoryStream(mockData))
             {
                 // Arrange
                 IUploadSession uploadSession = new Graph.Core.Models.UploadSession
@@ -27,13 +28,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                     ExpirationDateTime = DateTimeOffset.Parse("2019-11-07T06:39:31.499Z")
                 };
 
-                int maxSliceSize = 1000;//invalid slice size that is not a multiple of 320
+                int maxSliceSize = 200 * 1024;//slice size that is 200 KB
 
                 // Act 
-                var exception = Assert.Throws<ArgumentException>(() => new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize));
+                var largeFileUploadTask = new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize);
+                var uploadSlices = largeFileUploadTask.GetUploadSliceRequests();
+                var onlyUploadSlice = uploadSlices.First();
 
-                // Assert
-                Assert.Equal("maxSliceSize", exception.ParamName);
+                //Assert
+                Assert.Equal(0, onlyUploadSlice.RangeBegin);
+                Assert.Equal(204800, onlyUploadSlice.RangeLength);
+                Assert.Equal(204799, onlyUploadSlice.RangeEnd);
             }
         }
 


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1436

It removes the Argument Exception thrown when the LargeFileUploadTask is initialized with a slice size that is not a multiple of 320KB to allow for other scenarios like PrintDocument. 
This makes the LargeFileUploadTask more agnostic to the endpoints being uploaded to and leaves the failure of the task to the exception thrown by the API in the event of an incorrect slice size.

Tests have been updated to capture this as well. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/474)