### PR TITLE
ci: fixing double tagging and GH releases

### DIFF
--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -286,13 +286,11 @@ extends:
                   inputs:
                     gitHubConnection: 'Kiota_Release'
                     target: $(Build.SourceVersion)
-                    tagSource: userSpecifiedTag
-                    tag: 'v$(VERSION_STRING)'
-                    title: '$(VERSION_STRING)'
-                    releaseNotesSource: inline
+                    repositoryName: '$(Build.Repository.Name)'
+                    action: edit
+                    tag: $(VERSION_STRING)
+                    addChangeLog: false
+                    assetUploadMode: replace
                     assets: |
                       !**/**
                       $(Pipeline.Workspace)/Microsoft.Graph.Core.*.*nupkg
-                    changeLogType: issueBased
-                    isPreRelease: '$(IS_PRE_RELEASE)'
-                    addChangeLog: true


### PR DESCRIPTION
Release please already creates a GH release so the release pipeline should simply edit this by uploading the artifacts to it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/890)