### PR TITLE
Disables WinHttpHandler internal timeouts(Kiota)

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,9 +21,9 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>rc.5</VersionSuffix>
+    <VersionSuffix>rc.6</VersionSuffix>
     <PackageReleaseNotes>
-- Use ConcurrentDictionary for the serialization registries.
+- Fixes inability to set OverallTimeout when the WinHttpHandler is used by the client.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Threading;
     using Microsoft.Kiota.Http.HttpClientLibrary;
     using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
 
@@ -224,7 +225,7 @@ namespace Microsoft.Graph
             // If custom proxy is passed, the WindowsProxyUsePolicy will need updating
             // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs#L575
             var proxyPolicy = proxy != null ? WindowsProxyUsePolicy.UseCustomProxy : WindowsProxyUsePolicy.UseWinHttpProxy;
-            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy };
+            return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.None , WindowsProxyUsePolicy = proxyPolicy, SendTimeout = Timeout.InfiniteTimeSpan, ReceiveDataTimeout = Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan };
 #elif NET6_0_OR_GREATER
             //use resilient configs when we can https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#alternatives-to-ihttpclientfactory-1
             return new SocketsHttpHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.None, PooledConnectionLifetime = TimeSpan.FromMinutes(1)}; 

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Graph
                 {
                     var uploadResult = await this.UploadSliceAsync(request, trackedExceptions, cancellationToken).ConfigureAwait(false);
 
-                    progress?.Report(request.RangeBegin);//report the progress of upload
+                    progress?.Report(request.RangeEnd);//report the progress of upload (how many bytes have been uploaded so far)
 
                     if (uploadResult.UploadSucceeded)
                     {


### PR DESCRIPTION
Syncing the fix at https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/590 to the Kiota based branch

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/591)