### PR TITLE
Fix/batch steps order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 .idea/
+
+.mono/

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Graph
             bool isRemoved = false;
             if (BatchRequestSteps.ContainsKey(requestId)) {
                 (BatchRequestSteps as IDictionary<string, BatchRequestStep>).Remove(requestId);
+                OrderedBatchRequestIds.Remove(requestId);
                 isRemoved = true;
                 foreach (KeyValuePair<string, BatchRequestStep> batchRequestStep in BatchRequestSteps)
                 {

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Graph
             return currentRequest.AddBatchRequestStep(batchRequestStep);
 #pragma warning restore CS0618
         }
-        
+
         /// <summary>
         /// Adds a <see cref="HttpRequestMessage"/> to batch request content.
         /// </summary>
@@ -152,10 +152,10 @@ namespace Microsoft.Graph
             {
                 if (batchRequests.Count > 0)
                 {
-                    IEnumerable<KeyValuePair<string, BatchRequestStep>> result = batchRequests.Contains(currentRequest) ? 
-                        new List<KeyValuePair<string, BatchRequestStep>>() 
+                    IEnumerable<KeyValuePair<string, BatchRequestStep>> result = batchRequests.Contains(currentRequest) ?
+                        new List<KeyValuePair<string, BatchRequestStep>>()
                         : currentRequest.BatchRequestSteps;
-                    
+
                     foreach ( var request in batchRequests)
                     {
                         result = result.Concat(request.BatchRequestSteps);

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Graph;
 

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph;
+
+/// <summary>
+/// Represents a collection of ordered <see cref="BatchRequestStep"/> objects.
+/// </summary>
+public class BatchRequestContentSteps : IReadOnlyDictionary<string, BatchRequestStep>, IDictionary<string, BatchRequestStep>
+{
+    private readonly Dictionary<string, BatchRequestStep> _steps;
+
+    private readonly List<string> _requestIds;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BatchRequestContentSteps"/> class which keeps track of the order of the steps.
+    /// </summary>
+    public BatchRequestContentSteps()
+    {
+        _steps = new Dictionary<string, BatchRequestStep>();
+        _requestIds = new List<string>();
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="BatchRequestStep"/> with the specified key.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public BatchRequestStep this[string key]
+    {
+        get => _steps[key];
+        set => Add(key, value);
+    }
+
+    /// <summary>
+    /// Gets the keys in the collection.
+    /// </summary>
+    public ICollection<string> Keys => _requestIds;
+
+    /// <summary>
+    ///  Gets the values in the collection.
+    /// </summary>
+    public ICollection<BatchRequestStep> Values
+    {
+        get
+        {
+            List<BatchRequestStep> values = new List<BatchRequestStep>();
+            foreach (var key in _requestIds)
+            {
+                values.Add(_steps[key]);
+            }
+            return values;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of elements in the collection.
+    /// </summary>
+    public int Count => _requestIds.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the collection is read-only.
+    /// </summary>
+    public bool IsReadOnly => true;
+
+    IEnumerable<string> IReadOnlyDictionary<string, BatchRequestStep>.Keys => throw new NotImplementedException();
+
+    IEnumerable<BatchRequestStep> IReadOnlyDictionary<string, BatchRequestStep>.Values => throw new NotImplementedException();
+
+    /// <summary>
+    /// Adds a <see cref="BatchRequestStep"/> to the collection.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    public void Add(string key, BatchRequestStep value)
+    {
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentNullException(nameof(key));
+
+        _steps.Add(key, value);
+        _requestIds.Add(key);
+    }
+
+    /// <summary>
+    /// Adds a <see cref="BatchRequestStep"/> to the collection.
+    /// </summary>
+    /// <param name="item"></param>
+    public void Add(KeyValuePair<string, BatchRequestStep> item)
+    {
+        Add(item.Key, item.Value);
+    }
+
+    /// <summary>
+    /// Clears the collection.
+    /// </summary>
+    public void Clear()
+    {
+        _steps.Clear();
+        _requestIds.Clear();
+    }
+
+    /// <summary>
+    /// Determines whether the collection contains a specific value.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public bool Contains(KeyValuePair<string, BatchRequestStep> item)
+    {
+        if (!_steps.ContainsKey(item.Key))
+        {
+            return false;
+        }
+        return _steps[item.Key] == item.Value;
+    }
+
+    /// <summary>
+    /// Determines whether the collection contains a specific key.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public bool ContainsKey(string key)
+    {
+        return _steps.ContainsKey(key);
+    }
+
+    /// <summary>
+    /// Copies the elements of the collection to an array, starting at a particular array index.
+    /// </summary>
+    /// <param name="array"></param>
+    /// <param name="arrayIndex"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public void CopyTo(KeyValuePair<string, BatchRequestStep>[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        if (arrayIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+
+        if (array.Length - arrayIndex < _steps.Count)
+            throw new ArgumentException("The number of elements in the source collection is greater than the available space from arrayIndex to the end of the destination array.");
+
+        foreach (var key in _requestIds)
+        {
+            array[arrayIndex] = new KeyValuePair<string, BatchRequestStep>(key, _steps[key]);
+            arrayIndex++;
+        }
+    }
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the collection.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator<KeyValuePair<string, BatchRequestStep>> GetEnumerator()
+    {
+        return new BatchRequestStepEnumerator(_requestIds, _steps);
+    }
+
+    /// <summary>
+    /// Removes the <see cref="BatchRequestStep"/> with the specified key from the collection.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public bool Remove(string key)
+    {
+        if (_steps.ContainsKey(key))
+        {
+            _steps.Remove(key);
+            _requestIds.Remove(key);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Removes the <see cref="BatchRequestStep"/> with the specified key from the collection.
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public bool Remove(KeyValuePair<string, BatchRequestStep> item)
+    {
+        return Remove(item.Key);
+    }
+
+    /// <summary>
+    /// Tries to get the value associated with the specified key.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public bool TryGetValue(string key, out BatchRequestStep value)
+    {
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentNullException(nameof(key));
+
+        if (_steps.ContainsKey(key))
+        {
+            value = _steps[key];
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private sealed class BatchRequestStepEnumerator : IEnumerator<KeyValuePair<string, BatchRequestStep>>
+    {
+        private int _currentRequestIdIndex = -1;
+        private readonly List<string> _requestIds;
+        private readonly Dictionary<string, BatchRequestStep> _steps;
+
+        public BatchRequestStepEnumerator(List<string> requestIds, Dictionary<string, BatchRequestStep> steps)
+        {
+            _requestIds = requestIds;
+            _steps = steps;
+        }
+
+        public KeyValuePair<string, BatchRequestStep> Current
+        {
+            get {
+                if (_currentRequestIdIndex < 0 || _currentRequestIdIndex >= _requestIds.Count)
+                {
+                    throw new InvalidOperationException();
+                }
+                var key = _requestIds[_currentRequestIdIndex];
+                return new KeyValuePair<string, BatchRequestStep>(key, _steps[key]);
+            }
+        }
+        object IEnumerator.Current => Current;
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        public bool MoveNext()
+        {
+
+            _currentRequestIdIndex++;
+            return _currentRequestIdIndex <= _requestIds.Count - 1;
+        }
+
+        public void Reset()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentSteps.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Graph;
 /// <summary>
 /// Represents a collection of ordered <see cref="BatchRequestStep"/> objects.
 /// </summary>
-public class BatchRequestContentSteps : IReadOnlyDictionary<string, BatchRequestStep>, IDictionary<string, BatchRequestStep>
+internal class BatchRequestContentSteps : IReadOnlyDictionary<string, BatchRequestStep>, IDictionary<string, BatchRequestStep>
 {
     private readonly Dictionary<string, BatchRequestStep> _steps;
 
@@ -64,9 +64,9 @@ public class BatchRequestContentSteps : IReadOnlyDictionary<string, BatchRequest
     /// </summary>
     public bool IsReadOnly => true;
 
-    IEnumerable<string> IReadOnlyDictionary<string, BatchRequestStep>.Keys => throw new NotImplementedException();
+    IEnumerable<string> IReadOnlyDictionary<string, BatchRequestStep>.Keys => Keys.AsEnumerable();
 
-    IEnumerable<BatchRequestStep> IReadOnlyDictionary<string, BatchRequestStep>.Values => throw new NotImplementedException();
+    IEnumerable<BatchRequestStep> IReadOnlyDictionary<string, BatchRequestStep>.Values => Values.AsEnumerable();
 
     /// <summary>
     /// Adds a <see cref="BatchRequestStep"/> to the collection.

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentStepsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentStepsTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content;
+
+public class BatchRequestContentStepsTests
+{
+    private readonly BatchRequestContentSteps _steps;
+
+    public BatchRequestContentStepsTests()
+    {
+        _steps = new BatchRequestContentSteps();
+        _steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        _steps["2"] = new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me"));
+        _steps["uuid-123"] = new BatchRequestStep("uuid-123", new HttpRequestMessage(HttpMethod.Patch, "https://graph.microsoft.com/v1.0/me"));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Indexer_Get_ReturnsValue()
+    {
+        Assert.Equal("1", _steps["1"].RequestId);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Keys_ReturnsKeysInInsertionOrder()
+    {
+        var keys = _steps.Keys.ToList();
+        Assert.True(keys.Count == 3);
+        Assert.Equal("1", keys[0]);
+        Assert.Equal("2", keys[1]);
+        Assert.Equal("uuid-123", keys[2]);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Values_ReturnsValuesInInsertionOrder()
+    {
+        var values = _steps.Values.ToList();
+        Assert.True(values.Count == 3);
+        Assert.Equal("1", values[0].RequestId);
+        Assert.Equal("2", values[1].RequestId);
+        Assert.Equal("uuid-123", values[2].RequestId);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Count_ReturnsCount()
+    {
+        Assert.Equal(3, _steps.Count);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_IsReadOnly_ReturnsTrue()
+    {
+        Assert.True(_steps.IsReadOnly);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Add_ThrowsExceptionOnDuplicateValue()
+    {
+        Assert.Throws<ArgumentException>(() => _steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me"))));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Add_ThrowsExceptionOnNullKey()
+    {
+        Assert.Throws<ArgumentNullException>(() => _steps.Add(null, new BatchRequestStep("3", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me"))));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Add_ThrowsExceptionOnEmptyKey()
+    {
+        Assert.Throws<ArgumentNullException>(() => _steps.Add(string.Empty, new BatchRequestStep("3", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me"))));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Contains_ReturnsFalse()
+    {
+        Assert.DoesNotContain(new KeyValuePair<string, BatchRequestStep>("4", new BatchRequestStep("4", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me"))), _steps);
+        Assert.DoesNotContain(new KeyValuePair<string, BatchRequestStep>("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me"))), _steps);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_ContainsKey_ReturnsTrue()
+    {
+        Assert.True(_steps.ContainsKey("1"));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_ContainsKey_ReturnsFalse()
+    {
+        Assert.False(_steps.ContainsKey("4"));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Remove_ReturnsTrue()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        Assert.True(steps.Remove("1"));
+        Assert.False(steps.ContainsKey("1"));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Remove_ReturnsFalse()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        Assert.False(steps.Remove("2"));
+        Assert.True(steps.ContainsKey("1"));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_TryGetValue_ReturnsTrue()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        Assert.True(steps.TryGetValue("1", out var value));
+        Assert.Equal("1", value.RequestId);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_TryGetValue_ReturnsFalse()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        Assert.False(steps.TryGetValue("2", out var value));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Clear_RemovesAllItems()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        steps.Add("2", new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        steps.Clear();
+        Assert.True(steps.Count == 0);
+        Assert.True(steps.Keys.Count == 0);
+        Assert.True(steps.Values.Count == 0);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_CopyTo_CopiesItems()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        steps.Add("2", new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        var array = new KeyValuePair<string, BatchRequestStep>[2];
+        steps.CopyTo(array, 0);
+        Assert.Equal("1", array[0].Key);
+        Assert.Equal("2", array[1].Key);
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_CopyTo_ThrowsExceptionOnNullArray()
+    {
+        var steps = new BatchRequestContentSteps();
+        Assert.Throws<ArgumentNullException>(() => steps.CopyTo(null, 0));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_CopyTo_ThrowsExceptionOnNegativeArrayIndex()
+    {
+        var steps = new BatchRequestContentSteps();
+        Assert.Throws<ArgumentOutOfRangeException>(() => steps.CopyTo(new KeyValuePair<string, BatchRequestStep>[2], -1));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_CopyTo_ThrowsExceptionOnInsufficientArraySpace()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        Assert.Throws<ArgumentException>(() => steps.CopyTo(new KeyValuePair<string, BatchRequestStep>[1], 1));
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Enumerator_ReturnsItems()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        steps.Add("2", new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        foreach (var item in steps)
+        {
+            Assert.True(item.Key == "1" || item.Key == "2");
+        }
+    }
+
+    [Fact]
+    public void BatchRequestContentSteps_Enumerator_ReturnsItemsInInsertionOrder()
+    {
+        var steps = new BatchRequestContentSteps();
+        steps.Add("1", new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        steps.Add("2", new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me")));
+        var enumerator = steps.GetEnumerator();
+        enumerator.MoveNext();
+        Assert.Equal("1", enumerator.Current.Key);
+        enumerator.MoveNext();
+        Assert.Equal("2", enumerator.Current.Key);
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             BatchRequestStep batchRequestStep2 = new BatchRequestStep("2", new HttpRequestMessage(HttpMethod.Get, REQUEST_URL), new List<string> { "3" });
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => new BatchRequestContent(client, batchRequestStep1, batchRequestStep2));
-            
+
             Assert.Equal(ErrorConstants.Messages.InvalidDependsOnRequestId, ex.Message);
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             // Arrange
             BatchRequestStep batchRequestStep = new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, REQUEST_URL));
             BatchRequestContent batchRequestContent = new BatchRequestContent(client);
-            
+
             // Act
             Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
             bool isSuccess = batchRequestContent.AddBatchRequestStep(batchRequestStep);
@@ -196,14 +196,14 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             }
 
             batchRequestContent.GetBatchRequestsForExecution();// this is called when request is executed
-            
+
             Dictionary<string, HttpStatusCode> responseStatusCodes = requestIds.ToDictionary(requestId => requestId, requestId => HttpStatusCode.OK);
 
             var retryBatch = batchRequestContent.NewBatchWithFailedRequests(responseStatusCodes);
-            
+
             Assert.Empty(retryBatch.BatchRequestSteps);
         }
-        
+
         [Fact]
         public async Task BatchRequestContent_NewBatchWithFailedRequests2()
         {
@@ -225,7 +225,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             Assert.Empty(retryBatch.BatchRequestSteps);// All requests were succesfful
         }
-        
+
         [Fact]
         public async Task BatchRequestContent_NewBatchWithFailedRequestsWithBody()
         {
@@ -244,7 +244,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             });
             var postRequestId = await batchRequestContent.AddBatchRequestStepAsync(postRequestInformation);
             requestIds.Add(postRequestId);
-            
+
             // Add the second request with plain text
             var postRequestInformation2 = new RequestInformation
             {
@@ -258,28 +258,28 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             // 1. Simulate the first time building the request and serializing it.
             var batchRequestContents = batchRequestContent.GetBatchRequestsForExecution();
             var stringContentFirst = await batchRequestContents.First().ReadAsStringAsync();
-            
+
             // Assert the body is present
             Assert.Contains("\"body\":{\"@odata.type\":\"microsoft.graph.drive\",\"name\":\"testDrive\"}",stringContentFirst);
             Assert.Contains(Convert.ToBase64String(Encoding.UTF8.GetBytes("This is a test")), stringContentFirst);
             JsonDocument.Parse(stringContentFirst);// verify its valid json otherwise it will throw
-            
+
             Dictionary<string, HttpStatusCode> responseStatusCodes = requestIds.ToDictionary(requestId => requestId, requestId => HttpStatusCode.BadGateway);
             var retryBatch = batchRequestContent.NewBatchWithFailedRequests(responseStatusCodes);
-            
+
             // 2. Failed request is present
             Assert.NotEmpty(retryBatch.BatchRequestSteps);
 
             batchRequestContents = retryBatch.GetBatchRequestsForExecution();
             var retryStringContentFirst = await batchRequestContents.First().ReadAsStringAsync();
-            
+
             // Assert the body is still present
             Assert.Contains("\"body\":{\"@odata.type\":\"microsoft.graph.drive\",\"name\":\"testDrive\"}",retryStringContentFirst);
             Assert.Contains(Convert.ToBase64String(Encoding.UTF8.GetBytes("This is a test")), retryStringContentFirst);
             JsonDocument.Parse(retryStringContentFirst);// verify its valid json otherwise it will throw
         }
-        
-        
+
+
         [Fact]
         public async System.Threading.Tasks.Task BatchRequestContent_GetBatchRequestContentFromStepAsync()
         {
@@ -299,9 +299,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             {
                 requestContent = await reader.ReadToEndAsync();
             }
-            
+
             string expectedContent = "{\"requests\":[{\"id\":\"2\",\"url\":\"/me\",\"method\":\"GET\"}]}";
-            
+
             Assert.NotNull(requestContent);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(1));
             Assert.Equal(expectedContent, requestContent);
@@ -317,7 +317,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                 Content = new StreamContent(fileStream)
             };
             createImageMessage.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
-            
+
             BatchRequestStep batchRequestStep2 = new BatchRequestStep("2", createImageMessage, new List<string> { "1" });
 
             BatchRequestContent batchRequestContent = new BatchRequestContent(client);
@@ -325,7 +325,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             batchRequestContent.AddBatchRequestStep(batchRequestStep2);
 
             string requestContent;
-            // we do this to get a version of the json that is indented 
+            // we do this to get a version of the json that is indented
             using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
             using (JsonDocument jsonDocument = JsonDocument.Parse(requestStream))
             {
@@ -358,11 +358,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(2));
             Assert.Equal(expectedJson, requestContent);
         }
-        
+
         [Fact]
         public async System.Threading.Tasks.Task BatchRequestContent_GetBatchRequestContentFromStepAsyncDoesNotModifyDateTimes()
         {
-            // System.Text.Json is strict on json content by default. So make sure that there are no 
+            // System.Text.Json is strict on json content by default. So make sure that there are no
             // trailing comma's and special characters
             var payloadString = "{\r\n" +
                                 "  \"subject\": \"Lets go for lunch\",\r\n" +
@@ -402,7 +402,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             batchRequestContent.AddBatchRequestStep(batchRequestStep2);
 
             string requestContent;
-            // we do this to get a version of the json that is indented 
+            // we do this to get a version of the json that is indented
             using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
             using (JsonDocument jsonDocument = JsonDocument.Parse(requestStream))
             {
@@ -463,9 +463,35 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
         }
 
         [Fact]
+        public async Task BatchRequest_GetBathRequestContentAsyncRetainsInsertionOrder()
+        {
+            BatchRequestStep batchRequestStep1 = new BatchRequestStep("1", new HttpRequestMessage(HttpMethod.Get, REQUEST_URL));
+            BatchRequestStep batchRequestStep2 = new BatchRequestStep(Guid.NewGuid().ToString(), new HttpRequestMessage(HttpMethod.Get, REQUEST_URL), new List<string> { "1" });
+            BatchRequestStep batchRequestStep3 = new BatchRequestStep(Guid.NewGuid().ToString(), new HttpRequestMessage(HttpMethod.Post, REQUEST_URL));
+            BatchRequestStep batchRequestStep4 = new BatchRequestStep("5", new HttpRequestMessage(HttpMethod.Put, REQUEST_URL));
+
+            BatchRequestContent batchRequestContent = new BatchRequestContent(client, batchRequestStep1, batchRequestStep2, batchRequestStep3, batchRequestStep4);
+
+            // We get the contents of the stream as string for comparison.
+            using (Stream requestStream = await batchRequestContent.GetBatchRequestContentAsync())
+            {
+                // Parse requestStream to JSON object and check the "requests" array
+                using (JsonDocument jsonDocument = await JsonDocument.ParseAsync(requestStream))
+                {
+                    var requests = jsonDocument.RootElement.GetProperty("requests");
+                    Assert.True(requests.GetArrayLength().Equals(4));
+                    Assert.Equal(batchRequestStep1.RequestId, requests[0].GetProperty("id").GetString());
+                    Assert.Equal(batchRequestStep2.RequestId, requests[1].GetProperty("id").GetString());
+                    Assert.Equal(batchRequestStep3.RequestId, requests[2].GetProperty("id").GetString());
+                    Assert.Equal(batchRequestStep4.RequestId, requests[3].GetProperty("id").GetString());
+                }
+            }
+        }
+
+        [Fact]
         public void BatchRequestContent_AddBatchRequestStepWithHttpRequestMessage()
         {
-            // Arrange 
+            // Arrange
             BatchRequestContent batchRequestContent = new BatchRequestContent(client);
             Assert.False(batchRequestContent.BatchRequestSteps.Any());//Its empty
 
@@ -497,7 +523,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             // Act
             HttpRequestMessage extraHttpRequestMessage = new HttpRequestMessage(HttpMethod.Get, REQUEST_URL);
-            
+
             // Assert
             var exception = Assert.Throws<ArgumentException>(() => batchRequestContent.AddBatchRequestStep(extraHttpRequestMessage));//Assert we throw exception on excess add
             //Assert.Equal(ErrorConstants.Codes.MaximumValueExceeded, exception.Error.Code);
@@ -545,7 +571,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             Assert.True(batchRequestContent.BatchRequestSteps[batchRequestStepId].Request.Headers.Any());
             Assert.True(batchRequestContent.BatchRequestSteps[batchRequestStepId].Request.Content.Headers.Any());
 
-            // we do this to get a version of the json payload that is indented 
+            // we do this to get a version of the json payload that is indented
             await using var requestStream = await batchRequestContent.GetBatchRequestContentAsync();
             using var jsonDocument = await JsonDocument.ParseAsync(requestStream);
             string requestContentString = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions() { WriteIndented = true });
@@ -577,7 +603,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             // Act
             RequestInformation extraRequestInformation = new RequestInformation() { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
             var exception = await Assert.ThrowsAsync<ArgumentException>(() => batchRequestContent.AddBatchRequestStepAsync(extraRequestInformation));
-            
+
             // Assert
             //Assert.Equal(ErrorConstants.Codes.MaximumValueExceeded, exception.Error.Code);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -21,11 +21,14 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
     using Microsoft.Kiota.Serialization.Json;
     using Microsoft.Kiota.Serialization.Text;
     using HttpMethod = System.Net.Http.HttpMethod;
+    using System.Text.RegularExpressions;
 
     public class BatchRequestContentTests
     {
         private const string REQUEST_URL = "https://graph.microsoft.com/v1.0/me";
         private readonly IBaseClient client = new BaseClient(REQUEST_URL, new MockAuthenticationProvider().Object);
+
+        private readonly Regex whitespacePattern = new Regex("\\s");
 
         public BatchRequestContentTests()
         {
@@ -353,10 +356,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                   "    }\r\n" +
                                   "  ]\r\n" +
                                   "}";
+            expectedJson = whitespacePattern.Replace(expectedJson, "");
 
             Assert.NotNull(requestContent);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(2));
-            Assert.Equal(expectedJson, requestContent);
+            Assert.Equal(expectedJson, whitespacePattern.Replace(requestContent, ""));
         }
 
         [Fact]
@@ -456,10 +460,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                   "    }\r\n" +
                                   "  ]\r\n" +
                                   "}";
+            expectedJson = whitespacePattern.Replace(expectedJson, "");
 
             Assert.NotNull(requestContent);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(2));
-            Assert.Equal(expectedJson, requestContent);
+            Assert.Equal(expectedJson, whitespacePattern.Replace(requestContent, ""));
         }
 
         [Fact]
@@ -583,7 +588,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                                          "        \"ConsistencyLevel\": \"eventual\",\r\n" + // Ensure the requestMessage headers are present
                                          "        \"Content-Type\": \"application/json\"\r\n" + // Ensure the content headers are present
                                          "      }";
-            Assert.Contains(expectedJsonSection, requestContentString);
+            expectedJsonSection = whitespacePattern.Replace(expectedJsonSection, "");
+            Assert.Contains(expectedJsonSection, whitespacePattern.Replace(requestContentString, ""));
         }
 
         [Fact]


### PR DESCRIPTION
[`System.Collections.Generic.OrderedDictionary<TKey,TValue>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ordereddictionary-2?view=net-9.0) would have been the more ideal fix but it's only supported in .NET 9.

[`System.Collections.Specialized.OrderedDictionary`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.specialized.ordereddictionary?view=net-8.0) is supported by older versions but doesn't support generics meaning lots of [casting from `object` to expected types](https://github.com/dotnet/platform-compat/blob/master/docs/DE0006.md)

This PR:
- adds a custom structure to track insertion order of Batch request steps
- updates batch request content tests comparing strings to do so platform agnostically. Tests fail on linux envts due to expected `\r\n`

closes #891 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/892)