### PR TITLE
fix(security): upgrade .NET SDK to 10.0.202

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            8.x 
+            10.x 
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,7 +41,8 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            10.x 
+            6.x
+            10.x
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -23,10 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup .NET
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 6.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
 
       - name: Setup JDK for android targets
         uses: actions/setup-java@v5
@@ -66,7 +71,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Validate Trimming warnings
         run: dotnet publish -c Release -r win-x64 /p:TreatWarningsAsErrors=true /warnaserror -f net9.0

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.417", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "version": "10.0.202",
     "rollForward": "major"
   }
 }

--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -58,9 +58,9 @@ extends:
           inputs:
             version: 6.x
         - task: UseDotNet@2
-          displayName: 'Use .NET 9 for trimming validation'
+          displayName: 'Use .NET 10 for trimming validation'
           inputs:
-            version: 9.x
+            version: 10.x
         - task: PowerShell@2
           displayName: 'Set Java Home to use Java 11'
           inputs:

--- a/src/Microsoft.Graph.Core/global.json
+++ b/src/Microsoft.Graph.Core/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.417", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "version": "10.0.202",
     "rollForward": "major"
   }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Trimming/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "version": "10.0.202",
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
## Summary

Update all `global.json` files to use .NET 10.0.202 SDK, replacing outdated .NET 6 and .NET 9 versions that have reached end-of-life.

### Changes
| File | Old Version | New Version |
|------|------------|-------------|
| `global.json` (root) | 6.0.417 | 10.0.202 |
| `src/Microsoft.Graph.Core/global.json` | 6.0.417 | 10.0.202 |
| `tests/.../Trimming/global.json` | 9.0.102 | 10.0.202 |

### Why
.NET 6 reached end-of-life and no longer receives security patches. Upgrading to .NET 10 ensures continued security support.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/1026)