### PR TITLE
Fixes deltaLink parsing in PageIterator.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,6 @@ version: 2
 updates:
 - package-ecosystem: nuget
   directory: "/"
-  target-branch: feature/3.0
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: nuget
-  directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,7 @@ name: Auto-merge dependabot updates
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ dev ]
 
 permissions:
   pull-requests: write

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -20,10 +20,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Adds support for enhanced batch requests (https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/612)
+- Fixes missing delta link after completed iteration in the PageIterator (https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/619)
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -24,6 +24,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
 - Fixes missing delta link after completed iteration in the PageIterator (https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/619)
+- Updates kiota abstraction library dependencies
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -56,12 +57,12 @@
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.27.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />

--- a/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
+++ b/src/Microsoft.Graph.Core/Tasks/LargeFileUploadTask.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Graph
             {
                 throw new ArgumentException("Must provide stream that can read and seek");
             }
+            if (uploadStream.Length < 1)
+            {
+                throw new ArgumentException("Must a stream that is not empty");
+            }
             this.Session = ExtractSessionFromParsable(uploadSession);
             this._requestAdapter = requestAdapter ?? this.InitializeAdapter(Session.UploadUrl);
             this._uploadStream = uploadStream;

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -354,11 +354,11 @@ namespace Microsoft.Graph
         private static string ExtractNextLinkFromParsable(TCollectionPage parsableCollection, string nextLinkPropertyName = "OdataNextLink")
         {
             var nextLinkProperty = parsableCollection.GetType().GetProperty(nextLinkPropertyName);
-            if (nextLinkProperty != null)
+            if (nextLinkProperty != null && 
+                nextLinkProperty.GetValue(parsableCollection, null) is string nextLinkString  
+                && !string.IsNullOrEmpty(nextLinkString))
             {
-                var nextLinkString = nextLinkProperty.GetValue(parsableCollection, null) as string ?? string.Empty;
-                if (!string.IsNullOrEmpty(nextLinkString))
-                    return nextLinkString;
+                return nextLinkString;
             }
             
             // the next link property may not be defined in the response schema so we also check its presence in the additional data bag

--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -183,9 +183,19 @@ namespace Microsoft.Graph
             }
 
             // There are no pages CURRENTLY ready to be paged. Attempt to call delta query later.
-            else if (_currentPage.AdditionalData != null && _currentPage.AdditionalData.TryGetValue(CoreConstants.OdataInstanceAnnotations.DeltaLink, out object deltalink))
+            if (_currentPage.AdditionalData != null && _currentPage.AdditionalData.TryGetValue(CoreConstants.OdataInstanceAnnotations.DeltaLink, out object deltalink))
             {
                 Deltalink = deltalink.ToString();
+                State = PagingState.Delta;
+                Nextlink = string.Empty;
+
+                return false;
+            }
+            var deltaLink = ExtractNextLinkFromParsable(_currentPage, "OdataDeltaLink");
+            // There are no pages CURRENTLY ready to be paged. Attempt to call delta query later.
+            if (!string.IsNullOrEmpty(deltaLink))
+            {
+                Deltalink = deltaLink;
                 State = PagingState.Delta;
                 Nextlink = string.Empty;
 
@@ -346,8 +356,11 @@ namespace Microsoft.Graph
             var nextLinkProperty = parsableCollection.GetType().GetProperty(nextLinkPropertyName);
             if (nextLinkProperty != null)
             {
-                return nextLinkProperty.GetValue(parsableCollection, null) as string ?? string.Empty;
+                var nextLinkString = nextLinkProperty.GetValue(parsableCollection, null) as string ?? string.Empty;
+                if (!string.IsNullOrEmpty(nextLinkString))
+                    return nextLinkString;
             }
+            
             // the next link property may not be defined in the response schema so we also check its presence in the additional data bag
             return parsableCollection.AdditionalData.TryGetValue(CoreConstants.OdataInstanceAnnotations.NextLink,out var nextLink) ? nextLink.ToString() : string.Empty;
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/LargeFileUploadTaskTests.cs
@@ -30,6 +30,27 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         }
 
         [Fact]
