### PR TITLE
Fixes incomplete uploads due to properties mismatch

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.0.10</VersionPrefix>
+    <VersionPrefix>3.0.11</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fixes a bug where BatchRequestContentCollection.NewBatchWithFailedRequests would fail when more than 20 requests had been sent.  
+- Fixes a bug where large file uploads would not complete due to different cased properties.  
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Models/UploadSession.cs
+++ b/src/Microsoft.Graph.Core/Models/UploadSession.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -39,12 +39,10 @@ namespace Microsoft.Graph.Core.Models
         /// </summary>
         public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
         {
-            return new Dictionary<string, Action<IParseNode>> 
+            return new Dictionary<string, Action<IParseNode>> (StringComparer.OrdinalIgnoreCase)
             {
                 {"expirationDateTime", (n) => { ExpirationDateTime = n.GetDateTimeOffsetValue(); } },
-                {"ExpirationDateTime", (n) => { ExpirationDateTime = n.GetDateTimeOffsetValue(); } },//this is a duplicate to handle for different cased payload.
                 {"nextExpectedRanges", (n) => { NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },
-                {"NextExpectedRanges", (n) => { NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },//this is a duplicate to handle for different cased payload.
                 {"uploadUrl", (n) => { UploadUrl = n.GetStringValue(); } },
             };
         }

--- a/src/Microsoft.Graph.Core/Models/UploadSession.cs
+++ b/src/Microsoft.Graph.Core/Models/UploadSession.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Graph.Core.Models
             return new Dictionary<string, Action<IParseNode>> 
             {
                 {"expirationDateTime", (n) => { ExpirationDateTime = n.GetDateTimeOffsetValue(); } },
+                {"ExpirationDateTime", (n) => { ExpirationDateTime = n.GetDateTimeOffsetValue(); } },//this is a duplicate to handle for different cased payload.
                 {"nextExpectedRanges", (n) => { NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },
+                {"NextExpectedRanges", (n) => { NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },//this is a duplicate to handle for different cased payload.
                 {"uploadUrl", (n) => { UploadUrl = n.GetStringValue(); } },
             };
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Serialization/SerializerTests.cs
@@ -528,6 +528,30 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Serialization
             // Expect the string to be ISO 8601-1:2019 format
             Assert.Equal(expectedString, serializedJsonString);
         }
+        
+        [Fact]
+        public void DeserializeUploadSessionValues()
+        {
+            // Act 1
+            const string camelCasedPayload = @"{""expirationDateTime"":""2016-11-20T18:23:45.9356913+00:00"",""nextExpectedRanges"":[""0 - 1000""],""uploadUrl"":""http://localhost""}";
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(camelCasedPayload));
+            var parseNode = this.parseNodeFactory.GetRootParseNode(CoreConstants.MimeTypeNames.Application.Json, memoryStream);
+            var uploadSession = parseNode.GetObjectValue(UploadSession.CreateFromDiscriminatorValue);
+            Assert.NotNull(uploadSession);
+            Assert.NotNull(uploadSession.ExpirationDateTime);
+            Assert.NotNull(uploadSession.NextExpectedRanges);
+            Assert.Single(uploadSession.NextExpectedRanges);
+            
+            // Act 1
+            const string pascalCasedPayload = @"{""ExpirationDateTime"":""2016-11-20T18:23:45.9356913+00:00"",""NextExpectedRanges"":[""0 - 1000""],""uploadUrl"":""http://localhost""}";
+            var memoryStream2 = new MemoryStream(Encoding.UTF8.GetBytes(pascalCasedPayload));
+            var parseNode2 = this.parseNodeFactory.GetRootParseNode(CoreConstants.MimeTypeNames.Application.Json, memoryStream2);
+            var uploadSession2 = parseNode2.GetObjectValue(UploadSession.CreateFromDiscriminatorValue);
+            Assert.NotNull(uploadSession2);
+            Assert.NotNull(uploadSession2.ExpirationDateTime);
+            Assert.NotNull(uploadSession2.NextExpectedRanges);
+            Assert.Single(uploadSession2.NextExpectedRanges);
+        }
 
         [Fact]
         public void SerializeServiceExceptionValues()


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2092

The uploadSession payload sometimes returns with a property values that are pascal cased. This PR adds a couple of function to the `UploadSession` deserializers to enable uploads to not stop due to missing information. 

cc @GeoffreyYue1

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/719)