### PR TITLE
Omit CompressionHandler in Macatalyst 

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,9 +21,10 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>preview.17</VersionSuffix>
+    <VersionSuffix>preview.18</VersionSuffix>
     <PackageReleaseNotes>
-        - Updates Kiota dependencies to use updated UriTemplates library
+        - Updates Kiota dependencies
+        - Fixes MACCATALYST preprocessor directive to omit CompressionHandler that is already handler by the NSUrlSessionHandler
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -172,13 +172,13 @@ namespace Microsoft.Graph
                     throw new ArgumentNullException(nameof(handlers), "DelegatingHandler array contains null item.");
                 }
 
-#if iOS || macOS
-#if iOS
+#if IOS || MACOS || MACCATALYST
+#if IOS || MACCATALYST
                 // Skip CompressionHandler since NSUrlSessionHandler automatically handles decompression on iOS and macOS and it can't be turned off.
                 // See issue https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/481 for more details.
                 if (finalHandler.GetType().Equals(typeof(NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
-#elif macOS
-                 if (finalHandler.GetType().Equals(typeof(Foundation.NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
+#elif MACOS
+                if (finalHandler.GetType().Equals(typeof(Foundation.NSUrlSessionHandler)) && handler.GetType().Equals(typeof(CompressionHandler)))
 #endif
                 {
                     // Skip chaining of CompressionHandler.


### PR DESCRIPTION
This PR includes MACCATALYST preprocessor directive to omit CompressionHandler that is already handler by the NSUrlSessionHandler

It also aligns other directives to the directives used in the codebase. 

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1551

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/547)