### PR TITLE
Release 3.1.6

### DIFF
--- a/src/Microsoft.Graph.Core/Helpers/ReadOnlySubStream.cs
+++ b/src/Microsoft.Graph.Core/Helpers/ReadOnlySubStream.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Graph
         private readonly long _endInSuperStream;
         private readonly Stream _superStream;
         private bool _canRead;
+        private bool _canSeek;
         private bool _isDisposed;
 
         public ReadOnlySubStream(Stream superStream, long startPosition, long maxLength)
@@ -30,6 +31,7 @@ namespace Microsoft.Graph
             this._endInSuperStream = startPosition + maxLength;
             this._superStream = superStream;
             this._canRead = true;
+            this._canSeek = true;
             this._isDisposed = false;
         }
 
@@ -55,13 +57,21 @@ namespace Microsoft.Graph
             {
                 ThrowIfDisposed();
 
-                throw new NotSupportedException("seek not support");
+                if(!CanSeek)
+                    throw new NotSupportedException("seek not support");
+
+                if(value > int.MaxValue || value < 0 || value > Length)
+                    throw new ArgumentOutOfRangeException("value is out of range");
+
+                // update the position in base stream and seek to that position
+                _positionInSuperStream = value + _startInSuperStream;
+                _superStream.Seek(_positionInSuperStream, SeekOrigin.Begin);
             }
         }
 
         public override bool CanRead => _superStream.CanRead && _canRead;
 
-        public override bool CanSeek => false;
+        public override bool CanSeek => _superStream.CanSeek && _canSeek;
 
         public override bool CanWrite => false;
 
@@ -102,13 +112,26 @@ namespace Microsoft.Graph
         public override long Seek(long offset, SeekOrigin origin)
         {
             ThrowIfDisposed();
-            throw new NotSupportedException("seek not support");
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    Position = offset;
+                    break;
+                case SeekOrigin.Current:
+                    Position += offset;
+                    break;
+                case SeekOrigin.End:
+                    Position = Length - offset;
+                    break;
+            }
+            
+            return Position;
         }
 
         public override void SetLength(long value)
         {
             ThrowIfDisposed();
-            throw new NotSupportedException("seek and write not support");
+            throw new NotSupportedException("write not support");
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,10 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.3</VersionPrefix>
+    <VersionPrefix>3.1.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Fixes a bug when getting failed batch requests with a body.
+- Bumps abstraction dependencies to fix url encoding of special characters
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -59,7 +59,7 @@
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.2" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.4" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -25,6 +25,7 @@
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
 - Bumps abstraction dependencies to fix url encoding of special characters
+- Bumps abstractions http dependencies to fix `ActicitySource` memory leak when the HttpClientRequestAdapter does not construct the HttpClient internally.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -64,7 +65,7 @@
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.3.4" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,11 +21,11 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.4</VersionPrefix>
+    <VersionPrefix>3.1.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Bumps abstraction dependencies to fix url encoding of special characters
-- Bumps abstractions http dependencies to fix `ActicitySource` memory leak when the HttpClientRequestAdapter does not construct the HttpClient internally.
+- Bumps JWT dependencies to sucurity vlunerability(https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/792).
+- Fixes ITokenValidable interface to use kiota generated types.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -58,9 +58,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.4" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.5" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.1.1" />

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -21,11 +21,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.5</VersionPrefix>
+    <VersionPrefix>3.1.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Bumps JWT dependencies to sucurity vlunerability(https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/792).
-- Fixes ITokenValidable interface to use kiota generated types.
+- ReadOnlySubstream is seekable to be compatible with RetryHandler.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph.Core/Models/ITokenValidable.cs
+++ b/src/Microsoft.Graph.Core/Models/ITokenValidable.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// The collection of validation tokens
         /// </summary>
-        IEnumerable<string> ValidationTokens { get; set; }
+        List<string> ValidationTokens { get; set; }
 
         /// <summary>
         /// The collection of encrypted token bearers
         /// </summary>
-        IEnumerable<T1> Value { get; set; }
+        List<T1> Value { get; set; }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/ReadOnlySubStreamTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/ReadOnlySubStreamTests.cs
@@ -1,0 +1,93 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers
+{
+    public class ReadOnlySubStreamTests
+    {
+        private readonly Stream _baseStream;
+        private readonly List<string> _segments = new List<string>() 
+        {
+            "1234567890","0987654321","1357924680","2468013579"
+        };
+
+        public ReadOnlySubStreamTests()
+        {
+            _baseStream = new MemoryStream();
+            var writer = new StreamWriter(_baseStream);
+            foreach (var segment in _segments)
+            {
+                writer.Write(segment);
+            }
+            writer.Flush();
+            _baseStream.Position = 0;
+        }
+
+        [Fact]
+        public void SubstreamsAreReadableOnce()
+        {
+            long startIndex = 0;
+            foreach (var segment in _segments)
+            {
+                using var substream = new ReadOnlySubStream(_baseStream, startIndex, 10);
+                startIndex += substream.Length;
+                using var streamReader = new StreamReader(substream);
+                var readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment, readBytes);
+            }
+        }
+
+        [Fact]
+        public void SubstreamsAreReadableMultipleTimes()
+        {
+            long startIndex = 0;
+            foreach (var segment in _segments)
+            {
+                using var substream = new ReadOnlySubStream(_baseStream, startIndex, 10);
+                startIndex += substream.Length;
+                using var streamReader = new StreamReader(substream);
+
+                var readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment, readBytes);
+
+                // reset stream and read again
+                substream.Position = 0;
+                readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment, readBytes);
+            }
+        }
+
+        [Fact]
+        public void SubstreamsAreReadableFromDifferentPositionsTimes()
+        {
+            long startIndex = 0;
+            foreach (var segment in _segments)
+            {
+                using var substream = new ReadOnlySubStream(_baseStream, startIndex, 10);
+                startIndex += substream.Length;
+                using var streamReader = new StreamReader(substream);
+
+                var readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment, readBytes);
+
+                // reset stream to middle and read again
+                substream.Seek(5,SeekOrigin.Begin);
+                readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment[5..], readBytes);
+
+                // reset stream and read again
+                substream.Position = 0;
+                readBytes = streamReader.ReadToEnd();
+                Assert.Equal(segment, readBytes);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -25,7 +25,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
    <ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -25,7 +25,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit" Version="2.6.5" />
     <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
    <ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -25,7 +25,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit" Version="2.6.4" />
     <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
   </ItemGroup>
    <ItemGroup>


### PR DESCRIPTION
This PR creates the 3.1.6 release

Changes include
- ReadOnlySubstream is seekable to be compatible with RetryHandler via #797 
- Dependabot updates via #795 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/798)