### PR TITLE
Updates CI pipelines and creates release.

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -43,9 +43,11 @@ steps:
   inputs:
     version: 6.x
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: 'Run CredScan'
   inputs:
+    toolMajorVersion: 'V2'
+    scanFolder: '$(Build.SourcesDirectory)'
     debugMode: false
 
 - task: PowerShell@2
@@ -95,13 +97,14 @@ steps:
     projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj'
     arguments: '-c Release --no-incremental'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
+    Pattern: '**\*Microsoft.Graph.Core.dll'
     signConfigType: inlineSignParams
+    UseMinimatch: true
     inlineOperation: |
      [
          {
@@ -121,12 +124,13 @@ steps:
      ]
     SessionTimeout: 20
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
+    Pattern: '**\*Microsoft.Graph.Core.dll'
+    UseMinimatch: true
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -173,11 +177,12 @@ steps:
     dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration Release
   displayName: dotnet pack
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP NuGet CodeSigning'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
+    UseMinimatch: true
     Pattern: '*nupkg'
     signConfigType: inlineSignParams
     inlineOperation: |

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -42,9 +42,11 @@ steps:
   inputs:
     version: 6.x
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: 'Run CredScan'
   inputs:
+    toolMajorVersion: 'V2'
+    scanFolder: '$(Build.SourcesDirectory)'
     debugMode: false
 
 - task: PowerShell@2
@@ -86,12 +88,13 @@ steps:
     projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj'
     arguments: '-c Release --no-incremental'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core) (AKV)'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
+    Pattern: '**\*Microsoft.Graph.Core.dll'
+    UseMinimatch: true
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -112,12 +115,13 @@ steps:
      ]
     SessionTimeout: 20
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: src/Microsoft.Graph.Core/bin/release
-    Pattern: Microsoft.Graph.Core.dll
+    Pattern: '**\*Microsoft.Graph.Core.dll'
+    UseMinimatch: true
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -164,12 +168,13 @@ steps:
     dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration Release
   displayName: dotnet pack
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: EsrpCodeSigning@2
   displayName: 'ESRP NuGet CodeSigning'
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
     Pattern: '*.nupkg'
+    UseMinimatch: true
     signConfigType: inlineSignParams
     inlineOperation: |
           [

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -20,10 +20,11 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.0.4</VersionPrefix>
+    <VersionPrefix>3.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Updates kiota abstraction library dependencies to for generation updates to reduce code size 
+- Adds support from create a new batch request from failed requests(https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/636)
+- Updates batchReqeust builders to allow passing of error mappings from service libraries.      
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
This PR 

- updates CI build pipelines to latest `EsrpCodeSigning` and `Credscan` tasks
Runs at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=111731&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9 and https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=111732&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=c5f33a6e-0090-51d5-8ebe-807b6dc9ca94
- Bumps library version for new release.
- Updates the BatchRequestBuilder to accept `errorMapping` array to allow for consistent errors. Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1782

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/637)