### PR TITLE
Http client resilience extensions updates

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
+++ b/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(tenantIds));
             if (appIds == null || !appIds.Any())
                 throw new ArgumentNullException(nameof(appIds));
-            if(!issuerFormats?.Any() ?? true)
+            if(!(issuerFormats?.Any() ?? false))
                 issuerFormats = new string[] { "https://sts.windows.net/{0}/", "https://login.microsoftonline.com/{0}/v2.0" };
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(wellKnownUri, new OpenIdConnectConfigurationRetriever());
@@ -52,7 +52,7 @@ namespace Microsoft.Graph
             {
                 var issuersToValidate = tenantIds.Select(x => string.Format(issuerFormat,x));
                 var result = collection.ValidationTokens.Select(x => IsTokenValid(x, handler, openIdConfig, issuersToValidate, appIdsToValidate))
-                            .Aggregate((z, y) => z && y);
+                            .Aggregate(static (z, y) => z && y);
 
                 if(result)
                     return result;// no need to try the other issuer if this one worked.

--- a/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
+++ b/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Graph
         /// <param name="appIds">List of application id (client ids) that subscriptions have been created from.</param>
         /// <param name="wellKnownUri">Well known URL to get the signing certificates for the tokens.
         /// If you are not using the public cloud you need to pass the value corresponding to your national deployment.</param>
-        /// <param name="issuerPrefix">Issuer prefix for the "aud" claim in the tokens.
+        /// <param name="issuerFormats">Issuer formats for the "aud" claim in the tokens.
         /// If you are not using the public cloud you need to pass the value corresponding to your national deployment.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="tenantIds"/> or <paramref name="appIds"/> is null or empty</exception>
         /// <returns>Are tokens valid or not.</returns>
         public static async Task<bool> AreTokensValid<T1,T2>(this ITokenValidable<T1, T2> collection, IEnumerable<Guid> tenantIds, IEnumerable<Guid> appIds,
             string wellKnownUri = "https://login.microsoftonline.com/common/.well-known/openid-configuration",
-            string issuerPrefix = "https://sts.windows.net/") where T1 : IEncryptedContentBearer<T2> where T2 : IDecryptableContent
+            IEnumerable<string> issuerFormats = null) where T1 : IEncryptedContentBearer<T2> where T2 : IDecryptableContent
         {
             if ((collection.ValidationTokens == null || !collection.ValidationTokens.Any()) && collection.Value.All(x => x.EncryptedContent == null))
                 return true;
@@ -41,28 +41,46 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(tenantIds));
             if (appIds == null || !appIds.Any())
                 throw new ArgumentNullException(nameof(appIds));
+            if(!issuerFormats?.Any() ?? true)
+                issuerFormats = new string[] { "https://sts.windows.net/{0}/", "https://login.microsoftonline.com/{0}/v2.0" };
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(wellKnownUri, new OpenIdConnectConfigurationRetriever());
             var openIdConfig = await configurationManager.GetConfigurationAsync().ConfigureAwait(false);
             var handler = new JwtSecurityTokenHandler();
-            var issuersToValidate = tenantIds.Select(x => $"{issuerPrefix}{x}/");
             var appIdsToValidate = appIds.Select(x => x.ToString());
