### PR TITLE
fix: encoded batch request URI issue

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -329,7 +329,9 @@ namespace Microsoft.Graph
             if (requestUri == null)
                 throw new ArgumentNullException(nameof(requestUri));
 
-            return requestUri.PathAndQuery.Substring(5); // `v1.0/` and `beta/` are both 5 characters
+            var encodedUri = requestUri.PathAndQuery.Substring(5); // `v1.0/` and `beta/` are both 5 characters
+
+            return Uri.UnescapeDataString(encodedUri); // removes encoded chars from URI since graph batch encodes for us
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Removes encoding from batch request relative URIs
- Added unit test to ensure URIs are not encoded

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/discussions/2538
- Possibly related issue: https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2089
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/896)