### PR TITLE
PageIterator/LargeFileUploadTask enhancements

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,11 +21,9 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.14</VersionSuffix>
+    <VersionSuffix>preview.15</VersionSuffix>
     <PackageReleaseNotes>
-        - Adds WinHttpHandler to enable HTTP/2 scenarios in NetFramework
-        - Adds resilient HTTP configurations for clients running .NET 5 and above
-        - Improved token validation logic to support v2 tokens in ITokenValidableExtensions
+        - Adds contructors/factories for PageIterator/LargeFileUploadTask that accept IRequestAdapter
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
 
             // Create task
             IBaseClient baseClient = new BaseClient(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: GraphClientFactory.Create(finalHandler: testHttpMessageHandler)));
-            var fileUploadTask = new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize, baseClient);
+            var fileUploadTask = new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize, baseClient.RequestAdapter);
 
             // Assert that the task is cancellable
             var cancellationException = await Assert.ThrowsAsync<TaskCanceledException>(async () => await fileUploadTask.UploadAsync(cancellationToken: cancellationToken));


### PR DESCRIPTION
This PR adds contructors/factories for PageIterator/LargeFileUploadTask that accept IRequestAdapter to also better serve scenarios where sdks are self-generated and thus do not have defined implementation for IBaseClient as the generated service libraries do.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/514)