### PR TITLE
feat: Allow checking statuscodes of batch response without parsing step body

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -34,6 +34,10 @@
         /// <param name="batchRequestLimit">Number of requests that may be placed in a single batch</param>
         public BatchRequestContentCollection(IBaseClient baseClient, int batchRequestLimit)
         {
+            if(baseClient == null)
+            {
+                throw new ArgumentNullException(nameof(baseClient));
+            }
             if (batchRequestLimit < 2 || batchRequestLimit > CoreConstants.BatchRequest.MaxNumberOfRequests)
             {
                 throw new ArgumentOutOfRangeException(nameof(batchRequestLimit));

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContentCollection.cs
@@ -6,7 +6,9 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
+    using System.Text.Json;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -77,10 +79,29 @@
         /// All <see cref="HttpResponseMessage"/> in the dictionary MUST be disposed since they implement <see cref="IDisposable"/>.
         /// </summary>
         /// <returns>A Dictionary of id and <see cref="HttpResponseMessage"/> representing batch responses.</returns>
-        /// <remarks>Not implemented, need help</remarks>
+        /// <remarks>Not implemented, use GetResponsesStatusCodesAsync and fetch individual responses</remarks>
+        [Obsolete("use GetResponsesStatusCodesAsync and then GetResponseByIdAsync")]
         public Task<Dictionary<string, HttpResponseMessage>> GetResponsesAsync()
         {
             throw new NotImplementedException("GetResponsesAsync() is not available in the BatchCollection");
+        }
+
+        /// <summary>
+        /// Gets all batch responses statuscodes <see cref="Dictionary{String, HttpStatusCode}"/>.
+        /// </summary>
+        /// <returns>A Dictionary of id and <see cref="HttpStatusCode"/> representing batch responses.</returns>
+        public async Task<Dictionary<string, HttpStatusCode>> GetResponsesStatusCodesAsync()
+        {
+            Dictionary<string, HttpStatusCode> statuscodes = new Dictionary<string, HttpStatusCode>();
+            foreach(var response in batchResponses)
+            {
+                var batchStatusCodes = await response.Response.GetResponsesStatusCodesAsync();
+                foreach(var result in batchStatusCodes)
+                {
+                    statuscodes.Add(result.Key, result.Value);
+                }
+            }
+            return statuscodes;
         }
     }
 }


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #621 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Expose `GetResponsesStatusCodesAsync()` for **BatchResponseContentCollection** and **BatchResponseContent** that allows checking the status codes without creating **HttpResponseMessage** for each step (that has to be disposed)
- Expose `BatchRequestSteps` for **BatchRequestContentCollection** so you can possibly fetch the failed steps to retry, for instance in case of some `429` results in the batch.
- extra constructor for `BatchRequestContentCollection` including the number of requests that may be combined. (At the moment you cannot combine more then 4 requests, when creating TodoTasks, all above 4 fail with 429.) This allows the user to use batching without having to manage smaller batches himself.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://svrooij.io/2023/03/03/batching-in-microsoft-graph/
- Demo code https://github.com/svrooij/msgraph-sdk-dotnet-batching/tree/main/sample/BatchClient
- Video demonstrating batching https://youtu.be/u9buNZxbSNk

@maisarissi I've made batching even better to also support getting the failing steps.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/626)