### PR TITLE
Cache property mapping in DerivedTypeConverter<T>

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.13</VersionPrefix>
+    <VersionPrefix>2.0.14</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-        - Fixes WinHttpHandler initialization with proxy for .NetFramework clients
+        - Cache property mapping in DerivedTypeConverter to improve perfomance
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -214,8 +214,7 @@ namespace Microsoft.Graph
             writer.WriteStartObject();
             foreach (var propertyInfo in value.GetType().GetProperties())
             {
-                var ignoreConverterAttribute = propertyInfo.GetCustomAttribute<JsonIgnoreAttribute>();
-                if(ignoreConverterAttribute != null)
+                if (propertyInfo.IsDefined(typeof(JsonIgnoreAttribute)))
                 {
                     continue;// Don't serialize a property we are asked to ignore
                 }
@@ -233,8 +232,7 @@ namespace Microsoft.Graph
                 }
 
                 // Check so that we are not serializing the JsonExtensionDataAttribute(i.e AdditionalData) at a nested level
-                var jsonExtensionData = propertyInfo.GetCustomAttribute<JsonExtensionDataAttribute>();
-                if (jsonExtensionData != null)
+                if (propertyInfo.IsDefined(typeof(JsonExtensionDataAttribute)))
                 {
                     var additionalData = propertyInfo.GetValue(value) as IDictionary<string, object> ?? new Dictionary<string, object>();
                     foreach (var item in additionalData)

--- a/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DerivedTypeConverter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Graph
                 // Use the type assembly as part of the key since users might use v1 and beta at the same causing conflicts
                 var typeMappingCacheKey = $"{typeAssembly.FullName} : {typeString}";
 
-                if (DerivedTypeConverter<T>.TypeMappingCache.TryGetValue(typeMappingCacheKey, out var instanceType))
+                if (TypeMappingCache.TryGetValue(typeMappingCacheKey, out var instanceType))
                 {
                     instance = this.Create(instanceType);
                 }
@@ -88,7 +88,7 @@ namespace Microsoft.Graph
                 if (instance != null && instanceType == null)
                 {
                     // Cache the type mapping resolution if we haven't pulled it from the cache already.
-                    DerivedTypeConverter<T>.TypeMappingCache.TryAdd(typeMappingCacheKey, instance.GetType());
+                    TypeMappingCache.TryAdd(typeMappingCacheKey, instance.GetType());
                 }
             }
             else
