### PR TITLE
- bumps java version for sonarcloud to stay on supported version

### DIFF
--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'microsoft'
-          java-version: '11'
+          java-version: '17'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/703&drop=dogfoodAlpha