### PR TITLE
Adds net standard reference to fix MAUI targets

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -15,18 +15,15 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/microsoftgraph/msgraph-sdk-dotnet-core</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.12</VersionSuffix>
+    <VersionSuffix>preview.13</VersionSuffix>
     <PackageReleaseNotes>
-        - Adds support for MAUI TargetFrameworks
-        - Adds ability to build project with dotnet CLI
-        - Adds optional parameter to prevent disposal of created HttpClient 
+        - Fixes dependency resolution for MAUI target by specifying NETStandard.Library target
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -59,5 +56,8 @@
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0-preview.6" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0-preview.3" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.8" />
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1472

It resolved dependency resolution issues in non NetStandard targets due to dependecies potentially pulling lower versions of NetStandard libraries.

It also removes the `NetStandardImplicitPackageVersion` as it only works for versions matching `netstandard1.x` according to the reference link below.

https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#netstandardimplicitpackageversion