### PR TITLE
feat: Add option to specify requestId manually when calling AddBatchRequestStepAsync()

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Graph
         {
             if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
                 throw new ArgumentException(string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests));
-            if (requestId == null)
+            if (string.IsNullOrEmpty(requestId))
             {
                 requestId = Guid.NewGuid().ToString();
             }

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -130,13 +130,17 @@ namespace Microsoft.Graph
         /// Adds a <see cref="RequestInformation"/> to batch request content
         /// </summary>
         /// <param name="requestInformation">A <see cref="RequestInformation"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
+        /// <param name="requestId">An optional string that will be used as the requestId of the batch request</param>
         /// <returns>The requestId of the  newly created <see cref="BatchRequestStep"/></returns>
         [Obsolete("Please use the BatchRequestContentCollection for making batch requests as it supports handling more than 20 requests and provides a similar API experience.")]
-        public async Task<string> AddBatchRequestStepAsync(RequestInformation requestInformation)
+        public async Task<string> AddBatchRequestStepAsync(RequestInformation requestInformation, string requestId = null)
         {
             if (BatchRequestSteps.Count >= CoreConstants.BatchRequest.MaxNumberOfRequests)
                 throw new ArgumentException(string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests));
-            string requestId = Guid.NewGuid().ToString();
+            if (requestId == null)
+            {
+                requestId = Guid.NewGuid().ToString();
+            }
             var requestMessage = await RequestAdapter.ConvertToNativeRequestAsync<HttpRequestMessage>(requestInformation);
             BatchRequestStep batchRequestStep = new BatchRequestStep(requestId, requestMessage);
             (BatchRequestSteps as IDictionary<string, BatchRequestStep>)!.Add(batchRequestStep.RequestId, batchRequestStep);

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -101,12 +101,13 @@ namespace Microsoft.Graph
         /// Adds a <see cref="RequestInformation"/> to batch request content
         /// </summary>
         /// <param name="requestInformation">A <see cref="RequestInformation"/> to use to build a <see cref="BatchRequestStep"/> to add.</param>
+        /// <param name="requestId">An optional string that will be used as the requestId of the batch request</param>
         /// <returns>The requestId of the  newly created <see cref="BatchRequestStep"/></returns>
-        public Task<string> AddBatchRequestStepAsync(RequestInformation requestInformation)
+        public Task<string> AddBatchRequestStepAsync(RequestInformation requestInformation, string requestId = null)
         {
             SetupCurrentRequest();
 #pragma warning disable CS0618
-            return currentRequest.AddBatchRequestStepAsync(requestInformation);
+            return currentRequest.AddBatchRequestStepAsync(requestInformation, requestId);
 #pragma warning restore CS0618
         }
 


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #871 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Adding optional parameter `requestId` to `AddBatchRequestStepAsync()` function to allow manual configiguration of requestId on BatchRequests (See reasoning on issue #871 for details)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/887)