### PR TITLE
fix: daily CI pipeline configuration

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -58,6 +58,18 @@ extends:
               - task: NuGetAuthenticate@1
                 displayName: Authenticate to Azure Artifacts
 
+              - powershell: |
+                  @"
+                  <?xml version="1.0" encoding="utf-8"?>
+                  <configuration>
+                    <packageSources>
+                      <clear />
+                      <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                    </packageSources>
+                  </configuration>
+                  "@ | Set-Content -Path "$(Build.SourcesDirectory)\nuget.config" -Encoding UTF8
+                displayName: Create nuget.config
+
               - script: dotnet restore Microsoft.Graph.Core.sln --configfile nuget.config
                 displayName: Restore dependencies
                 workingDirectory: $(Build.SourcesDirectory)

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -21,6 +21,7 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
+      image: ubuntu-latest
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -49,7 +49,10 @@ extends:
                   packageType: 'sdk'
                   useGlobalJson: true
 
-              - script: dotnet restore Microsoft.Graph.Core.sln
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate to Azure Artifacts
+
+              - script: dotnet restore Microsoft.Graph.Core.sln --configfile nuget.config
                 displayName: Restore dependencies
                 workingDirectory: $(Build.SourcesDirectory)
 

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -21,8 +21,8 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
-      image: ubuntu-latest
-      os: linux
+      image: windows-latest
+      os: windows
     sdl:
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -1,9 +1,6 @@
 trigger: none
 pr: none
 
-variables:
-  NUGET_FEED_URI: 'https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json'
-
 schedules:
   - cron: '0 0 * * *'
     displayName: Daily builds

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -1,6 +1,9 @@
 trigger: none
 pr: none
 
+variables:
+  NUGET_FEED_URI: 'https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json'
+
 schedules:
   - cron: '0 0 * * *'
     displayName: Daily builds
@@ -64,7 +67,7 @@ extends:
                   <configuration>
                     <packageSources>
                       <clear />
-                      <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                      <add key="GraphDeveloperExperiences_Public" value="$(NUGET_FEED_URI)" />
                     </packageSources>
                   </configuration>
                   "@ | Set-Content -Path "$(Build.SourcesDirectory)\nuget.config" -Encoding UTF8

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -44,10 +44,16 @@ extends:
                 submodules: recursive
 
               - task: UseDotNet@2
-                displayName: Set up .NET
+                displayName: Set up .NET 8
                 inputs:
                   packageType: 'sdk'
-                  useGlobalJson: true
+                  version: 8.x
+
+              - task: UseDotNet@2
+                displayName: Set up .NET 10
+                inputs:
+                  packageType: 'sdk'
+                  version: 10.x
 
               - task: NuGetAuthenticate@1
                 displayName: Authenticate to Azure Artifacts

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

Fixes the daily CI pipeline that was failing due to multiple configuration issues.

### Changes
- **Added missing `image` property** to the 1ES pool config (required by 1ES Pipeline Templates)
- **Switched pool OS to Windows** to align with the release pipeline
- **Added Azure Artifacts feed** for NuGet restore to bypass network isolation on the `Azure-Pipelines-1ESPT-ExDShared` pool
  - `NuGetAuthenticate@1` step for feed authentication
  - Inline `nuget.config` generation using the `NUGET_FEED_URI` pipeline variable (set via ADO UI)
- **Installed both .NET 8 and .NET 10 SDKs** to support all test target frameworks (`net462`, `net8.0`, `net10.0`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/1063)