+        public void ThrowsOnEmptyStream()
+        {
+            
+            var uploadSession = new UploadSession
+            {
+                NextExpectedRanges = new List<string>() { "0-" },
+                UploadUrl = "http://localhost",
+                ExpirationDateTime = DateTimeOffset.Parse("2019-11-07T06:39:31.499Z")
+            };
+
+            int maxSliceSize = 200 * 1024;//slice size that is 200 KB
+
+            // Act 
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                using Stream stream = new MemoryStream();
+                return new LargeFileUploadTask<TestDriveItem>(uploadSession, stream, maxSliceSize);
+            });
+            Assert.NotNull(exception);
+        }
+        [Fact]
         public void AllowsVariableSliceSize()
         {
             byte[] mockData = new byte[1000000];

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -214,6 +214,29 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
         }
 
         [Fact]
+        public async Task Given_CollectionPage_Delta_Link_Property_It_Iterates_Across_Pages()
+        {
+            // // Arrange the sample first page of 17 events to initialize the original collection page.
+            var originalPage = new TestEventsDeltaResponse() { Value = new List<TestEventItem>() };
+            originalPage.OdataDeltaLink = "http://localhost/events?$skip=11";
+            var inputEventCount = 17;
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                originalPage.Value.Add(new TestEventItem() { Subject = $"Subject{i}" });
+            }
+            
+            Func<TestEventItem, bool> processEachEvent = (e) => true;
+
+            // Act by calling the iterator
+            var eventsDeltaPageIterator = PageIterator<TestEventItem, TestEventsDeltaResponse>.CreatePageIterator(baseClient, originalPage, processEachEvent);
+            await eventsDeltaPageIterator.IterateAsync();
+
+            // Assert that paging was paused and got to the next page
+            Assert.Equal(PagingState.Delta, eventsDeltaPageIterator.State);
+            Assert.Equal("http://localhost/events?$skip=11",eventsDeltaPageIterator.Deltalink);
+        }
+
+        [Fact]
         public async Task Given_CollectionPage_It_Iterates_Across_Pages_With_Async_Delegate()
         {
             // // Arrange the sample first page of 17 events to initialize the original collection page.

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsDeltaResponse.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/ServiceModels/TestEventsDeltaResponse.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
     {
         /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
         public IDictionary<string, object> AdditionalData { get; set; }
+        
+        public string OdataDeltaLink { get; set; }
+        
+        public string OdataNextLink { get; set; }
+
         public List<TestEventItem> Value { get; set; }
         /// <summary>
         /// Instantiates a new eventsResponse and sets the default values.
@@ -26,6 +31,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
         {
             return new Dictionary<string, Action<IParseNode>> {
+                {"@odata.deltaLink", n => { OdataDeltaLink = n.GetStringValue(); } },
+                {"@odata.nextLink", n => { OdataNextLink = n.GetStringValue(); } },
                 {"value", (n) => { Value = n.GetCollectionOfObjectValues<TestEventItem>(TestEventItem.CreateFromDiscriminatorValue).ToList(); } },
             };
         }
@@ -36,6 +43,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels
         public void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteStringValue("@odata.deltaLink", OdataDeltaLink);
+            writer.WriteStringValue("@odata.nextLink", OdataNextLink);
             writer.WriteCollectionOfObjectValues<TestEventItem>("value", Value);
             writer.WriteAdditionalData(AdditionalData);
         }


### PR DESCRIPTION
Closes #619 
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/554

It fixes parsing of the deltaLink in the pageIterator as the deltaLink will not necessarily live in the additionalData but as a strongly typed property of the `BaseDeltaFunctionResponse` class.

Test models have been updated to capture this. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/620)