### PR TITLE
Updates Kiota Dependecies for ResponseHandler updates

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,9 +21,9 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.15</VersionSuffix>
+    <VersionSuffix>preview.16</VersionSuffix>
     <PackageReleaseNotes>
-        - Adds contructors/factories for PageIterator/LargeFileUploadTask that accept IRequestAdapter
+        - Updates Kiota dependencies to align to changing the ResponeHandler parameter in IRequestAdapter to be a RequestOption
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -51,11 +51,11 @@
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.24.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.13" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.14" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0-preview.4" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.0-preview.7" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0-preview.4" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.10" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0-preview.11" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />

--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Graph
             {
                 var requestInformation = new RequestInformation() { HttpMethod = Method.GET , UrlTemplate = this.monitorUrl};
                 var nativeResponseHandler = new NativeResponseHandler();
-                await this.client.RequestAdapter.SendNoContentAsync(requestInformation, nativeResponseHandler, cancellationToken:cancellationToken).ConfigureAwait(false);
+                requestInformation.SetResponseHandler(nativeResponseHandler);
+                await this.client.RequestAdapter.SendNoContentAsync(requestInformation, cancellationToken:cancellationToken).ConfigureAwait(false);
                 using var responseMessage = nativeResponseHandler.Value as HttpResponseMessage;
 
                 // The monitor service will return an Accepted status for any monitor operation that hasn't completed.

--- a/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/BatchRequestBuilder.cs
@@ -46,9 +46,10 @@ namespace Microsoft.Graph.Core.Requests
         {
             _ = batchRequestContent ?? throw new ArgumentNullException(nameof(batchRequestContent));
             var requestInfo = await CreatePostRequestInformationAsync(batchRequestContent);
-            var responseHandler = new NativeResponseHandler();
-            await this.RequestAdapter.SendNoContentAsync(requestInfo, responseHandler, cancellationToken:cancellationToken);
-            return new BatchResponseContent(responseHandler.Value as HttpResponseMessage);
+            var nativeResponseHandler = new NativeResponseHandler();
+            requestInfo.SetResponseHandler(nativeResponseHandler);
+            await this.RequestAdapter.SendNoContentAsync(requestInfo, cancellationToken:cancellationToken);
+            return new BatchResponseContent(nativeResponseHandler.Value as HttpResponseMessage);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSessionRequestBuilder.cs
@@ -61,9 +61,10 @@ namespace Microsoft.Graph
         public async Task<IUploadSession> GetAsync(CancellationToken cancellationToken = default)
         {
             var requestInformation = this.CreateGetRequestInformationAsync();
-            var responseHandler = new NativeResponseHandler();
-            await this.requestAdapter.SendNoContentAsync(requestInformation, responseHandler, cancellationToken: cancellationToken).ConfigureAwait(false);
-            var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(responseHandler.Value as HttpResponseMessage).ConfigureAwait(false);
+            var nativeResponseHandler = new NativeResponseHandler();
+            requestInformation.SetResponseHandler(nativeResponseHandler);
+            await this.requestAdapter.SendNoContentAsync(requestInformation, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var uploadResult = await this.responseHandler.HandleResponse<UploadSession>(nativeResponseHandler.Value as HttpResponseMessage).ConfigureAwait(false);
             return uploadResult.UploadSession;
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequestBuilder.cs
+++ b/src/Microsoft.Graph.Core/Requests/Upload/UploadSliceRequestBuilder.cs
@@ -72,9 +72,10 @@ namespace Microsoft.Graph
         public async Task<UploadResult<T>> PutAsync(Stream stream, CancellationToken cancellationToken = default)
         {
             var requestInformation = this.CreatePutRequestInformationAsync(stream);
-            var responseHandler = new NativeResponseHandler();
-            await this.RequestAdapter.SendNoContentAsync(requestInformation, responseHandler, cancellationToken: cancellationToken).ConfigureAwait(false);
-            return await this.ResponseHandler.HandleResponse<T>(responseHandler.Value as HttpResponseMessage).ConfigureAwait(false);
+            var nativeResponseHandler = new NativeResponseHandler();
+            requestInformation.SetResponseHandler(nativeResponseHandler);
+            await this.RequestAdapter.SendNoContentAsync(requestInformation, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await this.ResponseHandler.HandleResponse<T>(nativeResponseHandler.Value as HttpResponseMessage).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
@@ -71,9 +71,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             redirectedResponseMessage.Content = redirectedStringContent;
 
             this.requestAdapter
-                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<NativeResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
-                .Callback((RequestInformation requestInfo, IResponseHandler responseHandler, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) =>
+                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                .Callback((RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) =>
                 {
+                    var responseHandler = requestInfo.GetRequestOption<ResponseHandlerOption>().ResponseHandler;
                     if (!called)
                     {
                         called = true;
@@ -96,8 +97,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task PollForOperationCompletionAsync_OperationCancelled()
         {
             this.requestAdapter
-                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<NativeResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
-                .Callback((RequestInformation requestInfo, IResponseHandler responseHandler, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)responseHandler).Value = this.httpResponseMessage)
+                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                .Callback((RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)requestInfo.GetRequestOption<ResponseHandlerOption>().ResponseHandler).Value = this.httpResponseMessage)
                 .Returns(Task.FromResult(0));
 
             using var stringContent = new StringContent(JsonSerializer.Serialize(new AsyncOperationStatus { Status = "cancelled" }));
@@ -112,8 +113,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task PollForOperationCompletionAsync_OperationDeleteFailed()
         {
             this.requestAdapter
-                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<NativeResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
-                .Callback((RequestInformation requestInfo, IResponseHandler responseHandler, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)responseHandler).Value = this.httpResponseMessage)
+                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                .Callback((RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)requestInfo.GetRequestOption<ResponseHandlerOption>().ResponseHandler).Value = this.httpResponseMessage)
                 .Returns(Task.FromResult(0));
 
             using var stringContent = new StringContent(JsonSerializer.Serialize(new AsyncOperationStatus { Status = "deleteFailed" }));
@@ -128,8 +129,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task PollForOperationCompletionAsync_OperationFailed()
         {
             this.requestAdapter
-                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<NativeResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
-                .Callback((RequestInformation requestInfo, IResponseHandler responseHandler, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)responseHandler).Value = this.httpResponseMessage)
+                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                .Callback((RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)requestInfo.GetRequestOption<ResponseHandlerOption>().ResponseHandler).Value = this.httpResponseMessage)
                 .Returns(Task.FromResult(0));
 
             using var stringContent = new StringContent(JsonSerializer.Serialize(new AsyncOperationStatus
@@ -149,8 +150,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         public async Task PollForOperationCompletionAsync_OperationNull()
         {
             this.requestAdapter
-                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<NativeResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
-                .Callback((RequestInformation requestInfo, IResponseHandler responseHandler, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)responseHandler).Value = this.httpResponseMessage)
+                .Setup(requestAdapter => requestAdapter.SendNoContentAsync(It.IsAny<RequestInformation>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                .Callback((RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping, CancellationToken cancellationToken) => ((NativeResponseHandler)requestInfo.GetRequestOption<ResponseHandlerOption>().ResponseHandler).Value = this.httpResponseMessage)
                 .Returns(Task.FromResult(0));
 
             using var stringContent = new StringContent("");

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 return true;
             };
 
-            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsDeltaResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsDeltaResponse>>(), It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsDeltaResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsDeltaResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                                     .Returns(() => { return Task.FromResult(nextPage); });
 
             // Act by calling the iterator
@@ -248,7 +248,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 return true;
             };
 
-            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                                     .Returns(() => { return Task.FromResult(nextPage); });
 
             // Act by calling the iterator
@@ -295,7 +295,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 return true;
             };
 
-            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(),It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                                     .Returns(() => { return Task.FromResult(nextPage); });
 
             // Act by calling the iterator
@@ -334,7 +334,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 return true;
             };
 
-            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                                     .Returns(() => { return Task.FromResult(nextPage); });
 
             eventPageIterator = PageIterator<TestEventItem, TestEventsResponse>.CreatePageIterator(baseClient, originalPage, processEachEvent);
@@ -366,7 +366,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                     return true;
                 };
 
-                this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+                this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                                     .Returns(() => { return Task.FromResult(nextPage); });
 
                 eventPageIterator = PageIterator<TestEventItem, TestEventsResponse>.CreatePageIterator(baseClient, originalPage, processEachEvent);
@@ -425,7 +425,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
                 return request;
             };
 
-            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<IResponseHandler>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
+            this.mockRequestAdapter.Setup(x => x.SendAsync<TestEventsResponse>(It.IsAny<RequestInformation>(), It.IsAny<ParsableFactory<TestEventsResponse>>(), It.IsAny<Dictionary<string, ParsableFactory<IParsable>>>(), It.IsAny<CancellationToken>()))
                     .Returns(() => { return Task.FromResult(nextPage); });
 
             eventPageIterator = PageIterator<TestEventItem, TestEventsResponse>.CreatePageIterator(baseClient, originalPage, processEachEvent, requestConfigurator);


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/1858

Depends on 
- https://github.com/microsoft/kiota-abstractions-dotnet/pull/41
- https://github.com/microsoft/kiota-http-dotnet/pull/44

Changes include
- Updates dependencies and aligns code changes to breaking changes made in https://github.com/microsoft/kiota-abstractions-dotnet/pull/41 and https://github.com/microsoft/kiota-http-dotnet/pull/44 to set the responseHandler using the new APIs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/523)