### PR TITLE
Fixes errors reported when using the PageIterator

### DIFF
--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Graph
 
             internal static string MissingRetryAfterHeader = "Missing retry after header.";
 
+            internal static string PageIteratorRequestError = "Error occured when making a request with the page iterator. See inner exception for more details.";
+
             public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
         }
     }

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,17 +21,17 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Adds support for trimming
+- Improves error messages when using the page iterator.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <NoWarn>NU5048</NoWarn>
+    <NoWarn>NU5048;NETSDK1202</NoWarn>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <!-- https://github.com/clairernovotny/DeterministicBuilds#deterministic-builds -->

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Tasks/PageIteratorTests.cs
@@ -6,12 +6,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
     using Microsoft.Graph.DotnetCore.Core.Test.TestModels.ServiceModels;
     using Microsoft.Kiota.Abstractions;
+    using Microsoft.Kiota.Abstractions.Authentication;
     using Microsoft.Kiota.Abstractions.Serialization;
+    using Microsoft.Kiota.Serialization.Json;
     using Moq;
     using Xunit;
 
@@ -395,6 +401,61 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Tasks
             Assert.Equal(PagingState.Paused, eventPageIterator.State);
         }
 
+        [Fact]
+        public async Task Given_ApiError_It_Shows_Helpful_Message()
+        {
+            // // Arrange the sample first page of 17 events to initialize the original collection page.
+            var originalPage = new TestEventsResponse() { Value = new List<TestEventItem>(), OdataNextLink = "http://localhost/events?$skip=11" };
+            var inputEventCount = 17;
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                originalPage.Value.Add(new TestEventItem() { Subject = $"Subject{i}" });
+            }
+            bool reachedNextPage = false;
+
+            // Create the delegate to process each entity returned in the pages. The delegate will 
+            // signal that we reached an event in the next page.
+            Func<TestEventItem, bool> processEachEvent = (e) =>
+            {
+                if (e.Subject.Contains("Subject for next page events"))
+                {
+                    reachedNextPage = true;
+                    return false;
+                }
+
+                return true;
+            };
+
+            var errorResponseMessage = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(@"{
+                    ""error"": {
+                        ""code"": ""ErrorInvalidParameter"",
+                        ""message"": ""The parameter is not currently supported on the resource."",
+                        ""innerError"": {
+                            ""request-id"": ""e8a0a3c8-7e8d-4b0b-8a0a-3c87e8d4b0b8"",
+                            ""date"": ""2019-08-01T19:26:29""
+                        }
+                    }
+                }", Encoding.UTF8, CoreConstants.MimeTypeNames.Application.Json)
+            };
+
+            using var testHttpMessageHandler = new TestHttpMessageHandler();
+            testHttpMessageHandler.AddResponseMapping("http://localhost/events?$skip=11",errorResponseMessage);
+            var customBaseClient = new BaseClient(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(),httpClient: GraphClientFactory.Create(finalHandler: testHttpMessageHandler)));
+            ApiClientBuilder.RegisterDefaultDeserializer<JsonParseNodeFactory>();
+
+            // Act by calling the iterator
+            eventPageIterator = PageIterator<TestEventItem, TestEventsResponse>.CreatePageIterator(customBaseClient, originalPage, processEachEvent);
+            var serviceException = await Assert.ThrowsAsync<ServiceException>(() => eventPageIterator.IterateAsync());
+
+            Assert.Equal(ErrorConstants.Messages.PageIteratorRequestError, serviceException.Message);
+            Assert.NotNull(serviceException.InnerException);
+            Assert.Equal("ErrorInvalidParameter : The parameter is not currently supported on the resource.",serviceException.InnerException.Message);
+            Assert.Equal(400,serviceException.ResponseStatusCode);// matching status code
+        }
+        
         [Fact]
         public async Task Given_CollectionPage_It_Detects_Next_Link_Loop()
         {


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/728

Changes include
- Improve error/exceptions thrown when using the pageIterator by allowing one to pass an errorMapping dictionary.
- Refactors serialization tests to use helpers from https://github.com/microsoft/kiota-abstractions-dotnet/pull/141