### PR TITLE
Disables WinHttpHandler internal timeouts

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>2.0.14</VersionPrefix>
+    <VersionPrefix>2.0.15</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-        - Cache property mapping in DerivedTypeConverter to improve perfomance
+        - Fixes inability to set OverallTimeout when the WinHttpHandler is used by the client.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Graph
     using System.Net.Http;
     using System.Reflection;
     using System.Net.Http.Headers;
+    using System.Threading;
+
     /// <summary>
     /// GraphClientFactory class to create the HTTP client
     /// </summary>
@@ -234,7 +236,7 @@ namespace Microsoft.Graph
             // If custom proxy is passed, the WindowsProxyUsePolicy will need updating
             // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs#L575
             var proxyPolicy = proxy != null ? WindowsProxyUsePolicy.UseCustomProxy : WindowsProxyUsePolicy.UseWinHttpProxy;
-            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy };
+            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy, SendTimeout = Timeout.InfiniteTimeSpan, ReceiveDataTimeout = Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan };
 #else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None };
 #endif

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Graph
                 {
                     var uploadResult = await this.UploadSliceAsync(request, trackedExceptions).ConfigureAwait(false);
                     
-                    progress?.Report(request.RangeBegin);//report the progress of upload
+                    progress?.Report(request.RangeEnd);//report the progress of upload (how many bytes have been uploaded so far)
 
                     if (uploadResult.UploadSucceeded)
                     {


### PR DESCRIPTION
This PR disables the timeouts in the `WinHttpHandler` used by clients targeting the .NetFramework. 

The default timeouts in `WinHttpHandler` of 30 seconds override the timeouts used by the HttpClient and therefore causes clients to be unable to configure the clients using the Timeout property provided by the client.

Also closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1580 so that the progress task reports the number of bytes uploaded so far. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/590)