-            return collection.ValidationTokens.Select(x => IsTokenValid(x, handler, openIdConfig, issuersToValidate, appIdsToValidate))
-                        .Aggregate((z, y) => z && y);
+            foreach (var issuerFormat in issuerFormats)
+            {
+                var issuersToValidate = tenantIds.Select(x => string.Format(issuerFormat,x));
+                var result = collection.ValidationTokens.Select(x => IsTokenValid(x, handler, openIdConfig, issuersToValidate, appIdsToValidate))
+                            .Aggregate((z, y) => z && y);
+
+                if(result)
+                    return result;// no need to try the other issuer if this one worked.
+            }
+
+            return false;// All issuers failed
         }
 
         private static bool IsTokenValid(string token, JwtSecurityTokenHandler handler, OpenIdConnectConfiguration openIdConfig, IEnumerable<string> issuersToValidate, IEnumerable<string> appIds)
         {
-            handler.ValidateToken(token, new TokenValidationParameters
+            try
             {
-                ValidateIssuer = true,
-                ValidateAudience = true,
-                ValidateIssuerSigningKey = true,
-                ValidateLifetime = true,
-                ValidIssuers = issuersToValidate,
-                ValidAudiences = appIds,
-                IssuerSigningKeys = openIdConfig.SigningKeys
-            }, out _);
+                handler.ValidateToken(token, new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidateLifetime = true,
+                    ValidIssuers = issuersToValidate,
+                    ValidAudiences = appIds,
+                    IssuerSigningKeys = openIdConfig.SigningKeys
+                }, out _);
+            }
+            catch
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos;net6.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
@@ -21,9 +21,11 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.13</VersionSuffix>
+    <VersionSuffix>preview.14</VersionSuffix>
     <PackageReleaseNotes>
-        - Fixes dependency resolution for MAUI target by specifying NETStandard.Library target
+        - Adds WinHttpHandler to enable HTTP/2 scenarios in NetFramework
+        - Adds resilient HTTP configurations for clients running .NET 5 and above
+        - Improved token validation logic to support v2 tokens in ITokenValidableExtensions
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -57,7 +59,10 @@
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0-preview.4" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.10" />
   </ItemGroup>
-  <ItemGroup  Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -220,6 +220,14 @@ namespace Microsoft.Graph
             return new Foundation.NSUrlSessionHandler { AllowAutoRedirect = false };
 #elif ANDROID
             return new Xamarin.Android.Net.AndroidMessageHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
+#elif NETFRAMEWORK
+            // If custom proxy is passed, the WindowsProxyUsePolicy will need updating
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs#L575
+            var proxyPolicy = proxy != null ? WindowsProxyUsePolicy.UseCustomProxy : WindowsProxyUsePolicy.UseWinHttpProxy;
+            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy };
+#elif NET6_0_OR_GREATER
+            //use resilient configs when we can https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#alternatives-to-ihttpclientfactory-1
+            return new SocketsHttpHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None, PooledConnectionLifetime = TimeSpan.FromMinutes(1)}; 
 #else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
 #endif

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -260,7 +260,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             // Creation should ignore the InnerHandler on RetryHandler
             HttpClient client = GraphClientFactory.Create(handlers: handlers);
             Assert.NotNull(client);
-            Assert.IsType<HttpClientHandler>(handlers[0].InnerHandler);
+            Assert.IsType<SocketsHttpHandler>(handlers[0].InnerHandler);
         }
 
         [Fact]

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -528,5 +528,31 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
             // Expect the string to be ISO 8601-1:2019 format
             Assert.Equal(expectedString, serializedJsonString);
         }
+
+        [Fact]
+        public void SerializeServiceExceptionValues()
+        {
+            // Arrange
+            var error = new Error
+            {
+                Code = "Unknown",
+                ClientRequestId = new Guid().ToString(),
+                Message = "Unknown Error"
+            };
+            var serviceException = new ServiceException(error, null, System.Net.HttpStatusCode.InternalServerError);
+            using var jsonSerializerWriter = new JsonSerializationWriter();
+
+            // Act
+            jsonSerializerWriter.WriteObjectValue(string.Empty, serviceException);
+            // Assert
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
+
+            var expectedString = @"{""error"":{""code"":""Unknown"",""message"":""Unknown Error""},""statusCode"":""internalServerError""}";
+            // Expect the string to be ISO 8601-1:2019 format
+            Assert.Equal(expectedString, serializedJsonString);
+        }
     }
 }


### PR DESCRIPTION
This PR includes a few improvements

Changes include:- 
- Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/174 by ensuring `ServiceException` implements `IParsable` similar to other error classes from Kiota.
- Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/317 by adding support for v2 tokens for the `ITokenValidableExtension`
- Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/318 by ensuring that target environments running net6.0 and above utilize the `SocketsHttpHandler` with the correct configuration to prevent stale DNS issues. 