### PR TITLE
feat: Added statusCodesToTreatAsSuccess (additive success set) to NewBatchWithFailedRequests and Preserving RequestId

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -183,7 +183,13 @@ namespace Microsoft.Graph
             {
                 if (steps.ContainsKey(response.Key) && !BatchResponseContent.IsSuccessStatusCode(response.Value))
                 {
-                    request.AddBatchRequestStep(steps[response.Key].Request);
+                    var step = steps[response.Key];
+                    var newStep = new BatchRequestStep(
+                        requestId: step.RequestId,
+                        httpRequestMessage: step.Request,
+                        dependsOn: step.DependsOn?.ToList());
+
+                    request.AddBatchRequestStep(newStep);
                 }
             }
             return request;

--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContentCollection.cs
@@ -177,22 +177,7 @@ namespace Microsoft.Graph
         /// <returns>new <see cref="BatchRequestContentCollection"/> with all failed requests.</returns>
         public BatchRequestContentCollection NewBatchWithFailedRequests(Dictionary<string, HttpStatusCode> responseStatusCodes)
         {
-            var request = new BatchRequestContentCollection(this.requestAdapter, batchRequestLimit);
-            var steps = this.BatchRequestSteps;
-            foreach (var response in responseStatusCodes)
-            {
-                if (steps.ContainsKey(response.Key) && !BatchResponseContent.IsSuccessStatusCode(response.Value))
-                {
-                    var step = steps[response.Key];
-                    var newStep = new BatchRequestStep(
-                        requestId: step.RequestId,
-                        httpRequestMessage: step.Request,
-                        dependsOn: step.DependsOn?.ToList());
-
-                    request.AddBatchRequestStep(newStep);
-                }
-            }
-            return request;
+            return NewBatchWithFailedRequests(responseStatusCodes, null);
         }
 
         /// <summary>
@@ -201,7 +186,7 @@ namespace Microsoft.Graph
         /// <param name="responseStatusCodes">A dictionary with response codes, get by executing batchResponseContentCollection.GetResponsesStatusCodesAsync()</param>
         /// <param name="statusCodesToTreatAsSuccess">Optional additional HTTP status codes to also treat as successful. Success is determined by <see cref="BatchResponseContent.IsSuccessStatusCode(HttpStatusCode)"/> OR membership in this set</param>
         /// <returns>new <see cref="BatchRequestContentCollection"/> with all failed requests.</returns>
-        public BatchRequestContentCollection NewBatchWithFailedRequests(Dictionary<string, HttpStatusCode> responseStatusCodes, IEnumerable<HttpStatusCode> statusCodesToTreatAsSuccess)
+        public BatchRequestContentCollection NewBatchWithFailedRequests(Dictionary<string, HttpStatusCode> responseStatusCodes, HashSet<HttpStatusCode> statusCodesToTreatAsSuccess)
         {
             var request = new BatchRequestContentCollection(this.requestAdapter, batchRequestLimit);
             if (responseStatusCodes == null || responseStatusCodes.Count == 0)
@@ -209,39 +194,21 @@ namespace Microsoft.Graph
                 return request;
             }
 
-            HashSet<HttpStatusCode> successSet = statusCodesToTreatAsSuccess != null
-                ? [.. statusCodesToTreatAsSuccess]
-                : null;
-
-            bool IsSuccess(HttpStatusCode code)
-            {
-                if (BatchResponseContent.IsSuccessStatusCode(code))
-                {
-                    return true;
-                }
-
-                if (successSet != null && successSet.Contains(code))
-                {
-                    return true;
-                }
-
-                return false;
-            }
+            bool IsSuccess(HttpStatusCode code) =>
+                BatchResponseContent.IsSuccessStatusCode(code)
+                || (statusCodesToTreatAsSuccess?.Contains(code) ?? false);
 
             var steps = this.BatchRequestSteps;
             foreach (var kvp in responseStatusCodes)
             {
-                if (steps.TryGetValue(kvp.Key, out var step))
+                if (steps.TryGetValue(kvp.Key, out var step) && !IsSuccess(kvp.Value))
                 {
-                    if (!IsSuccess(kvp.Value))
-                    {
-                        var newStep = new BatchRequestStep(
-                            requestId: step.RequestId,
-                            httpRequestMessage: step.Request,
-                            dependsOn: step.DependsOn?.ToList());
+                    var newStep = new BatchRequestStep(
+                        requestId: step.RequestId,
+                        httpRequestMessage: step.Request,
+                        dependsOn: step.DependsOn?.ToList());
 
-                        request.AddBatchRequestStep(newStep);
-                    }
+                    request.AddBatchRequestStep(newStep);
                 }
             }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Content/BatchRequestContentTests.cs
@@ -719,7 +719,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
                 { okId, HttpStatusCode.OK }
             };
 
-            var successOverrides = new[] { HttpStatusCode.NotFound };
+            var successOverrides = new HashSet<HttpStatusCode> { HttpStatusCode.NotFound };
 
             var retryBatch = batchRequestContent.NewBatchWithFailedRequests(responseStatusCodes, successOverrides);
 
@@ -787,6 +787,31 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests.Content
 
             Assert.Equal(id1, retryBatch.BatchRequestSteps[id1].RequestId);
             Assert.Equal(id3, retryBatch.BatchRequestSteps[id3].RequestId);
+        }
+
+        [Fact]
+        public async Task BatchRequestContent_NewBatchWithFailedRequests_NullSuccessSetMatchesSingleArgOverloadAsync()
+        {
+            var batchRequestContent = new BatchRequestContentCollection(client);
+
+            var req1 = new RequestInformation { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
+            var req2 = new RequestInformation { HttpMethod = Method.GET, UrlTemplate = REQUEST_URL };
+
+            var failedId = await batchRequestContent.AddBatchRequestStepAsync(req1);
+            var okId = await batchRequestContent.AddBatchRequestStepAsync(req2);
+
+            var responseStatusCodes = new Dictionary<string, HttpStatusCode>
+            {
+                { failedId, HttpStatusCode.BadGateway },
+                { okId, HttpStatusCode.OK }
+            };
+
+            var singleArgBatch = batchRequestContent.NewBatchWithFailedRequests(responseStatusCodes);
+            var nullSetBatch = batchRequestContent.NewBatchWithFailedRequests(responseStatusCodes, null);
+
+            Assert.Equal(singleArgBatch.BatchRequestSteps.Keys.OrderBy(key => key), nullSetBatch.BatchRequestSteps.Keys.OrderBy(key => key));
+            Assert.Single(nullSetBatch.BatchRequestSteps);
+            Assert.Equal(failedId, nullSetBatch.BatchRequestSteps[failedId].RequestId);
         }
 
     }


### PR DESCRIPTION
### Changes proposed in this pull request
- Preserving RequestId while using `NewBatchWithFailedRequests `
- Added **statusCodesToTreatAsSuccess** (additive success set) to `NewBatchWithFailedRequests`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/980)