@@ -214,7 +214,7 @@ namespace Microsoft.Graph
             writer.WriteStartObject();
             foreach (var propertyInfo in value.GetType().GetProperties())
             {
-                var ignoreConverterAttribute = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>();
+                var ignoreConverterAttribute = propertyInfo.GetCustomAttribute<JsonIgnoreAttribute>();
                 if(ignoreConverterAttribute != null)
                 {
                     continue;// Don't serialize a property we are asked to ignore
@@ -222,7 +222,7 @@ namespace Microsoft.Graph
 
                 string propertyName;
                 // Try to get the property name off the JsonAttribute otherwise camel case the property name
-                var jsonProperty = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonPropertyNameAttribute>();
+                var jsonProperty = propertyInfo.GetCustomAttribute<JsonPropertyNameAttribute>();
                 if (jsonProperty != null && !string.IsNullOrWhiteSpace(jsonProperty.Name))
                 {
                     propertyName = jsonProperty.Name;
@@ -233,7 +233,7 @@ namespace Microsoft.Graph
                 }
 
                 // Check so that we are not serializing the JsonExtensionDataAttribute(i.e AdditionalData) at a nested level
-                var jsonExtensionData = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonExtensionDataAttribute>();
+                var jsonExtensionData = propertyInfo.GetCustomAttribute<JsonExtensionDataAttribute>();
                 if (jsonExtensionData != null)
                 {
                     var additionalData = propertyInfo.GetValue(value) as IDictionary<string, object> ?? new Dictionary<string, object>();
@@ -256,7 +256,7 @@ namespace Microsoft.Graph
                 else
                 {
                     // Check to see if the property has a special converter specified
-                    var jsonConverter = propertyInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonConverterAttribute>();
+                    var jsonConverter = propertyInfo.GetCustomAttribute<JsonConverterAttribute>();
                     if ((propertyInfo.GetValue(value) == null && 
                          (jsonConverter == null || jsonConverter.ConverterType == typeof(NextLinkConverter))))
                     {


### PR DESCRIPTION
Contributes to #438. Fixes #436 (for good?)

### Changes proposed in this pull request
- Cache property mapping for all derived types of `T` in a static `ConcurrentDictionary`.
- Cache compiled factory delegates for all derived types of `T` in a static `ConcurrentDictionary`.
- Use `IsDefined` instead of `GetCustomAttribute` where the attribute itself isn't used.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Benchmarks

I ran the following benchmark (using `BenchmarkDotNet`) to verify the optimizations:

```csharp
[MemoryDiagnoser]
public class Benchmarks
{
    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);

    [Params(10, 100, 1000)] public int N;

    private string JsonData;

    [GlobalSetup]
    public void GlobalSetup()
    {
        var statuses = Enumerable.Range(0, N).Select(i => new AsyncOperationStatus
        {
            Operation = "Operation" + i,
            Status = "In progress",
            PercentageComplete = 0.8,
        }).ToList();

        JsonData = JsonSerializer.Serialize(statuses, JsonOptions);
    }
    
    [Benchmark]
    public List<AsyncOperationStatus>? ReadJson()
    {
        return JsonSerializer.Deserialize<List<AsyncOperationStatus>>(JsonData, JsonOptions);
    }
}
```

Using the following setup:

```
BenchmarkDotNet=v0.13.2, OS=macOS Monterey 12.2.1 (21D62) [Darwin 21.3.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK=6.0.401
  [Host]     : .NET 6.0.9 (6.0.922.41905), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 6.0.9 (6.0.922.41905), Arm64 RyuJIT AdvSIMD
```

It basically serializes 10, 100 and 1000 `AsyncOperationStatus` objects, which use `DerivedTypeConverter<AsyncOperationStatus>`, into JSON and benchmarks the process of deserializing the JSON back into objects.

#### `dev` branch at the `2.0.8` tag (before #438)

|   Method |    N |        Mean |    Error |   StdDev |      Gen0 |     Gen1 |    Gen2 |  Allocated |
|--------- |----- |------------:|---------:|---------:|----------:|---------:|--------:|-----------:|
| ReadJson |   10 |    102.0 us |  0.74 us |  0.70 us |   15.5029 |        - |       - |   31.73 KB |
| ReadJson |  100 |  1,016.8 us |  2.85 us |  2.52 us |  154.2969 |        - |       - |  316.27 KB |
| ReadJson | 1000 | 10,370.3 us | 26.09 us | 24.40 us | 1140.6250 | 156.2500 | 46.8750 | 3167.96 KB |

#### Current `dev` branch

|   Method |    N |        Mean |     Error |    StdDev |     Gen0 |     Gen1 |    Gen2 |  Allocated |
|--------- |----- |------------:|----------:|----------:|---------:|---------:|--------:|-----------:|
| ReadJson |   10 |    95.01 us |  0.200 us |  0.167 us |  10.7422 |        - |       - |   21.96 KB |
| ReadJson |  100 |   942.87 us |  6.695 us |  5.227 us | 106.4453 |        - |       - |  218.59 KB |
| ReadJson | 1000 | 9,648.96 us | 56.394 us | 47.091 us | 750.0000 | 187.5000 | 31.2500 | 2180.61 KB |

#### This PR branch

|   Method |    N |        Mean |    Error |   StdDev |     Gen0 |    Gen1 | Allocated |
|--------- |----- |------------:|---------:|---------:|---------:|--------:|----------:|
| ReadJson |   10 |    32.69 us | 0.158 us | 0.148 us |   3.4180 |       - |   7.04 KB |
| ReadJson |  100 |   317.46 us | 0.761 us | 0.675 us |  33.6914 |       - |  69.34 KB |
| ReadJson | 1000 | 3,237.44 us | 7.557 us | 7.069 us | 148.4375 | 62.5000 | 689.09 KB |

As you can see, the improvement is quite significant. Especially when looking at the allocations.

// @ros-han-n

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/519)