### PR TITLE
Add `Object` postfix to type name in `DerivedTypeConverter`

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.11</VersionPrefix>
+    <VersionPrefix>2.0.12</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-        - Remove 320KB multiple slice size restriction on LargeFileUploadTask
+        - Map Graph resources ending with 'Request' to correct type
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -53,6 +53,14 @@ namespace Microsoft.Graph
                 var typeString = type.ToString();
                 typeString = typeString.TrimStart('#');
                 typeString = StringHelper.ConvertTypeToTitleCase(typeString);
+
+                // The generated classes for resources which end with `Request` (e.g. `microsoft.graph.eventMessageRequest`)
+                // are post-fixed with `Object`. To find the correct class to instantiate, we also need to add that postfix here.
+                if (typeString.EndsWith("Request"))
+                {
+                    typeString += "Object";
+                }
+
                 var typeAssembly = objectType.GetTypeInfo().Assembly;
                 // Use the type assembly as part of the key since users might use v1 and beta at the same causing conflicts
                 var typeMappingCacheKey = $"{typeAssembly.FullName} : {typeString}";


### PR DESCRIPTION
Fixes microsoftgraph/msgraph-sdk-dotnet#1449.

### Changes proposed in this pull request
For Graph resources which end with `Request`, the model generator adds
the postfix `Object`. Since we use the ODataType to construct an
instance of the generated class in `DerivedTypeConverter`, we actually
attempt to create instances of the wrong type. To fix this, we also add
the postfix to the type name in `DerivedTypeConverter`, before
attempting to create instances of the type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/484)