### PR TITLE
Release 3.1.5

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -25,6 +25,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
 - Bumps abstraction dependencies to fix url encoding of special characters
+- Bumps abstractions http dependencies to fix `ActicitySource` memory leak when the HttpClientRequestAdapter does not construct the HttpClient internally.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -64,7 +65,7 @@
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.4" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,11 +21,11 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.4</VersionPrefix>
+    <VersionPrefix>3.1.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Bumps abstraction dependencies to fix url encoding of special characters
-- Bumps abstractions http dependencies to fix `ActicitySource` memory leak when the HttpClientRequestAdapter does not construct the HttpClient internally.
+- Bumps JWT dependencies to sucurity vlunerability(https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/792).
+- Fixes ITokenValidable interface to use kiota generated types.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -58,9 +58,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.4" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.5" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />

--- a/src/Microsoft.Graph.Core/Models/ITokenValidable.cs
+++ b/src/Microsoft.Graph.Core/Models/ITokenValidable.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// The collection of validation tokens
         /// </summary>
-        IEnumerable<string> ValidationTokens { get; set; }
+        List<string> ValidationTokens { get; set; }
 
         /// <summary>
         /// The collection of encrypted token bearers
         /// </summary>
-        IEnumerable<T1> Value { get; set; }
+        List<T1> Value { get; set; }
     }
 }


### PR DESCRIPTION
This PR creates the 3.1.5 release

Changes include : 
- Bumps JWT dependencies to sucurity vlunerability(https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/792).
- Fixes ITokenValidable interface to use kiota generated types.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/794)