### PR TITLE
ci: removes branch protection rule for old feature branch

### DIFF
--- a/.github/policies/msgraph-sdk-dotnet-core-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-core-branch-protection.yml
@@ -78,38 +78,3 @@ configuration:
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews. boolean
     restrictsReviewDismissals: false
-
-  - branchNamePattern: feature/3.0
-    # This branch pattern applies to the following branches:
-    # feature/3.0
-
-    # Specifies whether this branch can be deleted. boolean
-    allowsDeletions: false
-    # Specifies whether forced pushes are allowed on this branch. boolean
-    allowsForcePushes: false
-    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: true
-    # Specifies whether admins can overwrite branch protection. boolean
-    isAdminEnforced: false
-    # Indicates whether "Require a pull request before merging" is enabled. boolean
-    requiresPullRequestBeforeMerging: true
-    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
-    requiredApprovingReviewsCount: 1
-    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: true
-    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
-    requiresCommitSignatures: false
-    # Are conversations required to be resolved before merging? boolean
-    requiresConversationResolution: true
-    # Are merge commits prohibited from being pushed to this branch. boolean
-    requiresLinearHistory: false
-    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks:
-    - Build and Test # Contains CodeQL
-    # Require branches to be up to date before merging. boolean
-    requiresStrictStatusChecks: true
-    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
-    restrictsPushes: false
-    # Restrict who can dismiss pull request reviews. boolean
-    restrictsReviewDismissals: false
-


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/873)