### PR TITLE
ci: update ESRP code signing to v6

### DIFF
--- a/pipelines/productionBuild.yml
+++ b/pipelines/productionBuild.yml
@@ -96,7 +96,7 @@ extends:
           inputs:
             projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj'
             arguments: '-c Release --no-incremental -p:IncludeMauiTargets=true'
-        - task: EsrpCodeSigning@5
+        - task: EsrpCodeSigning@6
           displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Core)'
           inputs:
             ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
@@ -130,7 +130,7 @@ extends:
             MaxConcurrency: 50
             MaxRetryAttempts: 5
             PendingAnalysisWaitTimeoutMinutes: 5
-        - task: EsrpCodeSigning@5
+        - task: EsrpCodeSigning@6
           displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Core)'
           inputs:
             ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
@@ -188,7 +188,7 @@ extends:
         - powershell: |
             dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration Release
           displayName: dotnet pack
-        - task: EsrpCodeSigning@5
+        - task: EsrpCodeSigning@6
           displayName: 'ESRP NuGet CodeSigning (Microsoft.Graph.Core)'
           inputs:
             ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'


### PR DESCRIPTION
Updates Azure Pipeline ESRP code signing tasks from v5 to v6.

ESRP code signing v5 runs on Node16 and is getting deprecated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/1088)