### PR TITLE
Delay should return the real wait time

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Graph
             }                    
 
             TimeSpan delayTimeSpan = TimeSpan.FromSeconds(Math.Min(delayInSeconds, RetryHandlerOption.MAX_DELAY));
-
+            delayInSeconds=delayTimeSpan.TotalSeconds;
             return Task.Delay(delayTimeSpan, cancellationToken);
 
         }


### PR DESCRIPTION
Fixes #

[Retry Handler actually wait time and returned does not match](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/525)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/526)