### PR TITLE
ci/dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
+  directories:
+    - "**/*"
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
     kiota-dependencies:
       patterns:
         - "*kiota*"
+    xunit:
+      patterns:
+        - xunit*
+    coverlet:
+      patterns:
+        - coverlet*
+    mstest:
+      patterns:
+        - Microsoft.NET.Test.Sdk
+        - Microsoft.TestPlatform.ObjectModel
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
- **ci: adds test groups to dependabot configuration**
- **fix: use directories for dependabot configuration**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/855)