### PR TITLE
fix: removes upper bound on System.Net.Http.WinHttpHandler

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -78,6 +78,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="[6.0,9.0)" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="[6.0,)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
removes upper bound for http win handler following the discussions in https://github.com/microsoft/OpenApi.ApiManifest/pull/117
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/937)