### PR TITLE
Fixes authentication on every request when using the `AddBatchRequestStepAsync` overload

### DIFF
--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Validate Trimming warnings
-        run: dotnet publish -c Release -r win-x64 /p:TreatWarningsAsErrors=true /warnaserror -f net8.0
+        run: dotnet publish -c Release -r win-x64 /p:TreatWarningsAsErrors=true /warnaserror -f net9.0
         working-directory: ./tests/Microsoft.Graph.DotnetCore.Core.Trimming

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -62,16 +62,16 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.16.4" />
     <PackageReference Include="Microsoft.Kiota.Authentication.Azure" Version="1.16.4" />
     <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.16.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.3" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Text" Version="1.16.4" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Form" Version="1.16.4" />
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.4" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.3" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.4" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -35,6 +35,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>NU5048;NETSDK1202</NoWarn>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             // Assert
             var exception = Assert.Throws<ArgumentException>(() => batchRequestContent.AddBatchRequestStep(extraHttpRequestMessage));//Assert we throw exception on excess add
-            Assert.Equal(ErrorConstants.Messages.MaximumValueExceeded, exception.Message);
+            Assert.Equal(string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests), exception.Message);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(CoreConstants.BatchRequest.MaxNumberOfRequests));
         }
@@ -635,7 +635,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
             var exception = await Assert.ThrowsAsync<ArgumentException>(() => batchRequestContent.AddBatchRequestStepAsync(extraRequestInformation));
 
             // Assert
-            Assert.Equal(ErrorConstants.Messages.MaximumValueExceeded, exception.Message);
+            Assert.Equal(string.Format(ErrorConstants.Messages.MaximumValueExceeded, "Number of batch request steps", CoreConstants.BatchRequest.MaxNumberOfRequests), exception.Message);
             Assert.NotNull(batchRequestContent.BatchRequestSteps);
             Assert.True(batchRequestContent.BatchRequestSteps.Count.Equals(CoreConstants.BatchRequest.MaxNumberOfRequests));
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
@@ -10,7 +10,6 @@
         <PublishTrimmed>true</PublishTrimmed>
         <PublishAot>true</PublishAot>
         <NoWarn>IL3000</NoWarn> <!-- Ignore IL3000 warning as it references a code outside our control -->
-        <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
@@ -10,6 +10,7 @@
         <PublishTrimmed>true</PublishTrimmed>
         <PublishAot>true</PublishAot>
         <NoWarn>IL3000</NoWarn> <!-- Ignore IL3000 warning as it references a code outside our control -->
+        <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj" />

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/Microsoft.Graph.DotnetCore.Core.Trimming.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <InvariantGlobalization>true</InvariantGlobalization>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.101", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "version": "9.0.102", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2774

Authentication provider is unnecessarilly invoked repeatedly to set the Auth header which is unnecessary in the batch message. In the event that the message isn't in the cash this can cause increased execution for a task that is unneeded. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/956)