### PR TITLE
Release pipeline fix

### DIFF
--- a/pipelines/previewBuild.yml
+++ b/pipelines/previewBuild.yml
@@ -43,6 +43,14 @@ steps:
   inputs:
     version: 6.x
 
+- task: PowerShell@2
+  displayName: 'Set Java Home to use Java 11'
+  inputs:
+    targetType: 'inline'
+    script: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+      echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)\bin;$(PATH)"
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: 'Run CredScan'
   inputs:

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -42,6 +42,14 @@ steps:
   inputs:
     version: 6.x
 
+- task: PowerShell@2
+  displayName: 'Set Java Home to use Java 11'
+  inputs:
+    targetType: 'inline'
+    script: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+      echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)\bin;$(PATH)"
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: 'Run CredScan'
   inputs:


### PR DESCRIPTION
Fixes release pipeline to set Java Home to JDK 11 instead of JDK8 

References
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#java

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/779)