### PR TITLE
feat: New batch for failed requests

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Graph
 {
     using Microsoft.Kiota.Abstractions;
-    using Microsoft.Kiota.Http.HttpClientLibrary;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -152,6 +151,25 @@ namespace Microsoft.Graph
             }
             return isRemoved;
         }
+
+        /// <summary>
+        /// Creates a new <see cref="BatchRequestContent"/> with all <see cref="BatchRequestStep"/> that failed.
+        /// </summary>
+        /// <param name="responseStatusCodes">A dictionary with response codes, get with batchResponseContent.GetResponsesStatusCodesAsync()</param>
+        /// <returns>new <see cref="BatchRequestContent"/> with all failed requests.</returns>
+        public BatchRequestContent NewBatchWithFailedRequests(Dictionary<string, HttpStatusCode> responseStatusCodes)
+        {
+            var request = new BatchRequestContent(this.RequestAdapter);
+            foreach(var response in responseStatusCodes)
+            {
+                if (BatchRequestSteps.ContainsKey(response.Key) && !BatchResponseContent.IsSuccessStatusCode(response.Value)) {
+                    request.AddBatchRequestStep(BatchRequestSteps[response.Key]);
+                }
+            }
+            return request;
+        }
+
+        
 
         /// <summary>
         /// Get the content of the batchRequest in the form of a stream.

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -4,6 +4,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -140,6 +141,24 @@
 
                 return currentRequest.BatchRequestSteps;
             }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="BatchRequestContentCollection"/> with all <see cref="BatchRequestStep"/> that failed.
+        /// </summary>
+        /// <param name="responseStatusCodes">A dictionary with response codes, get by executing batchResponseContentCollection.GetResponsesStatusCodesAsync()</param>
+        /// <returns>new <see cref="BatchRequestContentCollection"/> with all failed requests.</returns>
+        public BatchRequestContentCollection NewBatchWithFailedRequests(Dictionary<string, HttpStatusCode> responseStatusCodes)
+        {
+            var request = new BatchRequestContentCollection(this.baseClient, batchRequestLimit);
+            var steps = this.BatchRequestSteps;
+            foreach(var response in responseStatusCodes)
+            {
+                if (steps.ContainsKey(response.Key) && !BatchResponseContent.IsSuccessStatusCode(response.Value)) {
+                    request.AddBatchRequestStep(steps[response.Key].Request);
+                }
+            }
+            return request;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContent.cs
@@ -154,6 +154,16 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
+        /// Checks is a <see cref="HttpStatusCode"/> can be marked as successful
+        /// </summary>
+        /// <param name="statusCode">A single <see cref="HttpStatusCode"/>.</param>
+        /// <returns>Returns true if status code is between 200 and 300.</returns>
+        public static bool IsSuccessStatusCode(HttpStatusCode statusCode)
+        {
+            return ((int)statusCode >= 200) && ((int)statusCode <= 299); 
+        }
+
+        /// <summary>
         /// Gets a <see cref="HttpResponseMessage"/> from <see cref="JsonElement"/> representing a batch response item.
         /// </summary>
         /// <param name="jResponseItem">A single batch response item of type <see cref="JsonElement"/>.</param>


### PR DESCRIPTION
### Changes proposed in this pull request
- Add `NewBatchWithFailedRequests` to both **BatchRequestContent** and **BatchRequestContentCollection** accepting the dictionary from `batchResponse.GetResponsesStatusCodesAsync()`


<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1759

I don't know where the docs are, but maybe add something like this.

```csharp
var client = new GraphServiceClient(...);
var batch = new BatchResponseContentCollection(client, 20);

// Add steps here with
await batch.AddRequestStepAsync(....);

// Execute batch
var batchResponse = await client.Batch.PostAsync(batch);

// Get status codes
var responseStatuses = await batchResponse.GetResponsesStatusCodesAsync();

// Validate success
var success = responseStatuses.All(s => BatchResponseContent.IsSuccessStatusCode(s.Value));

// Retry failure (this part in introduced by this pr)
var retryBatch = batch.NewBatchWithFailedRequests(responseStatuses);
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/636)