### PR TITLE
fix: Fixing code scanning alert on AAD issuer validation

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
+++ b/src/Microsoft.Graph.Core/Extensions/ITokenValidableExtension.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Graph
     using Microsoft.IdentityModel.Protocols.OpenIdConnect;
     using Microsoft.IdentityModel.Tokens;
     using Microsoft.IdentityModel.Protocols;
+    using Microsoft.IdentityModel.Validators;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -65,7 +66,7 @@ namespace Microsoft.Graph
         {
             try
             {
-                handler.ValidateToken(token, new TokenValidationParameters
+                var tokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,
                     ValidateAudience = true,
@@ -74,7 +75,9 @@ namespace Microsoft.Graph
                     ValidIssuers = issuersToValidate,
                     ValidAudiences = appIds,
                     IssuerSigningKeys = openIdConfig.SigningKeys
-                }, out _);
+                };
+                tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+                handler.ValidateToken(token,  tokenValidationParameters, out _);
             }
             catch
             {

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -63,14 +63,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.11.3" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.11.3" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.11.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.11.2" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.11.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.11.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.11.3" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.11.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.11.2" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.11.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="[6.0,9.0)" />


### PR DESCRIPTION
Fixes code scanning alerts on AAD issuer validation according to docs at https://identitydivision.visualstudio.com/DevEx/_wiki/wikis/DevEx.wiki/54311/Validate-the-AAD-key-issuer-if-you-use-IdentityModel-directly-to-validate-Azure-AD-tokens and alerts raised at https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/security/code-scanning


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/888)