### PR TITLE
Look up published version via CFS feed instead of api.nuget.org (CFSClean)

### DIFF
--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -63,8 +63,12 @@ extends:
           inputs:
             targetType: filePath
             filePath: 'scripts\ValidateUpdatedNugetVersion.ps1'
-            arguments: '-packageName "$(PACKAGE_NAME)" -projectPath "$(PROJECT_PATH)"'
+            # Look up the latest published version via the CFS central feed (which upstreams
+            # nuget.org) instead of api.nuget.org, to satisfy 1ES network isolation (CFSClean).
+            arguments: '-packageName "$(PACKAGE_NAME)" -projectPath "$(PROJECT_PATH)" -registrationsBaseUrl "https://pkgs.dev.azure.com/microsoftgraph/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/registrations2"'
             pwsh: true
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           enabled: true
         - powershell: |
             dotnet workload install android ios maccatalyst

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -16,6 +16,14 @@
 
 .Parameter projectPath
     Specifies the path to the project file.
+
+.Parameter registrationsBaseUrl
+    Base URL of the NuGet v3 registrations resource used to look up the latest published
+    version. Defaults to the public nuget.org endpoint. In network-isolated pipelines (CFSClean)
+    pass the CFS/Azure Artifacts feed registrations endpoint (which upstreams nuget.org) so the
+    lookup does not egress to api.nuget.org. When the URL is an Azure Artifacts feed it requires
+    authentication; set the SYSTEM_ACCESSTOKEN environment variable and it will be sent as a
+    Bearer token.
 #>
 
 Param(
@@ -23,7 +31,10 @@ Param(
     [string]$packageName,
 
     [parameter(Mandatory = $true)]
-    [string]$projectPath
+    [string]$projectPath,
+
+    [parameter(Mandatory = $false)]
+    [string]$registrationsBaseUrl = "https://api.nuget.org/v3/registration5-gz-semver2"
 )
 
 [xml]$xmlDoc = Get-Content $projectPath
@@ -40,18 +51,26 @@ $currentProjectVersion = [System.Management.Automation.SemanticVersion]"$version
 
 # API is case-sensitive
 $packageName = $packageName.ToLower()
-$url = "https://api.nuget.org/v3/registration5-gz-semver2/$packageName/index.json"
+$url = "$($registrationsBaseUrl.TrimEnd('/'))/$packageName/index.json"
+
+# Azure Artifacts feed endpoints require authentication; send the pipeline access token when
+# available. Public nuget.org ignores the header.
+$headers = @{}
+if ($env:SYSTEM_ACCESSTOKEN) {
+    $headers["Authorization"] = "Bearer $env:SYSTEM_ACCESSTOKEN"
+}
 
 # Call the NuGet API for the package and get the current published version.
 Try {
-    $nugetIndex = Invoke-RestMethod -Uri $url -Method Get
+    $nugetIndex = Invoke-RestMethod -Uri $url -Method Get -Headers $headers
 }
 Catch {
-    if ($_.ErrorDetails.Message && $_.ErrorDetails.Message.Contains("The specified blob does not exist.")) {
+    $statusCode = $_.Exception.Response.StatusCode.value__
+    if ($statusCode -eq 404 -or ($_.ErrorDetails.Message -and $_.ErrorDetails.Message.Contains("The specified blob does not exist."))) {
         Write-Host "No package exists. You will probably be publishing $packageName for the first time."
         Exit # exit gracefully
     }
-    
+
     Write-Host $_
     Exit 1
 }


### PR DESCRIPTION
## What
Fixes the sole **CFSClean** network-isolation violation on the `Dotnet Core Production` pipeline (definitionId 197): the release version-bump gate calls `api.nuget.org` directly.

## Why
Telemetry for the last run (build 230603) shows exactly one CFSClean violation — `pwsh.exe` -> `api.nuget.org` in the `build` job. It comes from the `Validate updated version` step, which runs `scripts/ValidateUpdatedNugetVersion.ps1`:

```powershell
$url = "https://api.nuget.org/v3/registration5-gz-semver2/$packageName/index.json"
$nugetIndex = Invoke-RestMethod -Uri $url -Method Get
```

This is a REST call (not a package restore) to read the latest published version. `dotnet restore` in this repo is already CFS-clean; only this lookup egresses to nuget.org.

## Changes
- `scripts/ValidateUpdatedNugetVersion.ps1`: add a `-registrationsBaseUrl` parameter (default stays `https://api.nuget.org/v3/registration5-gz-semver2` for back-compat), and send `Authorization: Bearer $env:SYSTEM_ACCESSTOKEN` when set. Broaden the graceful "first publish" handling to HTTP 404, and fix the `&&` condition to `-and`.
- `pipelines/productionBuild.yml` (`Validate updated version` step): pass the **CFS feed** registrations endpoint (`GraphDeveloperExperiences_Public`, which upstreams nuget.org) and expose `SYSTEM_ACCESSTOKEN: $(System.AccessToken)`.

## Validation
Ran the modified script locally against the CFS feed: it authenticated, returned the same latest version (**4.0.1**) as nuget.org, and produced the identical gate result (version-bump error when csproj == published). No `api.nuget.org` egress.

Relates to S360 KPI 527fb616-07aa-8198-6419-50d04ef1c2f3 (Vulnerability Management / 1ES network isolation).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/1086)