### PR TITLE
Add `create()` overloads to support adding Authorization handler to HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,29 @@ For an example of authenticating a UWP app using the V2 Authentication Endpoint,
 You can create an instance of **HttpClient** that is pre-configured for making requests to Microsoft Graph APIs using `GraphClientFactory`.
 
 ```cs
-HttpClient httpClient = GraphClientFactory.Create( version: "beta");
+// The client credentials flow requires that you request the
+// /.default scope, and pre-configure your permissions on the
+// app registration in Azure. An administrator must grant consent
+// to those permissions beforehand.
+var scopes = new[] { "https://graph.microsoft.com/.default" };
+
+// Values from app registration
+var clientId = "YOUR_CLIENT_ID";
+var tenantId = "YOUR_TENANT_ID";
+var clientSecret = "YOUR_CLIENT_SECRET";
+
+// using Azure.Identity;
+var options = new ClientSecretCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud,
+};
+
+// https://learn.microsoft.com/dotnet/api/azure.identity.clientsecretcredential
+var clientSecretCredential = new ClientSecretCredential(
+    tenantId, clientId, clientSecret, options);
+
+HttpClient httpClient = GraphClientFactory.create(tokenCredential: clientSecretCredential, version: "beta");
+
 ```
 
 For more information on initializing a client instance, see the [library overview](https://docs.microsoft.com/en-us/graph/sdks/sdks-overview)

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -6,11 +6,8 @@ namespace Microsoft.Graph
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Net.Http;
-    using System.Threading.Tasks;
-    using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
 
     /// <summary>
     /// Contains extension methods for <see cref="HttpRequestMessage"/>

--- a/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/IDecryptableContentExtensions.cs
@@ -9,10 +9,8 @@ namespace Microsoft.Graph
     using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.Kiota.Abstractions.Serialization;
-    using Microsoft.Kiota.Serialization.Json;
 
     /// <summary>
     /// Contains extension methods for <see cref="IDecryptableContentExtensions"/>
@@ -43,7 +41,7 @@ namespace Microsoft.Graph
 
         /// <summary>
         /// Validates the signature and decrypted content attached with the notification.
-        /// https://docs.microsoft.com/en-us/graph/webhooks-with-resource-data#decrypting-resource-data-from-change-notifications 
+        /// https://docs.microsoft.com/en-us/graph/webhooks-with-resource-data#decrypting-resource-data-from-change-notifications
         /// </summary>
         /// <param name="encryptedContent">The encrypted content of type <see cref="IDecryptableContent"/></param>
         /// <param name="certificateProvider">Certificate provider to decrypt the content.

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -68,10 +68,10 @@
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.14.0" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.14.0" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.12.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.12.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.14.0" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.12.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.14.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Graph.Core/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Graph.Core/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 #if DEBUG
 [assembly: InternalsVisibleTo("Microsoft.Graph.DotnetCore.Core.Test")]
 #endif

--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Graph
     using System;
     using System.Net;
     using System.Net.Http;
-    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Kiota.Abstractions;

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Graph
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.IO;

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchResponseContentCollection.cs
@@ -6,7 +6,6 @@
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.Kiota.Abstractions;
     using Microsoft.Kiota.Abstractions.Serialization;

--- a/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/DeltaResponseHandler.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Graph
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -21,7 +20,7 @@ namespace Microsoft.Graph
 #endif
 
     /// <summary>
-    /// PREVIEW 
+    /// PREVIEW
     /// A response handler that exposes the list of changes returned in a response.
     /// This supports scenarios where the service expresses changes to 'null'. The
     /// deserializer can't express changes to null so you can now discover if a property
@@ -56,7 +55,7 @@ namespace Microsoft.Graph
                 // set on the response body object.
                 var responseString = await GetResponseStringAsync(responseMessage).ConfigureAwait(false);
 
-                // Get the response body object with the change list 
+                // Get the response body object with the change list
                 // set on each response item.
                 var responseWithChangeList = await GetResponseBodyWithChangelistAsync(responseString).ConfigureAwait(false);
                 using var responseWithChangeListStream = new MemoryStream(Encoding.UTF8.GetBytes(responseWithChangeList));
@@ -112,7 +111,7 @@ namespace Microsoft.Graph
             // return a string instead.
             using (var responseJsonDocument = JsonDocument.Parse(deltaResponseBody))
             {
-                // An array of delta objects. We will need to process 
+                // An array of delta objects. We will need to process
                 // each one independently of each other.
                 if (!responseJsonDocument.RootElement.TryGetProperty("value", out var pageOfDeltaObjects))
                 {
@@ -193,7 +192,7 @@ namespace Microsoft.Graph
                             var arrayEnumerator = property.Value.EnumerateArray();
                             if (!arrayEnumerator.Any())
                             {
-                                // Handle the edge case when the change involves changing to an empty array 
+                                // Handle the edge case when the change involves changing to an empty array
                                 // as we can't observe elements in an empty collection in the foreach loop below
                                 changes.Add(parent);
                                 break;

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Graph
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Threading;
     using Microsoft.Kiota.Http.HttpClientLibrary;
     using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;
 
@@ -211,7 +210,7 @@ namespace Microsoft.Graph
             return new WinHttpHandler { Proxy = proxy, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate , WindowsProxyUsePolicy = proxyPolicy, SendTimeout = Timeout.InfiniteTimeSpan, ReceiveDataTimeout = Timeout.InfiniteTimeSpan, ReceiveHeadersTimeout = Timeout.InfiniteTimeSpan };
 #elif NET6_0_OR_GREATER
             //use resilient configs when we can https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0#alternatives-to-ihttpclientfactory-1
-            return new SocketsHttpHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.All, PooledConnectionLifetime = TimeSpan.FromMinutes(1)}; 
+            return new SocketsHttpHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.All, PooledConnectionLifetime = TimeSpan.FromMinutes(1)};
 #else
             return new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
 #endif

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -159,15 +159,7 @@ namespace Microsoft.Graph
             HttpMessageHandler finalHandler = null,
             bool disposeHandler = true)
         {
-            if (handlers == null)
-            {
-                handlers = CreateDefaultHandlers();
-            }
-            var handlerList = handlers.ToList();
-            handlerList.Add(new AuthorizationHandler(
-                new AzureIdentityAuthenticationProvider(tokenCredential, null, null, true)
-            ));
-            return Create(handlerList, version, nationalCloud, proxy, finalHandler, disposeHandler);
+            return Create(new AzureIdentityAuthenticationProvider(tokenCredential, null, null, true), handlers, version, nationalCloud, proxy, finalHandler, disposeHandler);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Threading;
     using Azure.Core;
     using Microsoft.Graph.Authentication;
     using Microsoft.Kiota.Abstractions.Authentication;
@@ -119,7 +120,7 @@ namespace Microsoft.Graph
         /// <param name="proxy">The proxy to be used with the created client</param>
         /// <param name="finalHandler">The last HttpMessageHandler to HTTP calls.</param>
         /// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler..</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers</returns>
         public static HttpClient Create(
             BaseBearerTokenAuthenticationProvider authenticationProvider,
             IEnumerable<DelegatingHandler> handlers = null,
@@ -133,21 +134,22 @@ namespace Microsoft.Graph
             {
                 handlers = CreateDefaultHandlers();
             }
-            handlers = handlers.Append(new AuthorizationHandler(authenticationProvider));
-            return Create(handlers, version, nationalCloud, proxy, finalHandler, disposeHandler);
+            var handlerList = handlers.ToList();
+            handlerList.Add(new AuthorizationHandler(authenticationProvider));
+            return Create(handlerList, version, nationalCloud, proxy, finalHandler, disposeHandler);
         }
 
         /// <summary>
         /// Creates a new <see cref="HttpClient"/> instance configured to authenticate requests using the provided <see cref="TokenCredential"/>.
         /// </summary>
-        /// <param name="tokenCredential">Token credential object use to initialise an <see cref="AzureIdentityAuthenticationProvider"></param>
+        /// <param name="tokenCredential">Token credential object use to initialise an <see cref="AzureIdentityAuthenticationProvider"/></param>
         /// <param name="handlers">Custom middleware pipeline to which the Authorization handler is appended. If null, default handlers are initialised</param>
         /// <param name="version">The Graph version to use in the base URL</param>
         /// <param name="nationalCloud">The national cloud endpoint to use</param>
         /// <param name="proxy">The proxy to be used with the created client</param>
         /// <param name="finalHandler">The last HttpMessageHandler to HTTP calls</param>
-        /// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler..</param>
-        /// <returns></returns>
+        /// <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers</returns>
         public static HttpClient Create(
             TokenCredential tokenCredential,
             IEnumerable<DelegatingHandler> handlers = null,
@@ -161,10 +163,11 @@ namespace Microsoft.Graph
             {
                 handlers = CreateDefaultHandlers();
             }
-            handlers = handlers.Append(new AuthorizationHandler(
+            var handlerList = handlers.ToList();
+            handlerList.Add(new AuthorizationHandler(
                 new AzureIdentityAuthenticationProvider(tokenCredential, null, null, true)
             ));
-            return Create(handlers, version, nationalCloud, proxy, finalHandler, disposeHandler);
+            return Create(handlerList, version, nationalCloud, proxy, finalHandler, disposeHandler);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphRequestContext.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Graph
 {
-    using System.Collections.Generic;
     using System.Threading;
-    using Microsoft.Kiota.Abstractions;
 
     /// <summary>
     /// The graph request context class

--- a/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphResponse{T}.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Graph
 {
-    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
@@ -27,7 +26,7 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Gets the deserialized object 
+        /// Gets the deserialized object
         /// </summary>
         /// <param name="responseHandler">The response handler to use for the reponse</param>
         /// <param name="errorMappings">The errorMappings to use in the event of a non sucess request</param>

--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -6,9 +6,7 @@ namespace Microsoft.Graph
 {
     using System;
     using System.Collections.Generic;
-    using System.Net;
     using System.Net.Http;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.Kiota.Abstractions;
     using Microsoft.Kiota.Abstractions.Serialization;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/ReadOnlySubStreamTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Helpers/ReadOnlySubStreamTests.cs
@@ -4,9 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.Kiota.Http.HttpClientLibrary.Extensions;
 using Xunit;
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Helpers

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/BaseClient.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/BaseClient.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 {
-    using System.Net.Http;
     using Microsoft.Graph.Core.Requests;
     using Microsoft.Kiota.Abstractions;
     using Microsoft.Kiota.Abstractions.Authentication;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockAccessTokenProvider.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockAccessTokenProvider.cs
@@ -1,0 +1,30 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Moq;
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
+{
+    public class MockAccessTokenProvider : Mock<IAccessTokenProvider>
+    {
+        public MockAccessTokenProvider(string accessToken = null) : base(MockBehavior.Strict)
+        {
+            this.Setup(x => x.GetAuthorizationTokenAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<CancellationToken>()
+            )).Returns(Task.FromResult(accessToken));
+
+            this.Setup(x => x.AllowedHostsValidator).Returns(
+                new AllowedHostsValidator(new List<string> { "graph.microsoft.com" })
+            );
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockAccessTokenProvider.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockAccessTokenProvider.cs
@@ -1,7 +1,6 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
-
 
 using System;
 using System.Collections.Generic;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Properties/AssemblyInfo.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public async Task CreateClientWithAuthenticationProviderAuthenticatesRequest()
+        public async Task CreateClientWithAuthenticationProviderAuthenticatesRequestAsync()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/me");
             var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
@@ -334,7 +334,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public async Task CreateClientWithTokenCredentialAuthenticatesRequest()
+        public async Task CreateClientWithTokenCredentialAuthenticatesRequestAsync()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/me");
             var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Kiota.Http.HttpClientLibrary.Middleware;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/ResponseHandlerTests.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
@@ -231,7 +230,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             // Update the value on a complex type property's value. Developer can't just replace the body
             // as that could result in overwriting other unchanged property. Essentially, they need to inspect
             // every leaf node in the selected property set.
-            if (changeList.Exists(x => x.Equals("body.content"))) // 
+            if (changeList.Exists(x => x.Equals("body.content"))) //
             {
                 if (myModel.Body == null)
                 {
@@ -247,7 +246,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var attendeesChangelist = changeList.FindAll(x => x.Contains("attendees"));
             if (attendeesChangelist.Count > 0)
             {
-                // This is where if we provided the delta response as a JSON object, 
+                // This is where if we provided the delta response as a JSON object,
                 // we could let the developer use JMESPath to query the changes.
                 if (changeList.Exists(x => x.Equals("attendees[0].emailAddress.name")))
                 {
@@ -259,7 +258,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     }
                     else // Attendees list is being updated.
                     {
-                        // We need to inspect each object, and determine which objects and properties 
+                        // We need to inspect each object, and determine which objects and properties
                         // need to be initialized and/or updated.
                     }
                 }
@@ -324,7 +323,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             // To view and format this test string, replace all \" with ", and use a JSON formatter
             // to make it pretty.
 
-            // In this scenario the attendees for the first event have been removed and the api has returned 
+            // In this scenario the attendees for the first event have been removed and the api has returned
             // an empty collection to the property
             var testString = "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#Collection(event)\",\"@odata.nextLink\":\"https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmci39OQxqJrxK4\",\"value\":[{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"EZ9r3czxY0m2jz8c45czkwAAFXcvIw==\",\"subject\":\"Get food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T19:30:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-10T21:30:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxTAAA=\"},{\"@odata.type\":\"#microsoft.graph.event\",\"@odata.etag\":\"WEZ9r3czxY0m2jz8c45czkwAAFXcvJA==\",\"subject\":\"Prepare food\",\"body\":{\"contentType\":\"html\",\"content\":\"\"},\"start\":{\"dateTime\":\"2016-12-10T22:00:00.0000000\",\"timeZone\":\"UTC\"},\"end\":{\"dateTime\":\"2016-12-11T00:00:00.0000000\",\"timeZone\":\"UTC\"},\"attendees\":[],\"organizer\":{\"emailAddress\":{\"name\":\"Samantha Booth\",\"address\":\"samanthab@contoso.onmicrosoft.com\"}},\"id\":\"AAMkADVxUAAA=\"}]}";
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DateTestClass.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/DateTestClass.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Microsoft.Kiota.Abstractions;
     using Microsoft.Kiota.Abstractions.Serialization;
 


### PR DESCRIPTION
pending review & release of https://github.com/microsoft/kiota-dotnet/pull/430

part of https://github.com/microsoft/kiota-dotnet/issues/270
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/924)