### PR TITLE
Use `IRequestAdapter` in `BatchRequestContentCollection`

### DIFF
--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -39,13 +39,13 @@ jobs:
           languages: csharp
 
       - name: Install needed dotnet workloads
-        run: dotnet workload restore ${{ env.solutionName }}
+        run: dotnet workload install android macos ios maccatalyst
 
       - name: Restore nuget dependencies
         run: dotnet restore ${{ env.solutionName }}
 
       - name: Build
-        run: dotnet build ${{ env.solutionName }} --no-restore -c Debug /p:UseSharedCompilation=false
+        run: dotnet build ${{ env.solutionName }} -c Debug /p:UseSharedCompilation=false,IncludeMauiTargets=true
 
       - name: Test
         run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Debug /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,156 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project does adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.10] - 2024-03-28
+
+### Changed
+
+- Updates the Kiota dependencies to the latest version.
+- Updates `BatchRequestContentCollection` constructor to accept `IRequestAdapter` to unlock self serve scenarios [#815](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/815)
+
+## [3.1.9] - 2024-03-18
+
+### Changed
+
+- Updates the Kiota dependencies to the latest version.
+- Cleans up unreferenced dependencies [#809](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/809)
+
+## [3.1.8] - 2024-02-16
+
+### Changed
+
+- Updates the Kiota dependencies to the latest version.
+- Add null-checks to properties of ServiceException when IsMatch is called to prevent a NullReferenceException
+
+## [3.1.7] - 2024-02-09
+
+### Changed
+
+- Updates the Kiota dependencies to the latest version.
+
+## [3.1.6] - 2024-01-23
+
+### Changed
+
+- ReadOnlySubstream is seekable to be compatible with RetryHandler.
+
+## [3.1.5] - 2024-01-15
+
+### Changed
+
+- Bumps JWT dependencies to security vulnerability [#792](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/792).
+- Fixes `ITokenValidable` interface to use kiota generated types.
+
+## [3.1.4] - 2024-01-09
+
+### Changed
+
+- Bumps abstraction dependencies to fix url encoding of special characters
+- Bumps abstractions http dependencies to fix `ActivitySource` memory leak when the HttpClientRequestAdapter does not construct the HttpClient internally.
+
+## [3.1.3] - 2023-11-29
+
+### Changed
+
+- Fixes a bug when getting failed batch requests with a body.
+
+## [3.1.2] - 2023-11-15
+
+### Changed
+
+- Updates Kiota dependencies for support of NET8.0
+
+## [3.1.1] - 2023-11-07
+
+### Changed
+
+- Improves error messages when using the page iterator.
+
+## [3.1.0] - 2023-10-24
+
+### Added
+
+- Adds support for trimming in .NET.
+
+## [3.0.11] - 2023-09-05
+
+### Changed
+
+- Fixes a bug where large file uploads would not complete due to different cased properties.
+
+## [3.0.10] - 2023-08-08
+
+### Changed
+
+- Fixes a bug where BatchRequestContentCollection.NewBatchWithFailedRequests would fail when more than 20 requests had been sent.
+
+## [3.0.9] - 2023-06-29
+
+### Changed
+
+- Fixes regression in url building when the httpClient base address is used.
+
+## [3.0.8] - 2023-06-27
+
+### Changed
+
+- Fixes nextLink loop exception when making delta requests with the page iterator [#1948](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1948)
+- Bumps kiota abstraction packages to fix bugs in Backing store and allow large stream downloads.
+
+## [3.0.7] - 2023-05-30
+
+### Changed
+
+- Bumps up abstractions packages for Backing store fixes involving nested properties
+- Includes graph.microsoft-ppe.com in Azure Identity default token provider.
+
+## [3.0.6] - 2023-04-18
+
+### Added
+
+- Include Request headers in APIException instances
+
+## [3.0.5] - 2023-03-30
+
+### Added
+
+- Adds support from create a new batch request from failed requests [#636](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/636)
+- Updates Batch Request builders to allow passing of error mappings from service libraries.
+
+## [3.0.4] - 2023-03-27
+
+### Changed
+
+- Updates kiota abstraction library dependencies to for generation updates to reduce code size
+
+## [3.0.3] - 2023-03-21
+
+### Changed
+
+- Allows checking for status codes without parsing request bodies in batch requests [#626](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/626)
+- Updates Kiota abstraction library dependencies to fix serialization errors.
+
+## [3.0.2] - 2023-03-13
+
+### Changed
+
+- Fixes missing delta link after completed iteration in the PageIterator [#619](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/619)
+- Updates Kiota abstraction library dependencies
+
+## [3.0.1] - 2023-03-07
+
+### Added
+
+- Adds support for enhanced batch requests [#612](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/612)
+
+## [3.0.0] - 2023-02-28
+
+### Added
+
+- GA Release supporting Kiota generated SDKs

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Microsoft Graph .NET Core Client Library
-[![Build Status](https://o365exchange.visualstudio.com/O365%20Sandbox/_apis/build/status/Microsoft%20Graph/.Net/msgraph-sdk-dotnet-build-and-packaging-core?branchName=dev)](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/latest?definitionId=1410&branchName=dev)
+
+[![Build Status](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_apis/build/status%2FDotnet%2FDotnet%20Core%20Production?repoName=microsoftgraph%2Fmsgraph-sdk-dotnet-core&branchName=andrueastman%2FContributions)](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/latest?definitionId=197&repoName=microsoftgraph%2Fmsgraph-sdk-dotnet-core&branchName=andrueastman%2FContributions)
 [![NuGet Version](https://buildstats.info/nuget/Microsoft.Graph.Core)](https://www.nuget.org/packages/Microsoft.Graph.Core/)
 
 Integrate the [Microsoft Graph API](https://graph.microsoft.com) into your .NET
 project!
 
-The Microsoft Graph .NET Core Client Library contains core classes and interfaces used by [Microsoft.Graph Client Library](https://github.com/microsoftgraph/msgraph-sdk-dotnet) to send native HTTP requests to [Microsoft Graph API](https://graph.microsoft.com). The core client library targets .NetStandard 1.1 and .Net Framework 4.5.
+The Microsoft Graph .NET Core Client Library contains core classes and interfaces used by [Microsoft.Graph Client Library](https://github.com/microsoftgraph/msgraph-sdk-dotnet) to send native HTTP requests to [Microsoft Graph API](https://graph.microsoft.com). The latest core client library targets .NetStandard 2.0.
 
 ## Installation via NuGet
 
@@ -67,6 +68,7 @@ if (response.IsSuccessStatusCode)
 ```
 
 ## Documentation and resources
+
 * [Microsoft Graph API](https://graph.microsoft.com)
 * [Release notes](https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/releases)
 
@@ -88,9 +90,11 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 If you are looking to build the library locally for the purposes of contributing code or running tests, you will need to:
 
-- Have the .NET Core SDK (> 1.0) installed
-- Run `dotnet restore` from the command line in your package directory
-- Run `nuget restore` and `msbuild` from CLI or run Build from Visual Studio to restore Nuget packages and build the project
+* Have the .NET Core SDK (> 1.0) installed
+* Run `dotnet restore` from the command line in your package directory
+* Run `nuget restore` and `msbuild` from CLI or run Build from Visual Studio to restore Nuget packages and build the project
+
+> Run `dotnet build -p:IncludeMauiTargets=true` if you wish to build the MAUI targets for the projects as well.
 
 ## License
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.417", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
-    "rollForward": "latestMinor"
+    "rollForward": "major"
   }
 }

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -73,8 +73,8 @@ extends:
             pwsh: true
           enabled: true
         - powershell: |
-            dotnet workload restore $(Build.SourcesDirectory)\Microsoft.Graph.Core.sln
-          displayName: 'dotnet workload restore'
+            dotnet workload install android macos ios maccatalyst 
+          displayName: 'Install needed dotnet workloads'
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
           inputs:
@@ -97,7 +97,7 @@ extends:
           displayName: 'dotnet build'
           inputs:
             projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj'
-            arguments: '-c Release --no-incremental'
+            arguments: '-c Release --no-incremental -p:IncludeMauiTargets=true'
         - task: EsrpCodeSigning@3
           displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core) (AKV)'
           inputs:

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -5,7 +5,6 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Core Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net462;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos;net6.0-windows</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Core</AssemblyName>
@@ -21,10 +20,10 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.1.9</VersionPrefix>
+    <VersionPrefix>3.1.10</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageReleaseNotes>
-- Cleans up unreferenced dependencies [https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/809] 
+- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/blob/dev/CHANGELOG.md
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -34,6 +33,19 @@
     <NoWarn>NU5048;NETSDK1202</NoWarn>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
+  <!-- By default let the Maui targets be excluded to make contribution for external parties easier and dependabot updates. They can be enabled by adding `-p:IncludeMauiTargets=true` to the target build/restore command which is done in the CI.-->
+  <Choose>
+    <When Condition="'$(IncludeMauiTargets)'=='true'">
+      <PropertyGroup>
+        <TargetFrameworks Condition="">netstandard2.0;net462;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos;net6.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks Condition="">netstandard2.0;net462;net6.0;</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <!-- https://github.com/clairernovotny/DeterministicBuilds#deterministic-builds -->
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Microsoft.Graph.Core/global.json
+++ b/src/Microsoft.Graph.Core/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.417", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
-    "rollForward": "latestMinor"
+    "rollForward": "major"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/815

Add a new constructor to the `BatchRequestContentCollection` class to also take a `IRequestAdapter` to unlock scenarios using self serve.

Other changes include
- Adds CHANGELOG.md file to the repo for tracking changes made to the code.
- Updates the csproj file to exclude MAUI targets by for easier to local development and unlock dependabot updates(currently failing due to environment not installing them and should fix https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/801 ). These targets are still built in CI for the PR checks and release pipelines and can be built locally by running -`dotnet build p:IncludeMauiTargets=true`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/818)