### PR TITLE
fix: resolve trimming warnings in project

### DIFF
--- a/.github/policies/msgraph-sdk-dotnet-core-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-core-branch-protection.yml
@@ -36,6 +36,7 @@ configuration:
     # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
     - Build and Test # Contains CodeQL
+    - Validate Project for Trimming
     - license/cla
     # Require branches to be up to date before merging. boolean
     requiresStrictStatusChecks: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -70,7 +70,7 @@ jobs:
           CoverletOutputFormat: "opencover" # https://github.com/microsoft/vstest/issues/4014#issuecomment-1307913682
         shell: pwsh
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"microsoftgraph_msgraph-sdk-dotnet-core" /o:"microsoftgraph2" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="tests/Microsoft.Graph.DotnetCore.Core.Test/coverage.opencover.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"microsoftgraph_msgraph-sdk-dotnet-core" /o:"microsoftgraph2" /d:sonar.scanner.scanAll=false /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="tests/Microsoft.Graph.DotnetCore.Core.Test/coverage.opencover.xml"
           dotnet workload restore
           dotnet build
           dotnet test Microsoft.Graph.Core.sln --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --framework net6.0

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -40,12 +40,12 @@ jobs:
 
       - name: Install needed dotnet workloads
         run: dotnet workload install android macos ios maccatalyst
+     
+      - name: Restore nuget dependencies
+        run: dotnet restore ${{ env.solutionName }}
 
       - name: Lint the code
         run: dotnet format --verify-no-changes
-        
-      - name: Restore nuget dependencies
-        run: dotnet restore ${{ env.solutionName }}
 
       - name: Build
         run: dotnet build ${{ env.solutionName }} -c Debug /p:UseSharedCompilation=false,IncludeMauiTargets=true
@@ -56,4 +56,17 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
 
+  validate-trimming:
+    name: Validate Project for Trimming
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Validate Trimming warnings
+        run: dotnet publish -c Release -r win-x64 /p:TreatWarningsAsErrors=true /warnaserror -f net8.0
+        working-directory: ./tests/Microsoft.Graph.DotnetCore.Core.Trimming

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -62,16 +62,16 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.12.3" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.12.3" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.12.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.11.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.11.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.3" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.12.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.11.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockUploadSessionWithoutInterface.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockUploadSessionWithoutInterface.cs
@@ -1,0 +1,78 @@
+﻿namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Kiota.Abstractions.Serialization;
+
+    /// <summary>
+    /// Concrete implementation of the IUploadSession interface
+    /// </summary>
+    internal class MockUploadSessionWithoutUploadSessionInterface : IParsable, IAdditionalDataHolder
+    {
+        /// <summary>
+        /// Expiration date of the upload session
+        /// </summary>
+        public DateTimeOffset? ExpirationDateTime
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The ranges yet to be uploaded to the server
+        /// </summary>
+        public List<string> NextExpectedRanges
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The URL for upload
+        /// </summary>
+        public string UploadUrl
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+        /// </summary>
+        public IDictionary<string, object> AdditionalData { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// The deserialization information for the current model
+        /// </summary>
+        public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
+        {
+            return new Dictionary<string, Action<IParseNode>>(StringComparer.OrdinalIgnoreCase)
+            {
+                {"expirationDateTime", (n) => { ExpirationDateTime = n.GetDateTimeOffsetValue(); } },
+                {"nextExpectedRanges", (n) => { NextExpectedRanges = n.GetCollectionOfPrimitiveValues<string>().ToList(); } },
+                {"uploadUrl", (n) => { UploadUrl = n.GetStringValue(); } },
+            };
+        }
+
+        /// <summary>
+        /// Serializes information the current object
+        /// <param name="writer">Serialization writer to use to serialize this model</param>
+        /// </summary>
+        public void Serialize(ISerializationWriter writer)
+        {
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteDateTimeOffsetValue("expirationDateTime", ExpirationDateTime);
+            writer.WriteCollectionOfPrimitiveValues<string>("nextExpectedRanges", NextExpectedRanges);
+            writer.WriteStringValue("uploadUrl", UploadUrl);
+            writer.WriteAdditionalData(AdditionalData);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the appropriate class based on discriminator value
+        /// <param name="parseNode">The parse node to use to read the discriminator value and create the object</param>
+        /// </summary>
+        public static MockUploadSessionWithoutUploadSessionInterface CreateFromDiscriminatorValue(IParseNode parseNode)
+        {
+            _ = parseNode ?? throw new ArgumentNullException(nameof(parseNode));
+            return new MockUploadSessionWithoutUploadSessionInterface();
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <TrimmerSingleWarn>false</TrimmerSingleWarn>
+        <PublishTrimmed>true</PublishTrimmed>
+        <PublishAot>true</PublishAot>
+    </PropertyGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />
+      <TrimmerRootAssembly Include="Microsoft.Graph.Core" />
+    </ItemGroup>
+</Project>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Program.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Graph.DotnetCore.Core.Trimming;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello, World!");
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.101", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "rollForward": "major"
+  }
+}


### PR DESCRIPTION
This PR resolves all trimming warnings in the project 

- Adding relevant `DynamicallyAccessedMembers` attributes where necessarry and Removing calls of `object.GetType()` (as this results in unresolvable trimming warnings)
- Add a trimming validation project and add a validation build step in the pipeline. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/903)