### PR TITLE
Fixes error on BatchRequestContentCollection.NewBatchWithFailedRequests after request is sent out

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.0.9</VersionPrefix>
+    <VersionPrefix>3.0.10</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fixes regression in url building when the httpClient base addresss is used.   
+- Fixes a bug where BatchRequestContentCollection.NewBatchWithFailedRequests would fail when more than 20 requests had been sent.  
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/UrlHelperTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/UrlHelperTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(0, queryValues.Count);
+            Assert.Empty(queryValues);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(0, queryValues.Count);
+            Assert.Empty(queryValues);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(0, queryValues.Count);
+            Assert.Empty(queryValues);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(1, queryValues.Count);
+            Assert.Single(queryValues);
             Assert.Equal("value", queryValues["key"]);
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(1, queryValues.Count);
+            Assert.Single(queryValues);
             Assert.Equal("value", queryValues["key"]);
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
 
             var queryValues = UrlHelper.GetQueryOptions(uri);
 
-            Assert.Equal(1, queryValues.Count);
+            Assert.Single(queryValues);
             Assert.Equal("value", queryValues["key"]);
         }
     }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
 
                 if (e.Subject.Contains("Subject for next page events"))
                 {
-                    Assert.True(false, "Unexpectedly paged the next page of results.");
+                    Assert.Fail("Unexpectedly paged the next page of results.");
                 }
 
                 return true;
@@ -464,7 +464,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
             }
             catch (Exception)
             {
-                Assert.True(false, "Unexpected exception occurred when next page contains no elements.");
+                Assert.Fail("Unexpected exception occurred when next page contains no elements.");
             }
         }
 


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/657

It fixes a bug where the values of the a single request would be added twice when being marshalled for verification. 

It also updates various tests to remove warnings after the update of the testing package via https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/691

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/693&drop=dogfoodAlpha